### PR TITLE
Skip validation workflow on Release Please PRs

### DIFF
--- a/.github/workflows/validate-configs.yml
+++ b/.github/workflows/validate-configs.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   validate:
     name: Validate Environment Configurations
+    if: ${{ ! startsWith(github.head_ref, 'release-please--branches--') }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The validation workflow was unnecessarily running on Release Please PRs. This fix adds the same condition used by other workflows to skip automated release PRs.

## Changes
- Added condition to skip validation when PR branch starts with 'release-please--branches--'
- Matches behavior of lint.yml and other workflows

This prevents unnecessary workflow runs on PR #63 and future Release Please PRs.