### PR TITLE
Add version check for --append-system-prompt-file flag

### DIFF
--- a/tests/test_setup_environment_validation.py
+++ b/tests/test_setup_environment_validation.py
@@ -507,9 +507,9 @@ class TestValidateAllConfigFiles:
         assert all_valid is False
         # Check info messages
         mock_info.assert_any_call('Validating 2 files...')
-        mock_info.assert_any_call('  ✓ agent: good.md (remote, validated via HEAD)')
+        mock_info.assert_any_call('  [OK] agent: good.md (remote, validated via HEAD)')
         # Check error message
-        mock_error.assert_called_once_with('  ✗ agent: bad.md (remote, not accessible)')
+        mock_error.assert_called_once_with('  [FAIL] agent: bad.md (remote, not accessible)')
 
     @patch('setup_environment.get_auth_headers')
     @patch('setup_environment.resolve_resource_path')


### PR DESCRIPTION
The --append-system-prompt-file flag only exists in Claude Code v2.0.34+. When using older versions, users get "unknown option" error. This fix detects Claude Code version at runtime and uses appropriate strategy: file-based flag for v2.0.34+, content-based flag for small prompts on older versions, or skips system prompt for large prompts to prevent command-line length errors.