### PR TITLE
Prevent false positive when verifying Claude installation

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -329,6 +329,10 @@ def find_command_robust(cmd: str, fallback_paths: list[str] | None = None) -> st
     if system == 'Windows':
         if cmd == 'claude':
             common_paths = [
+                # Native installer location (checked first)
+                os.path.expandvars(r'%USERPROFILE%\.local\bin\claude.exe'),
+                os.path.expandvars(r'%USERPROFILE%\.local\bin\claude'),
+                # npm global installation paths
                 os.path.expandvars(r'%APPDATA%\npm\claude.cmd'),
                 os.path.expandvars(r'%APPDATA%\npm\claude'),
                 os.path.expandvars(r'%ProgramFiles%\nodejs\claude.cmd'),

--- a/tests/test_install_claude_critical.py
+++ b/tests/test_install_claude_critical.py
@@ -149,7 +149,11 @@ class TestSSLErrorHandling:
 
     @patch('scripts.install_claude.ssl.create_default_context')
     @patch('scripts.install_claude.urlopen')
-    def test_install_claude_native_ssl_error(self, mock_urlopen, mock_ssl_context):
+    @patch('scripts.install_claude.verify_claude_installation')
+    @patch('scripts.install_claude.ensure_local_bin_in_path_windows')
+    def test_install_claude_native_ssl_error(
+        self, mock_ensure_path, mock_verify, mock_urlopen, mock_ssl_context,
+    ):
         """Test Claude native installer with SSL certificate error."""
         with patch('scripts.install_claude.platform.system', return_value='Windows'):
             # First urlopen raises SSL error
@@ -162,6 +166,10 @@ class TestSSLErrorHandling:
             # Mock SSL context
             mock_ctx = MagicMock()
             mock_ssl_context.return_value = mock_ctx
+
+            # Mock the new verification and PATH functions
+            mock_verify.return_value = (True, 'C:\\Users\\Test\\.local\\bin\\claude.exe', 'native')
+            mock_ensure_path.return_value = True
 
             with (
                 patch('scripts.install_claude.run_command') as mock_run,


### PR DESCRIPTION
Add explicit file existence verification with source detection to prevent reporting success when claude.exe doesn't actually exist. The native installer reports installation at ~/.local/bin/claude.exe but may not create the file there, while npm installations exist elsewhere. This fix ensures accurate verification by checking actual file existence and identifying the installation source (native/npm/winget/unknown/none).