### PR TITLE
Add --no-project flag to prevent uv version conflicts

### DIFF
--- a/scripts/linux/install-claude-linux.sh
+++ b/scripts/linux/install-claude-linux.sh
@@ -52,7 +52,7 @@ SCRIPT_URL="https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main
 
 # Download and run the Python script with uv
 # uv will handle Python 3.12 installation automatically
-if curl -fsSL "$SCRIPT_URL" | uv run --python 3.12 -; then
+if curl -fsSL "$SCRIPT_URL" | uv run --no-project --python 3.12 -; then
     exit 0
 else
     echo -e "${RED}[FAIL]${NC} Installation failed"

--- a/scripts/linux/setup-environment.sh
+++ b/scripts/linux/setup-environment.sh
@@ -93,9 +93,9 @@ trap 'rm -f "$TEMP_SCRIPT"' EXIT
 
 if curl -fsSL "$SCRIPT_URL" -o "$TEMP_SCRIPT"; then
     if [ -n "$AUTH_ARGS" ]; then
-        uv run --python 3.12 "$TEMP_SCRIPT" "$CONFIG" $AUTH_ARGS
+        uv run --no-project --python 3.12 "$TEMP_SCRIPT" "$CONFIG" $AUTH_ARGS
     else
-        uv run --python 3.12 "$TEMP_SCRIPT" "$CONFIG"
+        uv run --no-project --python 3.12 "$TEMP_SCRIPT" "$CONFIG"
     fi
     EXIT_CODE=$?
 else

--- a/scripts/macos/install-claude-macos.sh
+++ b/scripts/macos/install-claude-macos.sh
@@ -52,7 +52,7 @@ SCRIPT_URL="https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main
 
 # Download and run the Python script with uv
 # uv will handle Python 3.12 installation automatically
-if curl -fsSL "$SCRIPT_URL" | uv run --python 3.12 -; then
+if curl -fsSL "$SCRIPT_URL" | uv run --no-project --python 3.12 -; then
     exit 0
 else
     echo -e "${RED}[FAIL]${NC} Installation failed"

--- a/scripts/macos/setup-environment.sh
+++ b/scripts/macos/setup-environment.sh
@@ -93,9 +93,9 @@ trap 'rm -f "$TEMP_SCRIPT"' EXIT
 
 if curl -fsSL "$SCRIPT_URL" -o "$TEMP_SCRIPT"; then
     if [ -n "$AUTH_ARGS" ]; then
-        uv run --python 3.12 "$TEMP_SCRIPT" "$CONFIG" $AUTH_ARGS
+        uv run --no-project --python 3.12 "$TEMP_SCRIPT" "$CONFIG" $AUTH_ARGS
     else
-        uv run --python 3.12 "$TEMP_SCRIPT" "$CONFIG"
+        uv run --no-project --python 3.12 "$TEMP_SCRIPT" "$CONFIG"
     fi
     EXIT_CODE=$?
 else

--- a/scripts/windows/install-claude-windows.ps1
+++ b/scripts/windows/install-claude-windows.ps1
@@ -60,7 +60,7 @@ try {
 
     # Run with uv (it will handle Python 3.12 installation automatically)
     # Script runs from stable location to prevent PATH pollution
-    & uv run --python 3.12 $stableScript
+    & uv run --no-project --python 3.12 $stableScript
     $exitCode = $LASTEXITCODE
 
     # Keep the script in stable location for future use and debugging

--- a/scripts/windows/setup-environment.ps1
+++ b/scripts/windows/setup-environment.ps1
@@ -100,9 +100,9 @@ try {
     # Run with uv (it will handle Python 3.12 installation automatically)
     # Script runs from stable location to prevent PATH pollution
     if ($authArgs.Count -gt 0) {
-        & uv run --python 3.12 $stableScript $config @authArgs
+        & uv run --no-project --python 3.12 $stableScript $config @authArgs
     } else {
-        & uv run --python 3.12 $stableScript $config
+        & uv run --no-project --python 3.12 $stableScript $config
     }
     $exitCode = $LASTEXITCODE
 


### PR DESCRIPTION
Adds --no-project flag to all uv run --python 3.12 invocations across bootstrap scripts. This prevents version conflicts when scripts are executed from Python project directories with different version requirements in pyproject.toml. The flag ensures the specified Python 3.12 version is used regardless of the current directory's project configuration.