### PR TITLE
Strip query parameters from system prompt filename in launcher script

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -1590,7 +1590,12 @@ def main() -> None:
         # Step 10: Create launcher script
         print()
         print(f'{Colors.CYAN}Step 10: Creating launcher script...{Colors.NC}')
-        prompt_filename = Path(system_prompt).name if system_prompt else None
+        # Strip query parameters from system prompt filename (must match download logic)
+        if system_prompt:
+            clean_prompt = system_prompt.split('?')[0] if '?' in system_prompt else system_prompt
+            prompt_filename = Path(clean_prompt).name
+        else:
+            prompt_filename = None
         launcher_path = create_launcher_script(claude_user_dir, command_name, prompt_filename)
 
         # Step 11: Register global command


### PR DESCRIPTION
The launcher script was looking for files with query parameters in the filename (e.g., 'requirements-orchestrator.md?ref_type=heads'), but the actual files were saved without query parameters. This fix ensures the launcher script uses the same cleaned filename as the download process.

Fixes the 'System prompt not found' error when running global commands like 'claude-pm' with GitLab configurations containing query parameters.