### PR TITLE
Improve private repository authentication documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,26 +35,34 @@ iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/s
 ```
 
 ##### Option 5: Using private repository configurations
+
+**For Private GitLab Repositories (One-liner recommended):**
 ```powershell
-# For private GitLab repositories (supports both web and API URLs)
-# Web URL format (automatically converted to API format):
+# One-liner (recommended) - works from any shell, Run dialog, or shortcuts
+powershell -NoProfile -NoExit -ExecutionPolicy Bypass -Command "`$env:CLAUDE_ENV_CONFIG='https://gitlab.company.com/namespace/project/-/raw/main/config.yaml'; `$env:GITLAB_TOKEN='glpat-YOUR-TOKEN'; iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')"
+
+# Alternative: Two-step approach (if already in PowerShell)
 $env:CLAUDE_ENV_CONFIG='https://gitlab.company.com/namespace/project/-/raw/main/path/to/config.yaml'
 $env:GITLAB_TOKEN='glpat-YOUR-TOKEN-HERE'
 iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')
+```
 
-# API URL format (if you prefer to use it directly):
-$env:CLAUDE_ENV_CONFIG='https://gitlab.company.com/api/v4/projects/namespace%2Fproject/repository/files/path%2Fto%2Fconfig.yaml/raw?ref=main'
-$env:GITLAB_TOKEN='glpat-YOUR-TOKEN-HERE'
-iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')
+**For Private GitHub Repositories (One-liner recommended):**
+```powershell
+# One-liner (recommended) - works from any shell, Run dialog, or shortcuts
+powershell -NoProfile -NoExit -ExecutionPolicy Bypass -Command "`$env:CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/repo/main/config.yaml'; `$env:GITHUB_TOKEN='ghp_YOUR-TOKEN'; iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')"
 
-# For private GitHub repositories
+# Alternative: Two-step approach (if already in PowerShell)
 $env:CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/repo/main/config.yaml'
 $env:GITHUB_TOKEN='ghp_YOUR-TOKEN-HERE'
 iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')
-
-# One-liner with escaping (use -NoExit to see any errors)
-powershell -NoProfile -NoExit -ExecutionPolicy Bypass -Command "`$env:CLAUDE_ENV_CONFIG='https://gitlab.company.com/namespace/project/-/raw/main/config.yaml'; `$env:GITLAB_TOKEN='glpat-YOUR-TOKEN'; iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')"
 ```
+
+**💡 Pro Tips:**
+- Use `-NoExit` flag to keep the window open and see any errors
+- GitLab web URLs (`/-/raw/`) are automatically converted to API format
+- Query parameters (like `?ref_type=heads`) are handled automatically
+- The script only uses authentication when needed (public repos work without tokens)
 
 #### macOS
 ```bash
@@ -64,15 +72,11 @@ CLAUDE_ENV_CONFIG=python curl -fsSL https://raw.githubusercontent.com/alex-feel/
 # Local config file
 CLAUDE_ENV_CONFIG=./my-env.yaml curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash
 
-# Private GitLab repository (web URL - auto-converted)
-CLAUDE_ENV_CONFIG='https://gitlab.company.com/namespace/project/-/raw/main/config.yaml' \
-GITLAB_TOKEN='glpat-YOUR-TOKEN' \
-curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash
+# Private GitLab repository (one-liner)
+CLAUDE_ENV_CONFIG='https://gitlab.company.com/namespace/project/-/raw/main/config.yaml' GITLAB_TOKEN='glpat-YOUR-TOKEN' curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash
 
-# Private GitHub repository
-CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/repo/main/config.yaml' \
-GITHUB_TOKEN='ghp_YOUR-TOKEN' \
-curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash
+# Private GitHub repository (one-liner)
+CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/repo/main/config.yaml' GITHUB_TOKEN='ghp_YOUR-TOKEN' curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash
 ```
 
 #### Linux
@@ -83,15 +87,11 @@ CLAUDE_ENV_CONFIG=python curl -fsSL https://raw.githubusercontent.com/alex-feel/
 # Local config file
 CLAUDE_ENV_CONFIG=./my-env.yaml curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
 
-# Private GitLab repository (web URL - auto-converted)
-CLAUDE_ENV_CONFIG='https://gitlab.company.com/namespace/project/-/raw/main/config.yaml' \
-GITLAB_TOKEN='glpat-YOUR-TOKEN' \
-curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
+# Private GitLab repository (one-liner)
+CLAUDE_ENV_CONFIG='https://gitlab.company.com/namespace/project/-/raw/main/config.yaml' GITLAB_TOKEN='glpat-YOUR-TOKEN' curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
 
-# Private GitHub repository
-CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/repo/main/config.yaml' \
-GITHUB_TOKEN='ghp_YOUR-TOKEN' \
-curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
+# Private GitHub repository (one-liner)
+CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/repo/main/config.yaml' GITHUB_TOKEN='ghp_YOUR-TOKEN' curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
 ```
 
 This automated setup includes:
