### PR TITLE
Resolve Git installer download failure on Windows

### DIFF
--- a/tests/test_install_claude_additional.py
+++ b/tests/test_install_claude_additional.py
@@ -44,8 +44,9 @@ class TestErrorHandling:
         result = install_claude.install_git_windows_download()
         assert result is False
 
+    @patch('install_claude.get_git_installer_url_from_github', return_value=None)
     @patch('install_claude.urlopen')
-    def test_install_git_windows_download_ssl_error(self, mock_urlopen):
+    def test_install_git_windows_download_ssl_error(self, mock_urlopen, mock_github):
         """Test Git download with SSL error and fallback."""
         mock_response = MagicMock()
         mock_response.read.return_value = b'<a href="/git/Git-2.43.0-64-bit.exe">Download</a>'
@@ -61,6 +62,8 @@ class TestErrorHandling:
             mock_run.return_value = subprocess.CompletedProcess([], 0, '', '')
             result = install_claude.install_git_windows_download()
             assert result is True
+            # Verify GitHub API was tried first
+            mock_github.assert_called_once()
 
     @patch('install_claude.urlopen')
     def test_install_git_windows_download_url_error_non_ssl(self, mock_urlopen):

--- a/tests/test_install_claude_critical.py
+++ b/tests/test_install_claude_critical.py
@@ -18,9 +18,10 @@ import scripts.install_claude as install_claude
 class TestSSLErrorHandling:
     """Test SSL certificate error handling in various functions."""
 
+    @patch('scripts.install_claude.get_git_installer_url_from_github', return_value=None)
     @patch('scripts.install_claude.ssl.create_default_context')
     @patch('scripts.install_claude.urlopen')
-    def test_install_git_windows_download_ssl_error(self, mock_urlopen, mock_ssl_context):
+    def test_install_git_windows_download_ssl_error(self, mock_urlopen, mock_ssl_context, mock_github):
         """Test Git for Windows download with SSL certificate error."""
         # First urlopen raises SSL error, second succeeds
         ssl_error = urllib.error.URLError('SSL: CERTIFICATE_VERIFY_FAILED')
@@ -53,6 +54,8 @@ class TestSSLErrorHandling:
             result = install_claude.install_git_windows_download()
 
             assert result is True
+            # Verify GitHub API was tried first
+            mock_github.assert_called_once()
             assert mock_ssl_context.called
             assert mock_ctx.check_hostname is False
             assert mock_ctx.verify_mode == 0  # ssl.CERT_NONE


### PR DESCRIPTION
The git-scm.com download page changed from static HTML to JavaScript-based redirects, causing the regex pattern to fail with "Could not find Git installer link" error. This fix adds GitHub Releases API as the primary download method with the legacy scraping method as a fallback, ensuring reliable Git for Windows installation across different environments.