### PR TITLE
Handle unbound variable error in setup scripts when piped to bash

### DIFF
--- a/scripts/linux/setup-environment.sh
+++ b/scripts/linux/setup-environment.sh
@@ -53,7 +53,7 @@ echo ""
 SCRIPT_URL="https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/setup_environment.py"
 
 # Check if configuration is specified
-CONFIG="${CLAUDE_ENV_CONFIG:-$1}"
+CONFIG="${CLAUDE_ENV_CONFIG:-${1:-}}"
 
 if [ -z "$CONFIG" ]; then
     echo -e "${RED}[ERROR]${NC} No configuration specified!"

--- a/scripts/macos/setup-environment.sh
+++ b/scripts/macos/setup-environment.sh
@@ -53,7 +53,7 @@ echo ""
 SCRIPT_URL="https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/setup_environment.py"
 
 # Check if configuration is specified
-CONFIG="${CLAUDE_ENV_CONFIG:-$1}"
+CONFIG="${CLAUDE_ENV_CONFIG:-${1:-}}"
 
 if [ -z "$CONFIG" ]; then
     echo -e "${RED}[ERROR]${NC} No configuration specified!"


### PR DESCRIPTION
Fix "$1: unbound variable" error that occurs when setup-environment.sh is piped to bash (e.g., via curl). The issue was caused by unsafe parameter expansion ${CLAUDE_ENV_CONFIG:-$1} which fails with set -u when $1 is unbound in piped execution context.

Changed to ${CLAUDE_ENV_CONFIG:-${1:-}} to safely handle both:
- Piped execution: CLAUDE_ENV_CONFIG=config curl ... | bash (works)
- Direct execution: ./setup-environment.sh config (still works)