@@ -130,34 +130,53 @@ The setup script will warn you when loading from remote URLs. Always review the 
 
 ### 🔐 Using Private Repository Configurations
 
-For configurations stored in private repositories, you need to provide authentication:
+For configurations stored in private repositories, you need to provide authentication.
 
-#### Supported Authentication Methods
+#### Quick Start: One-liner Commands
 
-1. **GitLab Token** (via `GITLAB_TOKEN` environment variable)
-   - Create a personal access token with `read_repository` scope
-   - The token will be used as `PRIVATE-TOKEN` header
+**GitLab Private Repository (Windows):**
+```powershell
+powershell -NoProfile -NoExit -ExecutionPolicy Bypass -Command "`$env:CLAUDE_ENV_CONFIG='https://gitlab.company.com/team/configs/-/raw/main/env.yaml'; `$env:GITLAB_TOKEN='glpat-YOUR-TOKEN'; iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')"
+```
 
-2. **GitHub Token** (via `GITHUB_TOKEN` environment variable)
-   - Create a personal access token with `repo` scope
-   - The token will be used as `Authorization: Bearer` header
+**GitHub Private Repository (Windows):**
+```powershell
+powershell -NoProfile -NoExit -ExecutionPolicy Bypass -Command "`$env:CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/configs/main/env.yaml'; `$env:GITHUB_TOKEN='ghp_YOUR-TOKEN'; iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')"
+```
 
-3. **Generic Token** (via `REPO_TOKEN` environment variable)
-   - Automatically detects repository type and uses appropriate header
+**GitLab Private Repository (macOS/Linux):**
+```bash
+CLAUDE_ENV_CONFIG='https://gitlab.company.com/team/configs/-/raw/main/env.yaml' GITLAB_TOKEN='glpat-YOUR-TOKEN' curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
+```
 
-4. **Custom Auth** (via `CLAUDE_ENV_AUTH` environment variable)
-   - Specify custom header format: `Header-Name:token-value`
+**GitHub Private Repository (macOS/Linux):**
+```bash
+CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/configs/main/env.yaml' GITHUB_TOKEN='ghp_YOUR-TOKEN' curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
+```
 
-#### Important Notes for Private Repositories
+#### Authentication Details
 
-- **Use `-NoExit` flag on Windows**: When running from PowerShell shortcuts or Run dialog, add `-NoExit` to see any authentication errors
-- **Check token permissions**: Ensure your token has read access to the repository and all referenced resources
-- **GitLab URLs**: Both web and API formats are supported
-  - Web format (auto-converted): `https://gitlab.com/namespace/project/-/raw/branch/path/to/file`
-  - API format: `https://gitlab.com/api/v4/projects/namespace%2Fproject/repository/files/path%2Fto%2Ffile/raw?ref=branch`
-  - The setup script automatically converts web URLs to API format for authentication
-- **GitHub URLs**: Use raw content URL
-  - Format: `https://raw.githubusercontent.com/{org}/{repo}/{branch}/{path}`
+**GitLab Authentication:**
+- Create a personal access token with `read_repository` scope
+- Use `GITLAB_TOKEN` environment variable
+- GitLab web URLs (`/-/raw/`) are automatically converted to API format
+- Query parameters (like `?ref_type=heads`) are handled automatically
+
+**GitHub Authentication:**
+- Create a personal access token with `repo` scope
+- Use `GITHUB_TOKEN` environment variable
+- Use raw.githubusercontent.com URLs
+
+**Additional Options:**
+- `REPO_TOKEN` - Generic token that auto-detects repository type
+- `CLAUDE_ENV_AUTH` - Custom header format: `Header-Name:token-value`
+
+#### Pro Tips
+
+- **Windows**: Always use `-NoExit` flag to see any errors
+- **All platforms**: The script tries public access first, only using tokens when needed
+- **GitLab**: Both web (`/-/raw/`) and API URLs work - web URLs are auto-converted
+- **Tokens**: Never commit tokens to repositories - use environment variables instead
 
 ---
 

