### PR TITLE
Remove output-style support and add system-prompt mode field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,7 @@ YAML configurations define complete development environments including:
 - Agents (subagents for Claude Code)
 - MCP servers (with automatic permission pre-allowing)
 - Slash commands
-- Output styles (complete system prompt replacements)
-- System prompts (append to default prompt)
+- System prompts (with configurable mode: append or replace)
 - Hooks (event-driven scripts)
 
 ### Cross-Shell Command Registration (Windows)
@@ -108,14 +107,13 @@ uv run pytest
 
 **Testing workflow after code changes:**
 1. Make your code changes
-2. Run `uv run pytest` to check all tests pass (must be 312/312, not 311/312)
+2. Run `uv run pytest` to check all tests pass
 3. Fix any failing tests immediately
 4. Run `uv run pre-commit run --all-files` for code quality validation
-5. Only commit when ALL tests pass (312/312) and all pre-commit hooks pass
+5. Only commit when ALL tests pass and all pre-commit hooks pass
 
 **IMPORTANT:**
-- 312/312 tests passing is the ONLY acceptable result
-- 311/312 or any other number is a FAILURE
+- All tests must pass (100% pass rate)
 - Use ONLY `uv run pre-commit run --all-files` for code quality checks
 
 **Important:** Never skip the test suite. Even small changes can have unexpected impacts.
@@ -187,11 +185,21 @@ hooks:
           command: linter.py  # References filename from 'files'
 ```
 
-### System Prompts vs Output Styles
+### System Prompt Configuration
 
-- **system-prompt**: Appends to Claude's default development prompt (use `--append-system-prompt`)
-- **output-style**: Completely replaces the system prompt (use `--output-style`)
-- These are mutually exclusive in `command-defaults`
+The `command-defaults` section supports system prompt configuration with two modes:
+
+```yaml
+command-defaults:
+  system-prompt: "prompts/my-prompt.md"  # Path to the system prompt file
+  mode: "replace"  # Optional: "append" or "replace" (default: "replace")
+```
+
+**Mode Behavior:**
+- **mode: "replace"** (default): Completely replaces the default system prompt using `--system-prompt` flag (added in Claude Code v2.0.14)
+- **mode: "append"**: Appends to Claude's default development prompt using `--append-system-prompt` flag (added in Claude Code v1.0.55)
+
+**Important:** If `mode` is not specified, it defaults to `"replace"` for a clean slate experience.
 
 ## Testing Workflows
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -125,8 +125,7 @@ Configuration-driven environment setup that installs based on YAML files:
 - **Slash commands** specified in YAML
 - **MCP servers** with support for HTTP, SSE, and stdio transports
 - **Hooks** for automatic actions on events
-- **System prompts** for role-specific behavior
-- **Output styles** for formatted responses
+- **System prompts** with configurable mode (append or replace)
 - **Global commands** (e.g., `claude-python`) that work in all shells
 
 Example Python environment includes:
@@ -264,8 +263,7 @@ Directory structure created:
 ~/.claude/
 ├── agents/          # Subagent configurations
 ├── commands/        # Slash command definitions
-├── prompts/         # System prompts
-├── output-styles/   # Output style configurations
+├── prompts/         # System prompts (with mode: append/replace)
 ├── hooks/           # Event handler scripts
 └── start-<command-name>.{ps1,sh}  # Launcher script
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,6 @@ def sample_environment_config() -> dict[str, Any]:
             },
         ],
         'slash-commands': ['commands/test-command.md'],
-        'output-styles': ['styles/test-style.md'],
         'hooks': {
             'files': ['hooks/test-hook.py'],
             'events': [
@@ -73,7 +72,8 @@ def sample_environment_config() -> dict[str, Any]:
             'allow': ['mcp__test'],
         },
         'command-defaults': {
-            'output-style': 'test-style',
+            'system-prompt': 'prompts/test-prompt.md',
+            'mode': 'replace',  # Optional: 'append' or 'replace' (default: 'replace')
         },
     }
 

--- a/tests/test_setup_environment_validation.py
+++ b/tests/test_setup_environment_validation.py
@@ -313,7 +313,6 @@ class TestValidateAllConfigFiles:
         config = {
             'agents': ['agent.md'],
             'slash-commands': ['cmd1.py', 'cmd2.py'],
-            'output-styles': ['style.md'],
             'command-defaults': {
                 'system-prompt': 'prompt.md',
             },
@@ -328,7 +327,6 @@ class TestValidateAllConfigFiles:
             ('https://example.com/agent.md', True),  # Remote
             ('/local/path/cmd1.py', False),  # Local
             ('https://example.com/cmd2.py', True),  # Remote
-            ('/local/path/style.md', False),  # Local
             ('https://example.com/prompt.md', True),  # Remote
             ('/local/path/hook1.py', False),  # Local
             ('https://example.com/hook2.py', True),  # Remote
@@ -336,7 +334,7 @@ class TestValidateAllConfigFiles:
 
         # Mock local file checks
         mock_path = MagicMock()
-        mock_path.exists.side_effect = [True, True, True]  # All local files exist
+        mock_path.exists.side_effect = [True, True]  # All local files exist
         mock_path.is_file.return_value = True
         mock_path_cls.return_value = mock_path
 
@@ -355,15 +353,14 @@ class TestValidateAllConfigFiles:
         )
 
         assert all_valid is True
-        assert len(results) == 7
+        assert len(results) == 6
         # Check result types and validation methods
         assert results[0] == ('agent', 'agent.md', True, 'HEAD')  # Remote
         assert results[1] == ('slash_command', 'cmd1.py', True, 'Local')  # Local
         assert results[2] == ('slash_command', 'cmd2.py', True, 'Range')  # Remote
-        assert results[3] == ('output_style', 'style.md', True, 'Local')  # Local
-        assert results[4] == ('system_prompt', 'prompt.md', True, 'HEAD')  # Remote
-        assert results[5] == ('hook', 'hook1.py', True, 'Local')  # Local
-        assert results[6] == ('hook', 'hook2.py', True, 'HEAD')  # Remote
+        assert results[3] == ('system_prompt', 'prompt.md', True, 'HEAD')  # Remote
+        assert results[4] == ('hook', 'hook1.py', True, 'Local')  # Local
+        assert results[5] == ('hook', 'hook2.py', True, 'HEAD')  # Remote
 
     @patch('setup_environment.get_auth_headers')
     @patch('setup_environment.resolve_resource_path')
@@ -523,7 +520,6 @@ class TestValidateAllConfigFiles:
         config = {
             'agents': [],
             'slash-commands': None,
-            'output-styles': [],
             'hooks': {
                 'files': None,
             },


### PR DESCRIPTION
BREAKING CHANGE: Output-style configuration is completely removed. Users must migrate to the new system-prompt mode field.

This change removes all output-style support and introduces a new mode field for system-prompt configuration:
- mode: 'append' uses --append-system-prompt flag (appends to default prompt)
- mode: 'replace' uses --system-prompt flag (replaces entire prompt, new default)

The mode field is optional and defaults to 'replace' for a clean slate experience. This provides more explicit control over system prompt behavior while simplifying the configuration model.