### PR TITLE
Force MCP server removal before re-adding to ensure config updates

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -1156,6 +1156,11 @@ def configure_mcp_server(server: dict[str, Any]) -> bool:
         return False
 
     try:
+        # Remove existing MCP server if present (ignore errors if it doesn't exist)
+        info(f'Removing existing MCP server {name} if present...')
+        remove_cmd = [str(claude_cmd), 'mcp', 'remove', '--scope', scope, name]
+        run_command(remove_cmd, capture_output=True)  # Ignore result - server might not exist
+
         # Build the base command
         base_cmd = [str(claude_cmd), 'mcp', 'add']
 
@@ -1229,9 +1234,6 @@ $LASTEXITCODE
         # Check if successful
         if result.returncode == 0:
             success(f'MCP server {name} configured successfully!')
-            return True
-        if result.stderr and 'already exists' in result.stderr.lower():
-            success(f'MCP server {name} already configured!')
             return True
 
         # If it still fails, try one more time with a delay

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -426,11 +426,12 @@ class TestConfigureMCPServer:
 
         result = setup_environment.configure_mcp_server(server)
         assert result is True
-        mock_run.assert_called_once()
-        # Check the command string contains mcp add
-        cmd_str = ' '.join(str(arg) for arg in mock_run.call_args[0][0])
-        assert 'mcp add' in cmd_str
-        assert 'test-server' in cmd_str
+        # Should call run_command twice: once for remove, once for add
+        assert mock_run.call_count == 2
+        # Check the second call (add command) contains mcp add
+        add_cmd_str = ' '.join(str(arg) for arg in mock_run.call_args_list[1][0][0])
+        assert 'mcp add' in add_cmd_str
+        assert 'test-server' in add_cmd_str
 
     @patch('setup_environment.find_command')
     @patch('setup_environment.run_command')
@@ -447,6 +448,8 @@ class TestConfigureMCPServer:
 
         result = setup_environment.configure_mcp_server(server)
         assert result is True
+        # Should call run_command twice: once for remove, once for add
+        assert mock_run.call_count == 2
 
 
 class TestCreateAdditionalSettings:


### PR DESCRIPTION
Previously, re-running setup would skip existing MCP servers with 'already configured' message, preventing configuration updates. Now the script removes each server before adding it, making the setup idempotent and allowing configuration changes to be applied on subsequent runs.