--- a/environments/README.md
+++ b/environments/README.md
@@ -45,9 +45,8 @@ CLAUDE_ENV_CONFIG=./my-config.yaml curl -fsSL https://raw.githubusercontent.com/
 ### 3. Remote URLs (⚠️ Verify Source!)
 Load configurations from any web server:
 ```powershell
-# Windows
-$env:CLAUDE_ENV_CONFIG='https://example.com/my-env.yaml'
-iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')
+# Windows (One-liner recommended)
+powershell -NoProfile -NoExit -ExecutionPolicy Bypass -Command "`$env:CLAUDE_ENV_CONFIG='https://example.com/my-env.yaml'; iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')"
 
 # Linux/macOS
 CLAUDE_ENV_CONFIG=https://example.com/my-env.yaml curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
@@ -55,53 +54,78 @@ CLAUDE_ENV_CONFIG=https://example.com/my-env.yaml curl -fsSL https://raw.githubu
 
 **⚠️ WARNING:** The script will display a warning when loading from URLs. Review the configuration carefully!
 
-## Private Repository Support
+## 🔐 Private Repository Support
 
 The setup script supports loading configurations from private GitLab and GitHub repositories with authentication.
 
-### Authentication Methods (in order of precedence)
+### Quick Start: One-liner Commands (Recommended)
 
-1. **Command-line parameter** (highest priority)
-2. **Environment variables**
-3. **Interactive prompt** (fallback)
+#### GitLab Private Repositories
 
-### GitLab Private Repositories
-
+**Windows (PowerShell/CMD/Run Dialog):**
 ```powershell
-# Windows - Using environment variable
-$env:GITLAB_TOKEN='glpat-YOUR_TOKEN_HERE'
-$env:CLAUDE_ENV_CONFIG='https://gitlab.company.com/api/v4/projects/123/repository/files/config.yaml/raw?ref=main'
+powershell -NoProfile -NoExit -ExecutionPolicy Bypass -Command "`$env:CLAUDE_ENV_CONFIG='https://gitlab.company.com/team/configs/-/raw/main/env.yaml'; `$env:GITLAB_TOKEN='glpat-YOUR-TOKEN'; iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')"
+```
+
+**macOS/Linux:**
+```bash
+CLAUDE_ENV_CONFIG='https://gitlab.company.com/team/configs/-/raw/main/env.yaml' GITLAB_TOKEN='glpat-YOUR-TOKEN' curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
+```
+
+**Key Features:**
+- ✅ GitLab web URLs (`/-/raw/`) are automatically converted to API format
+- ✅ Query parameters (like `?ref_type=heads`) are handled automatically
+- ✅ Works with both self-hosted and gitlab.com
+- ✅ Create token with `read_repository` scope
+
+#### GitHub Private Repositories
+
+**Windows (PowerShell/CMD/Run Dialog):**
+```powershell
+powershell -NoProfile -NoExit -ExecutionPolicy Bypass -Command "`$env:CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/configs/main/env.yaml'; `$env:GITHUB_TOKEN='ghp_YOUR-TOKEN'; iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')"
+```
+
+**macOS/Linux:**
+```bash
+CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/configs/main/env.yaml' GITHUB_TOKEN='ghp_YOUR-TOKEN' curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
+```
+
+**Key Features:**
+- ✅ Use `raw.githubusercontent.com` URLs
+- ✅ Works with github.com and GitHub Enterprise
+- ✅ Create token with `repo` scope
+
+### Alternative Methods
+
+#### Two-Step Approach (If Already in Shell)
+
+**Windows PowerShell:**
+```powershell
+# GitLab
+$env:CLAUDE_ENV_CONFIG='https://gitlab.company.com/team/configs/-/raw/main/env.yaml'
+$env:GITLAB_TOKEN='glpat-YOUR-TOKEN'
 iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')
 
-# Windows - Using --auth parameter
-python scripts/setup_environment.py "https://gitlab.company.com/api/v4/projects/123/repository/files/config.yaml/raw?ref=main" --auth "glpat-YOUR_TOKEN_HERE"
+# GitHub
+$env:CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/configs/main/env.yaml'
+$env:GITHUB_TOKEN='ghp_YOUR-TOKEN'
+iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')
+```
 
-# Linux/macOS - Using environment variable
-export GITLAB_TOKEN='glpat-YOUR_TOKEN_HERE'
-CLAUDE_ENV_CONFIG='https://gitlab.company.com/api/v4/projects/123/repository/files/config.yaml/raw?ref=main' \
+**macOS/Linux:**
+```bash
+# GitLab
+export GITLAB_TOKEN='glpat-YOUR-TOKEN'
+CLAUDE_ENV_CONFIG='https://gitlab.company.com/team/configs/-/raw/main/env.yaml' \
+  curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
+
+# GitHub
+export GITHUB_TOKEN='ghp_YOUR-TOKEN'
+CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/configs/main/env.yaml' \
   curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
 ```
 
-### GitHub Private Repositories
-
-```powershell
-# Windows - Using environment variable
-$env:GITHUB_TOKEN='ghp_YOUR_TOKEN_HERE'
-$env:CLAUDE_ENV_CONFIG='https://api.github.com/repos/owner/repo/contents/config.yaml'
-iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')
-
-# Windows - Using --auth parameter
-python scripts/setup_environment.py "https://api.github.com/repos/owner/repo/contents/config.yaml" --auth "ghp_YOUR_TOKEN_HERE"
-
-# Linux/macOS - Using environment variable
-export GITHUB_TOKEN='ghp_YOUR_TOKEN_HERE'
-CLAUDE_ENV_CONFIG='https://api.github.com/repos/owner/repo/contents/config.yaml' \
-  curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
-```
-
-### Generic Token Support
-
-You can also use `REPO_TOKEN` as a generic environment variable that works for both GitLab and GitHub:
+#### Generic Token (Auto-detects Repository Type)
 
 ```powershell
 # Windows
