### PR TITLE
Ensure Python 3.12 is used for hook execution on Unix systems

### DIFF
--- a/scripts/linux/setup-environment.sh
+++ b/scripts/linux/setup-environment.sh
@@ -47,6 +47,16 @@ else
     echo -e "${GREEN}[OK]${NC}   uv is already installed"
 fi
 
+# Install Python 3.12 if not already available
+echo -e "${CYAN}[INFO]${NC} Ensuring Python 3.12 is available..."
+if ! command -v python3.12 &> /dev/null; then
+    echo -e "${CYAN}[INFO]${NC} Installing Python 3.12 via uv..."
+    uv python install 3.12
+fi
+
+# Ensure ~/.local/bin is in PATH for current session
+export PATH="$HOME/.local/bin:$PATH"
+
 # Run the setup script
 echo -e "${CYAN}[INFO]${NC} Running environment setup..."
 echo ""

--- a/scripts/macos/setup-environment.sh
+++ b/scripts/macos/setup-environment.sh
@@ -47,6 +47,16 @@ else
     echo -e "${GREEN}[OK]${NC}   uv is already installed"
 fi
 
+# Install Python 3.12 if not already available
+echo -e "${CYAN}[INFO]${NC} Ensuring Python 3.12 is available..."
+if ! command -v python3.12 &> /dev/null; then
+    echo -e "${CYAN}[INFO]${NC} Installing Python 3.12 via uv..."
+    uv python install 3.12
+fi
+
+# Ensure ~/.local/bin is in PATH for current session
+export PATH="$HOME/.local/bin:$PATH"
+
 # Run the setup script
 echo -e "${CYAN}[INFO]${NC} Running environment setup..."
 echo ""

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -1424,11 +1424,21 @@ def create_additional_settings(
                 hook_path_str = hook_path.as_posix()
                 full_command = f'{python_cmd} {hook_path_str}'
             else:
-                # Unix-like systems can use shebang directly
+                # Unix-like systems - explicitly use Python 3.12 for hooks
+                # This ensures compatibility with modern Python features (e.g., datetime.UTC)
+                python_cmd = 'python3.12' if shutil.which('python3.12') else None
+
+                if not python_cmd:
+                    error(f'Python 3.12 required for hook "{command}" but not found in PATH')
+                    error('Please install Python 3.12: uv python install 3.12')
+                    # Continue without this hook rather than failing the entire setup
+                    continue
+
                 # Make script executable
                 if hook_path.exists():
                     hook_path.chmod(0o755)
-                full_command = str(hook_path)
+
+                full_command = f'{python_cmd} {hook_path}'
         else:
             # Not a Python script, use command as-is
             full_command = command


### PR DESCRIPTION
- Add Python 3.12 installation to Linux and macOS setup scripts
- Explicitly use python3.12 executable for hook execution instead of relying on shebang
- Fix ImportError for datetime.UTC which requires Python 3.11+
- Provide clear error messages when Python 3.12 is not available

This resolves hook execution failures on macOS and Linux where system Python 3.9 was being used instead of the required Python 3.12.