### PR TITLE
Ensure Node.js PATH propagates to MCP configuration on Windows

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -1825,19 +1825,66 @@ $LASTEXITCODE
                 )
         elif command:
             # Stdio transport (command)
-            if env:
-                base_cmd.extend(['--env', env])
-            base_cmd.append('--')
 
-            # Platform-specific command handling
-            if system == 'Windows' and 'npx' in command:
-                # Windows needs cmd /c wrapper for npx
-                base_cmd.extend(['cmd', '/c', command])
+            # Try with PowerShell environment reload on Windows
+            if system == 'Windows':
+                # Build explicit PATH including Node.js location
+                # This fixes Windows 10+ PATH propagation bug where MSI registry updates
+                # don't propagate to running processes via WM_SETTINGCHANGE
+                nodejs_path = r'C:\Program Files\nodejs'
+                current_path = os.environ.get('PATH', '')
+
+                # Ensure Node.js is in PATH
+                if Path(nodejs_path).exists() and nodejs_path not in current_path:
+                    explicit_path = f'{nodejs_path};{current_path}'
+                else:
+                    explicit_path = current_path
+
+                # Build command string with proper escaping for PowerShell
+                # PowerShell uses backtick for escaping
+                command_escaped = command.replace('"', '`"')
+
+                # Special handling for npx (needs cmd /c wrapper on Windows)
+                command_str = f'cmd /c {command_escaped}' if 'npx' in command else command_escaped
+
+                # Build PowerShell script with explicit PATH
+                if env:
+                    ps_script = f'''
+$env:Path = "{explicit_path}"
+& "{claude_cmd}" mcp add --scope {scope} --env {env} {name} -- {command_str}
+$LASTEXITCODE
+'''
+                else:
+                    ps_script = f'''
+$env:Path = "{explicit_path}"
+& "{claude_cmd}" mcp add --scope {scope} {name} -- {command_str}
+$LASTEXITCODE
+'''
+                result = run_command(
+                    [
+                        'powershell',
+                        '-NoProfile',
+                        '-Command',
+                        ps_script,
+                    ],
+                    capture_output=True,
+                )
+
+                # Fallback to direct execution if PowerShell fails
+                if result.returncode != 0:
+                    info('PowerShell execution failed, trying direct execution...')
+                    fallback_cmd = [str(claude_cmd), 'mcp', 'add', '--scope', scope]
+                    if env:
+                        fallback_cmd.extend(['--env', env])
+                    fallback_cmd.extend([name, '--'])
+                    fallback_cmd.extend(command.split())
+                    result = run_command(fallback_cmd, capture_output=True)
             else:
-                # Unix-like systems can run command directly
+                # Unix-like systems - direct execution
+                base_cmd.extend(['--env', env] if env else [])
+                base_cmd.extend([name, '--'])
                 base_cmd.extend(command.split())
-
-            result = run_command(base_cmd, capture_output=True)
+                result = run_command(base_cmd, capture_output=True)
         else:
             error(f'MCP server {name} missing url or command')
             return False

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -1851,13 +1851,13 @@ $LASTEXITCODE
                 if env:
                     ps_script = f'''
 $env:Path = "{explicit_path}"
-& "{claude_cmd}" mcp add --scope "{scope}" --env "{env}" "{name}" -- {command_str}
+& "{claude_cmd}" mcp add --scope "{scope}" --env "{env}" "{name}" -- "{command_str}"
 $LASTEXITCODE
 '''
                 else:
                     ps_script = f'''
 $env:Path = "{explicit_path}"
-& "{claude_cmd}" mcp add --scope "{scope}" "{name}" -- {command_str}
+& "{claude_cmd}" mcp add --scope "{scope}" "{name}" -- "{command_str}"
 $LASTEXITCODE
 '''
                 result = run_command(

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -1760,11 +1760,12 @@ def configure_mcp_server(server: dict[str, Any]) -> bool:
         if scope:
             base_cmd.extend(['--scope', scope])
 
-        base_cmd.append(name)
+        # Note: Don't add name here - it must be added after options for correct argument order
 
         # Handle different transport types
         if transport and url:
             # HTTP or SSE transport
+            base_cmd.append(name)  # Add name here for HTTP/SSE transport
             base_cmd.extend(['--transport', transport, url])
             if header:
                 base_cmd.extend(['--header', header])
@@ -1850,6 +1851,7 @@ $LASTEXITCODE
                 # Ensure base_cmd has command args for potential retry at line 1902
                 if env:
                     base_cmd.extend(['--env', env])
+                base_cmd.append(name)  # Add name AFTER all options for correct argument order
                 base_cmd.extend(['--'])
                 if 'npx' in command:
                     base_cmd.extend(['cmd', '/c', command])

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -1851,13 +1851,13 @@ $LASTEXITCODE
                 if env:
                     ps_script = f'''
 $env:Path = "{explicit_path}"
-& "{claude_cmd}" mcp add --scope {scope} --env {env} {name} -- {command_str}
+& "{claude_cmd}" mcp add --scope "{scope}" --env "{env}" "{name}" -- {command_str}
 $LASTEXITCODE
 '''
                 else:
                     ps_script = f'''
 $env:Path = "{explicit_path}"
-& "{claude_cmd}" mcp add --scope {scope} {name} -- {command_str}
+& "{claude_cmd}" mcp add --scope "{scope}" "{name}" -- {command_str}
 $LASTEXITCODE
 '''
                 result = run_command(

--- a/tests/test_setup_environment_additional.py
+++ b/tests/test_setup_environment_additional.py
@@ -668,11 +668,13 @@ class TestMCPServerConfigurationEdgeCases:
         # Verify 3 remove commands and 1 add command were called
         assert mock_run.call_count == 4
 
+    @patch('platform.system', return_value='Windows')
     @patch('setup_environment.find_command', return_value='claude')
     @patch('setup_environment.run_command')
-    def test_configure_mcp_server_final_failure(self, mock_run, mock_find):
+    def test_configure_mcp_server_final_failure(self, mock_run, mock_find, mock_system):
         """Test MCP configuration final failure after retry."""
         del mock_find  # Unused but required for patch
+        del mock_system  # Unused but required for patch
         # 3 removes (one per scope), first add fails (PowerShell), fallback fails
         # retry add fails (PowerShell) - no second fallback
         mock_run.side_effect = [


### PR DESCRIPTION
Fixes Windows 10+ PATH propagation bug where MSI installations update the registry but changes don't propagate to running processes. MCP server configuration was failing with "node is not recognized" error despite successful Node.js installation.

Adds verify_nodejs_available() function with retry logic and explicit PATH passing to PowerShell subprocess calls, ensuring Node.js is accessible when configuring MCP servers.