@@ -111,38 +135,34 @@ $env:REPO_TOKEN='your-token-here'
 export REPO_TOKEN='your-token-here'
 ```
 
-### One-liner with Authentication
+### Authentication Methods (Priority Order)
 
-```powershell
-# Windows PowerShell - GitLab with token
-powershell -NoProfile -ExecutionPolicy Bypass -Command "`$env:CLAUDE_ENV_CONFIG='https://gitlab.company.com/api/v4/projects/123/repository/files/config.yaml/raw?ref=main'; `$env:GITLAB_TOKEN='glpat-xxx'; iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')"
+1. **Command-line `--auth` parameter** (highest priority)
+2. **Environment variables** (`GITLAB_TOKEN`, `GITHUB_TOKEN`, `REPO_TOKEN`)
+3. **Interactive prompt** (fallback if terminal available)
 
-# Linux/macOS - GitHub with token
-GITHUB_TOKEN='ghp_xxx' CLAUDE_ENV_CONFIG='https://api.github.com/repos/owner/repo/contents/config.yaml' curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
-```
+### Pro Tips
 
-### Authentication Notes
-
-- The script tries to access public repositories first, only using authentication if needed (401/403 errors)
-- Tokens are never stored or logged by the setup script
-- For CI/CD pipelines, use environment variables rather than --auth parameter
-- Interactive prompt is only available when running in a terminal (not in CI/CD)
+- **Windows Users**: Always use `-NoExit` flag to see any errors
+- **All Platforms**: Script tries public access first, only uses tokens when needed
+- **CI/CD**: Use environment variables, not interactive prompts
+- **Security**: Never commit tokens - use environment variables or secrets management
+- **GitLab**: Both web (`/-/raw/`) and API formats work - web URLs auto-convert
+- **Troubleshooting**: Check token permissions match the required scope
 
 ## Quick Start Examples
 
-### Windows (PowerShell)
+### Windows (PowerShell/CMD/Run Dialog)
 
 ```powershell
-# Repository config (recommended for standard setups)
-$env:CLAUDE_ENV_CONFIG='python'
-iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')
-
-# Local config with API keys (for team/personal setups)
-$env:CLAUDE_ENV_CONFIG='./team-config.yaml'
-iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')
-
-# One-liner for any shell
+# One-liner for repository config (works from any shell)
 powershell -NoProfile -ExecutionPolicy Bypass -Command "`$env:CLAUDE_ENV_CONFIG='python'; iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')"
+
+# One-liner for local config with API keys
+powershell -NoProfile -NoExit -ExecutionPolicy Bypass -Command "`$env:CLAUDE_ENV_CONFIG='./team-config.yaml'; iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')"
+
+# One-liner for private GitLab repo
+powershell -NoProfile -NoExit -ExecutionPolicy Bypass -Command "`$env:CLAUDE_ENV_CONFIG='https://gitlab.company.com/configs/-/raw/main/env.yaml'; `$env:GITLAB_TOKEN='glpat-TOKEN'; iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')"
 ```
 
 ### macOS/Linux


### PR DESCRIPTION
Enhanced authentication documentation with clearer separation between GitLab and GitHub, making one-liners the primary recommended method:

- Added separate sections for GitLab vs GitHub authentication
- Made one-liner commands the primary examples (with -NoExit flag)
- Documented automatic GitLab URL conversion from web to API format
- Clarified that query parameters are handled automatically
- Added Pro Tips sections with practical advice
- Reorganized authentication methods for better clarity
- Updated both main README.md and environments/README.md

The documentation now clearly shows how to use authentication tokens with private repositories, emphasizing the simplest approach first.