### PR TITLE
Fix release-please workflow skipping with correct approach

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,6 @@ name: Lint and Validate
 
 on:
   pull_request:
-    branches-ignore:
-      - 'release-please--branches--**'  # Skip release-please PRs entirely
   workflow_dispatch:
 
 permissions:
@@ -13,6 +11,7 @@ permissions:
 jobs:
   pre-commit:
     name: Run Pre-Commit Checks
+    if: ${{ ! startsWith(github.head_ref, 'release-please--branches--') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -42,6 +41,7 @@ jobs:
 
   powershell:
     name: PowerShell Script Analysis
+    if: ${{ ! startsWith(github.head_ref, 'release-please--branches--') }}
     runs-on: windows-latest
 
     steps:
@@ -63,6 +63,7 @@ jobs:
 
   security:
     name: Security Scan
+    if: ${{ ! startsWith(github.head_ref, 'release-please--branches--') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Test & Coverage
 
 on:
   pull_request:
-    branches-ignore:
-      - 'release-please--branches--**'  # Skip release-please PRs entirely
   workflow_dispatch:
 
 permissions:
@@ -14,6 +12,7 @@ permissions:
 jobs:
   test:
     name: Test Python on ${{ matrix.os }}
+    if: ${{ ! startsWith(github.head_ref, 'release-please--branches--') }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -77,6 +76,7 @@ jobs:
 
   test-validation:
     name: Test Environment Validation
+    if: ${{ ! startsWith(github.head_ref, 'release-please--branches--') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -104,6 +104,7 @@ jobs:
 
   test-install-scripts:
     name: Test Install Scripts
+    if: ${{ ! startsWith(github.head_ref, 'release-please--branches--') }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -150,7 +151,7 @@ jobs:
     name: Test Summary
     runs-on: ubuntu-latest
     needs: [test, test-validation, test-install-scripts]
-    if: always()
+    if: ${{ always() && ! startsWith(github.head_ref, 'release-please--branches--') }}
 
     steps:
       - name: Summary

--- a/.github/workflows/validate-configs.yml
+++ b/.github/workflows/validate-configs.yml
@@ -2,8 +2,6 @@ name: Validate Environment Configs
 
 on:
   pull_request:
-    branches-ignore:
-      - 'release-please--branches--**'  # Skip release-please PRs entirely
 
 permissions:
   contents: read
@@ -12,6 +10,7 @@ permissions:
 jobs:
   validate:
     name: Validate Environment Configurations
+    if: ${{ ! startsWith(github.head_ref, 'release-please--branches--') }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Remove incorrect branches-ignore filters (they filter target branch, not source branch). Use job-level 'if: ! startsWith(github.head_ref, release-please--)' conditions instead.

GitHub Actions limitation: workflows cannot be skipped entirely based on source branch. Jobs must use github.head_ref in conditionals to skip based on pull request source branch.

For Release Please PRs: all test jobs will now be skipped (not started).