### PR TITLE
Fix environment variable passing in bash piped execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,31 +55,43 @@ iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/s
 ### macOS
 ```bash
 # Public repository config
-CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/repo/main/config.yaml' curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash
+export CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/repo/main/config.yaml'
+curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash
 
 # Local config file
-CLAUDE_ENV_CONFIG=./my-env.yaml curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash
+export CLAUDE_ENV_CONFIG=./my-env.yaml
+curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash
 
 # Private GitLab repository
-CLAUDE_ENV_CONFIG='https://gitlab.company.com/namespace/project/-/raw/main/config.yaml' GITLAB_TOKEN='glpat-<your-token>' curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash
+export CLAUDE_ENV_CONFIG='https://gitlab.company.com/namespace/project/-/raw/main/config.yaml'
+export GITLAB_TOKEN='glpat-<your-token>'
+curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash
 
 # Private GitHub repository
-CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/repo/main/config.yaml' GITHUB_TOKEN='ghp_<your-token>' curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash
+export CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/repo/main/config.yaml'
+export GITHUB_TOKEN='ghp_<your-token>'
+curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash
 ```
 
 ### Linux
 ```bash
 # Public repository config
-CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/repo/main/config.yaml' curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
+export CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/repo/main/config.yaml'
+curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
 
 # Local config file
-CLAUDE_ENV_CONFIG=./my-env.yaml curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
+export CLAUDE_ENV_CONFIG=./my-env.yaml
+curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
 
 # Private GitLab repository
-CLAUDE_ENV_CONFIG='https://gitlab.company.com/namespace/project/-/raw/main/config.yaml' GITLAB_TOKEN='glpat-<your-token>' curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
+export CLAUDE_ENV_CONFIG='https://gitlab.company.com/namespace/project/-/raw/main/config.yaml'
+export GITLAB_TOKEN='glpat-<your-token>'
+curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
 
 # Private GitHub repository
-CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/repo/main/config.yaml' GITHUB_TOKEN='ghp_<your-token>' curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
+export CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/repo/main/config.yaml'
+export GITHUB_TOKEN='ghp_<your-token>'
+curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
 ```
 
 **✅ After setup, use the simple command:**

--- a/scripts/linux/setup-environment.sh
+++ b/scripts/linux/setup-environment.sh
@@ -4,7 +4,8 @@
 # Purpose: Bootstrap uv and run the cross-platform environment setup
 # Usage: curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
 # To specify configuration:
-#   CLAUDE_ENV_CONFIG=python curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
+#   export CLAUDE_ENV_CONFIG=python
+#   curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
 
 set -euo pipefail
 

--- a/scripts/macos/setup-environment.sh
+++ b/scripts/macos/setup-environment.sh
@@ -4,7 +4,8 @@
 # Purpose: Bootstrap uv and run the cross-platform environment setup
 # Usage: curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash
 # To specify configuration:
-#   CLAUDE_ENV_CONFIG=python curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash
+#   export CLAUDE_ENV_CONFIG=python
+#   curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash
 
 set -euo pipefail
 


### PR DESCRIPTION
Update documentation and usage comments to use export statements before piped commands. The previous pattern (VAR=value curl | bash) doesn't work because inline environment variables only apply to the first command in a pipe, not to subsequent commands.