### PR TITLE
Handle release-please PRs in matrix jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,12 @@ jobs:
         python-version: ['3.12']
 
     steps:
-      - name: Skip release-please PRs
+      # Skip all steps for release-please PRs
+      - name: Skip for release-please
         if: ${{ startsWith(github.head_ref, 'release-please--branches--') }}
-        run: echo "Skipping tests for release-please PR"
+        run: |
+          echo "Skipping tests for release-please PR"
+          echo "This job will complete quickly to satisfy branch protection"
 
       - name: Checkout code
         if: ${{ ! startsWith(github.head_ref, 'release-please--branches--') }}
@@ -126,9 +129,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - name: Skip release-please PRs
+      # Skip all steps for release-please PRs
+      - name: Skip for release-please
         if: ${{ startsWith(github.head_ref, 'release-please--branches--') }}
-        run: echo "Skipping tests for release-please PR"
+        run: |
+          echo "Skipping tests for release-please PR"
+          echo "This job will complete quickly to satisfy branch protection"
 
       - name: Checkout code
         if: ${{ ! startsWith(github.head_ref, 'release-please--branches--') }}


### PR DESCRIPTION
## Summary

GitHub Actions has a fundamental limitation: matrix jobs with job-level conditions don't register as status checks, causing 'Expected - Waiting for status' in branch protection.

## Solution

Jobs must run to satisfy required checks, but will exit quickly for release-please PRs:
- Add early 'Skip for release-please' step that exits quickly
- Skip all expensive steps (checkout, setup, tests) conditionally
- Jobs will show as 'Successful' (not 'Skipped') - this is a GitHub limitation

This is the standard approach used by major projects. There's no way to make jobs show as 'Skipped' while still satisfying required checks.