### PR TITLE
Add platform-specific dependencies support

### DIFF
--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -348,7 +348,7 @@ class TestInstallDependencies:
         assert mock_system.return_value == 'Windows'
         mock_run.return_value = subprocess.CompletedProcess([], 0, '', '')
 
-        result = setup_environment.install_dependencies(['npm install -g package'])
+        result = setup_environment.install_dependencies({'windows': ['npm install -g package']})
         assert result is True
         mock_run.assert_called_with(['npm', 'install', '-g', 'package'], capture_output=False)
 
@@ -360,7 +360,7 @@ class TestInstallDependencies:
         assert mock_system.return_value == 'Linux'
         mock_run.return_value = subprocess.CompletedProcess([], 0, '', '')
 
-        result = setup_environment.install_dependencies(['apt-get install package'])
+        result = setup_environment.install_dependencies({'linux': ['apt-get install package']})
         assert result is True
         mock_run.assert_called_with(['bash', '-c', 'apt-get install package'], capture_output=False)
 
@@ -372,7 +372,7 @@ class TestInstallDependencies:
         assert mock_system.return_value == 'Windows'
         mock_run.return_value = subprocess.CompletedProcess([], 0, '', '')
 
-        result = setup_environment.install_dependencies(['uv tool install ruff'])
+        result = setup_environment.install_dependencies({'windows': ['uv tool install ruff']})
         assert result is True
         mock_run.assert_called_with(['uv', 'tool', 'install', '--force', 'ruff'], capture_output=False)
 

--- a/tests/test_setup_environment_additional.py
+++ b/tests/test_setup_environment_additional.py
@@ -1290,7 +1290,7 @@ class TestInstallDependenciesEdgeCases:
         """Test PowerShell fallback for unknown commands on Windows."""
         mock_run.return_value = subprocess.CompletedProcess([], 0, '', '')
 
-        result = setup_environment.install_dependencies(['custom-command install package'])
+        result = setup_environment.install_dependencies({'windows': ['custom-command install package']})
         assert result is True
 
         # Should use PowerShell for unknown command
@@ -1303,7 +1303,7 @@ class TestInstallDependenciesEdgeCases:
         """Test uv tool install with force flag on Linux."""
         mock_run.return_value = subprocess.CompletedProcess([], 0, '', '')
 
-        result = setup_environment.install_dependencies(['uv tool install pytest'])
+        result = setup_environment.install_dependencies({'linux': ['uv tool install pytest']})
         assert result is True
 
         # Should add --force flag
@@ -1319,7 +1319,7 @@ class TestInstallDependenciesEdgeCases:
             subprocess.CompletedProcess([], 0, '', ''),  # Second succeeds
         ]
 
-        result = setup_environment.install_dependencies(['failing-dep', 'working-dep'])
+        result = setup_environment.install_dependencies({'windows': ['failing-dep', 'working-dep']})
         assert result is True
         assert mock_run.call_count == 2
 


### PR DESCRIPTION
BREAKING CHANGE: Dependencies structure changed from flat list to platform-specific dictionary. All existing environment configs must be updated.

Old format (no longer supported):

```yaml
dependencies:
  - command1
  - command2
```

New format (required):

```yaml
dependencies:
  common:
    - command_for_all_platforms
  windows:
    - windows_specific_command
  mac:
    - mac_specific_command
  linux:
    - linux_specific_command
```

This change allows single config files to work across all platforms, eliminating the need for separate OS-specific configs. The install_dependencies() function now strictly validates the dict format and rejects list format with no backward compatibility.