### PR TITLE
Add native Claude Code installation support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,12 +16,33 @@ This is the Claude Code Toolbox - a community project providing automated instal
    - These install `uv` (Astral's Python package manager) and run Python scripts
 
 2. **Cross-platform Python scripts** (comprehensive installers)
-   - `scripts/install_claude.py`: Installs Git Bash, Node.js, and Claude Code
+   - `scripts/install_claude.py`: Installs Git Bash (Windows) and Claude Code via native installers with npm fallback
    - `scripts/setup_environment.py`: Configuration-driven environment setup from YAML
    - Support three configuration sources:
      - Repository configs: `python` → downloads from repo
      - Local files: `./my-config.yaml` → loads from disk
      - Remote URLs: `https://example.com/config.yaml` → downloads from web
+
+### Native Claude Code Installation Support
+
+The installer uses a native-first approach with automatic npm fallback:
+
+**Native Installation Functions:**
+- `install_claude_native_windows()` - PowerShell installer for Windows
+- `install_claude_native_macos()` - Shell installer for macOS
+- `install_claude_native_linux()` - Shell installer for Linux
+- `install_claude_native_cross_platform()` - Platform dispatcher
+- `ensure_claude()` - Main orchestrator with native-first logic
+
+**Environment Variables:**
+- `CLAUDE_INSTALL_METHOD` - Controls installation method: `auto` (default), `native`, or `npm`
+- `CLAUDE_VERSION` - Forces specific version via npm (native installers don't support version selection)
+
+**Benefits:**
+- Resolves Node.js v25+ compatibility issues (bug #9628)
+- Eliminates Node.js dependency for most users
+- More reliable auto-updates via official Anthropic installers
+- Maintains full backward compatibility with existing npm installations
 
 ### Environment Configuration System
 

--- a/README.md
+++ b/README.md
@@ -160,19 +160,38 @@ For configurations stored in private repositories, you need to provide authentic
 
 ## ⏬ Only Claude Code Installation
 
+### Installation Methods
+
+The installer supports two installation methods for Claude Code:
+
+#### 🎯 Native Installation (Default)
+
+- Uses official installers from Anthropic
+- No Node.js dependency required
+- More reliable auto-updates
+- Resolves Node.js v25+ compatibility issues
+- Recommended for most users
+
+#### 📦 NPM Installation (Fallback)
+- Installs via npm package manager
+- Requires Node.js 18+
+- Used automatically if native installation fails
+- Can be forced via environment variable
+
 ### Windows (PowerShell)
 
 The Windows installer automatically:
 - ✅ Installs Git for Windows (Git Bash) if not present
-- ✅ Installs Node.js LTS (v18+) if not present or outdated
+- ✅ Installs Node.js LTS (v18+) only if needed for npm method
 - ✅ Handles dependencies (Microsoft.UI.Xaml) for winget if needed
 - ✅ Falls back to direct downloads if winget is unavailable
 - ✅ Configures `CLAUDE_CODE_GIT_BASH_PATH` if bash.exe is not on PATH
-- ✅ Installs Claude Code CLI using the official installer
+- ✅ Installs Claude Code CLI using native installer (with npm fallback)
 
 **Reliability Features:**
+- Native-first installation approach (bypasses Node.js dependency)
 - Smart dependency resolution for winget/App Installer
-- Automatic fallback to direct downloads
+- Automatic fallback to npm if native installation fails
 - Cached availability checks to prevent redundant attempts
 - Comprehensive PATH refresh for immediate command availability
 
@@ -188,11 +207,76 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command "iex (irm 'https://raw.gi
 curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/install-claude-macos.sh | bash
 ```
 
+The installer uses the native shell installer from Anthropic with automatic npm fallback if needed.
+
 ### Linux
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/install-claude-linux.sh | bash
 ```
+
+The installer uses the native shell installer from Anthropic with automatic npm fallback if needed.
+
+### Environment Variables
+
+Control the installation behavior with these environment variables:
+
+#### CLAUDE_INSTALL_METHOD
+
+- `auto` (default) - Try native installation first, fall back to npm if needed
+- `native` - Use only native installation, no npm fallback
+- `npm` - Use only npm installation method
+
+#### CLAUDE_VERSION
+
+- Specify a particular version to install (e.g., `1.0.128`)
+- Forces npm installation method (native installers don't support version selection)
+
+**Examples:**
+
+```powershell
+# Windows - Force npm installation
+$env:CLAUDE_INSTALL_METHOD='npm'
+iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/install-claude-windows.ps1')
+
+# Windows - Install specific version
+$env:CLAUDE_VERSION='1.0.128'
+iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/install-claude-windows.ps1')
+
+# Linux/macOS - Force native installation only
+export CLAUDE_INSTALL_METHOD=native
+curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/install-claude-linux.sh | bash
+
+# Linux/macOS - Install specific version
+export CLAUDE_VERSION=1.0.128
+curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/install-claude-linux.sh | bash
+```
+
+### Troubleshooting
+
+#### Native installation fails on Windows
+
+- The installer will automatically fall back to npm method
+- Check Windows firewall or corporate proxy settings
+- Try manual installation: `irm https://claude.ai/install.ps1 | iex`
+
+#### Native installation fails on macOS/Linux
+
+- The installer will automatically fall back to npm method
+- Ensure you have `curl` and `bash` installed
+- Check sudo permissions if needed
+- Try manual installation: `curl -fsSL https://claude.ai/install.sh | bash`
+
+#### Node.js v25+ compatibility issues
+
+- Native installation bypasses this issue entirely
+- If you must use npm method, downgrade to Node.js v18 or v20 LTS
+
+#### Switching from npm to native installation
+
+- Uninstall npm version: `npm uninstall -g @anthropic-ai/claude-code`
+- Run the installer again (it will use native method by default)
+- Your configurations are preserved (both methods use the same config directory)
 
 ## 🤝 Contributing
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,7 +31,7 @@ The installation system uses a two-tier architecture:
    - Handle platform-specific PATH setup
 
 2. **Cross-platform Python scripts** (comprehensive installers)
-   - `install_claude.py`: Handles Git Bash, Node.js, and Claude Code installation
+   - `install_claude.py`: Handles Git Bash installation (Windows) and Claude Code installation via native installers (with npm fallback)
    - `setup_environment.py`: Sets up complete development environment based on YAML configuration
    - Work identically across Windows, Linux, and macOS
    - Require Python 3.12 (automatically handled by uv)
@@ -42,14 +42,14 @@ The installation system uses a two-tier architecture:
 The scripts automatically install all requirements, including:
 - **uv** - Astral's fast Python package and project manager
 - **Python 3.12** - Managed automatically by uv
-- **Node.js 18+** - For Claude Code CLI
+- **Node.js 18+** - Only installed if npm installation method is needed (optional for native installation)
 - **Git** (Windows only) - For Git Bash
 
 ### Manual Prerequisites
 If you prefer manual installation:
 - **uv**: Install from [docs.astral.sh/uv](https://docs.astral.sh/uv/)
 - **Python**: Version 3.12 or higher
-- **Node.js**: Version 18.0.0 or higher
+- **Node.js**: Version 18.0.0 or higher (only required if using npm installation method)
 - **Git**: Required on Windows for Git Bash
 
 ## 🚀 Quick Start
@@ -110,12 +110,17 @@ bash scripts/macos/install-claude-macos.sh
 
 Comprehensive Claude Code installer that:
 - **Windows**: Installs Git Bash via winget or direct download
-- **All Platforms**: Installs Node.js LTS (>= 18.0.0) if needed
-- Downloads and installs Claude Code CLI via npm
+- **All Platforms**: Installs Claude Code CLI using native installers (default)
+  - Windows: PowerShell installer from `https://claude.ai/install.ps1`
+  - macOS: Shell installer from `https://claude.ai/install.sh`
+  - Linux: Shell installer from `https://claude.ai/install.sh`
+- **Automatic Fallback**: Falls back to npm installation if native method fails
+- **Node.js Management**: Only installs Node.js LTS (>= 18.0.0) if npm method is needed
+- **Environment Variables**: Supports `CLAUDE_INSTALL_METHOD` and `CLAUDE_VERSION` for installation control
 - Configures PowerShell execution policy (Windows)
 - Sets up environment variables (PATH, CLAUDE_CODE_GIT_BASH_PATH)
 - Handles SSL certificate issues in corporate environments
-- Provides fallback installation methods
+- Provides multiple fallback installation methods
 
 ### Environment Setup Scripts (`setup_environment.py`)
 
@@ -241,6 +246,10 @@ Scripts provide detailed output with:
 Scripts respect these environment variables:
 
 ```bash
+# Installation method control
+CLAUDE_INSTALL_METHOD=auto     # auto (default), native, or npm
+CLAUDE_VERSION=1.0.128         # Specific version to install (forces npm method)
+
 # Proxy settings (all platforms)
 HTTP_PROXY=http://proxy:port
 HTTPS_PROXY=http://proxy:port
@@ -251,6 +260,16 @@ CLAUDE_CODE_GIT_BASH_PATH=C:\Program Files\Git\bin\bash.exe
 # Terminal session detection (Windows)
 WT_SESSION=1  # Windows Terminal detection for ANSI colors
 ```
+
+**CLAUDE_INSTALL_METHOD Options:**
+- `auto` (default) - Try native installation first, fall back to npm if needed
+- `native` - Use only native installation, no npm fallback
+- `npm` - Use only npm installation method
+
+**CLAUDE_VERSION:**
+- Specify a particular Claude Code version to install
+- Forces npm installation method (native installers don't support version selection)
+- Example: `CLAUDE_VERSION=1.0.128`
 
 ### Configuration Files
 

--- a/scripts/install_claude.py
+++ b/scripts/install_claude.py
@@ -1497,7 +1497,7 @@ def install_claude_native_linux() -> bool:
 
         except Exception as e:
             error(f'Native installer failed: {e}')
-            return False
+            # Fall through to final return
     return False
 
 

--- a/scripts/install_claude.py
+++ b/scripts/install_claude.py
@@ -1253,8 +1253,22 @@ def install_claude_npm(upgrade: bool = False, version: str | None = None) -> boo
     return False
 
 
-def install_claude_native() -> bool:
-    """Install Claude Code using native installer."""
+def install_claude_native_windows() -> bool:
+    """Install Claude Code using native installer on Windows.
+
+    Downloads and executes the official PowerShell installer script from claude.ai.
+    The native installer places the executable at %USERPROFILE%\\.local\bin\\claude.exe
+    and automatically updates the Windows PATH registry.
+
+    Returns:
+        True if installation succeeded and was verified, False otherwise.
+
+    Raises:
+        urllib.error.URLError: Network errors (caught internally, returns False).
+
+    Note:
+        Windows only. Returns False on other platforms (should not be called).
+    """
     if platform.system() != 'Windows':
         return False
 
@@ -1331,59 +1345,305 @@ def install_claude_native() -> bool:
     return False
 
 
+def install_claude_native_macos() -> bool:
+    """Install Claude Code using native installer on macOS.
+
+    Downloads and executes the official shell installer script from claude.ai.
+    The native installer places the executable at /usr/local/bin/claude
+    and handles PATH configuration automatically.
+
+    Returns:
+        True if installation succeeded and was verified, False otherwise.
+
+    Raises:
+        urllib.error.URLError: Network errors (caught internally, returns False).
+
+    Note:
+        macOS only. Returns False on other platforms (should not be called).
+    """
+    if sys.platform == 'darwin':
+        try:
+            info('Trying official native installer for macOS...')
+
+            # Download installer script (with SSL fallback)
+            installer_url = 'https://claude.ai/install.sh'
+            try:
+                with urlopen(installer_url) as response:
+                    installer_script = response.read().decode('utf-8')
+            except urllib.error.URLError as e:
+                if 'SSL' in str(e) or 'certificate' in str(e).lower():
+                    warning('SSL certificate verification failed, trying with unverified context')
+                    ctx = ssl.create_default_context()
+                    ctx.check_hostname = False
+                    ctx.verify_mode = ssl.CERT_NONE
+                    with urlopen(installer_url, context=ctx) as response:
+                        installer_script = response.read().decode('utf-8')
+                else:
+                    raise
+
+            # Save to temp file and execute
+            with tempfile.NamedTemporaryFile(suffix='.sh', delete=False, mode='w') as tmp:
+                tmp.write(installer_script)
+                temp_path = tmp.name
+
+            # Make executable
+            os.chmod(temp_path, 0o755)
+
+            # Execute installer (may require sudo)
+            info('Running native installer (may require password)...')
+            result = run_command(['bash', temp_path], capture_output=False)
+
+            # Clean up
+            with contextlib.suppress(Exception):
+                os.unlink(temp_path)
+
+            if result.returncode == 0:
+                success('Claude Code installed via native installer')
+
+                # Give system time to complete installation
+                time.sleep(1)
+
+                # Verify installation
+                is_installed, claude_path, source = verify_claude_installation()
+                if is_installed:
+                    success(f'Native installation verified at: {claude_path} (source: {source})')
+                    return True
+                warning('Native installation completed but Claude executable not found')
+                error('Installation verification failed')
+                info('You may need to restart your terminal or run in a new session')
+                return False
+
+            error(f'Native installer exited with code {result.returncode}')
+            return False
+
+        except Exception as e:
+            error(f'Native installer failed: {e}')
+            return False
+    return False
+
+
+def install_claude_native_linux() -> bool:
+    """Install Claude Code using native installer on Linux.
+
+    Downloads and executes the official shell installer script from claude.ai.
+    The native installer places the executable at /usr/local/bin/claude
+    or ~/.local/bin/claude depending on permissions.
+
+    Supports: Ubuntu 20.04+, Debian 10+, and other modern Linux distributions.
+
+    Returns:
+        True if installation succeeded and was verified, False otherwise.
+
+    Raises:
+        urllib.error.URLError: Network errors (caught internally, returns False).
+
+    Note:
+        Linux only. Returns False on other platforms (should not be called).
+    """
+    if sys.platform == 'linux':
+        try:
+            info('Trying official native installer for Linux...')
+
+            # Download installer script (with SSL fallback)
+            installer_url = 'https://claude.ai/install.sh'
+            try:
+                with urlopen(installer_url) as response:
+                    installer_script = response.read().decode('utf-8')
+            except urllib.error.URLError as e:
+                if 'SSL' in str(e) or 'certificate' in str(e).lower():
+                    warning('SSL certificate verification failed, trying with unverified context')
+                    ctx = ssl.create_default_context()
+                    ctx.check_hostname = False
+                    ctx.verify_mode = ssl.CERT_NONE
+                    with urlopen(installer_url, context=ctx) as response:
+                        installer_script = response.read().decode('utf-8')
+                else:
+                    raise
+
+            # Save to temp file and execute
+            with tempfile.NamedTemporaryFile(suffix='.sh', delete=False, mode='w') as tmp:
+                tmp.write(installer_script)
+                temp_path = tmp.name
+
+            # Make executable
+            os.chmod(temp_path, 0o755)
+
+            # Execute installer (may require sudo)
+            info('Running native installer (may require password for system-wide installation)...')
+            result = run_command(['bash', temp_path], capture_output=False)
+
+            # Clean up
+            with contextlib.suppress(Exception):
+                os.unlink(temp_path)
+
+            if result.returncode == 0:
+                success('Claude Code installed via native installer')
+
+                # Give system time to complete installation
+                time.sleep(1)
+
+                # Verify installation
+                is_installed, claude_path, source = verify_claude_installation()
+                if is_installed:
+                    success(f'Native installation verified at: {claude_path} (source: {source})')
+                    return True
+                warning('Native installation completed but Claude executable not found')
+                error('Installation verification failed')
+                info('You may need to restart your terminal or run in a new session')
+                return False
+
+            error(f'Native installer exited with code {result.returncode}')
+            return False
+
+        except Exception as e:
+            error(f'Native installer failed: {e}')
+            return False
+    return False
+
+
+def install_claude_native_cross_platform() -> bool:
+    """Install Claude Code using native installer (cross-platform dispatcher).
+
+    Dispatches to platform-specific native installation functions based on
+    the current operating system. This is the unified entry point for native
+    installation across all supported platforms.
+
+    Supported platforms:
+        - Windows: Uses PowerShell installer script
+        - macOS: Uses shell installer script
+        - Linux: Uses shell installer script
+
+    Returns:
+        True if installation succeeded, False otherwise.
+
+    Note:
+        This function automatically detects the platform and calls the
+        appropriate platform-specific installer.
+    """
+    system = platform.system()
+
+    if system == 'Windows':
+        return install_claude_native_windows()
+    if system == 'Darwin':
+        return install_claude_native_macos()
+    # Linux and other Unix-like systems
+    return install_claude_native_linux()
+
+
 def ensure_claude() -> bool:
-    """Ensure Claude Code is installed."""
+    """Ensure Claude Code is installed (native-first, npm fallback).
+
+    Installation method can be controlled via CLAUDE_INSTALL_METHOD environment variable:
+    - 'auto' (default): Try native first, fall back to npm if needed
+    - 'native': Only use native installer, no npm fallback
+    - 'npm': Only use npm installer
+
+    Specific versions can only be installed via npm (set CLAUDE_VERSION environment variable).
+
+    Returns:
+        True if Claude Code is installed successfully, False otherwise.
+    """
     info('Checking Claude Code CLI...')
 
-    # Check if a specific version is requested via environment variable
+    # Check installation method preference
+    install_method = os.environ.get('CLAUDE_INSTALL_METHOD', 'auto').lower()
+    if install_method not in ['auto', 'native', 'npm']:
+        warning(f'Invalid CLAUDE_INSTALL_METHOD "{install_method}", using "auto"')
+        install_method = 'auto'
+
+    # Check if a specific version is requested
     requested_version = os.environ.get('CLAUDE_VERSION')
+
+    # Specific version requires npm (native installer doesn't support version selection)
+    if requested_version and install_method == 'native':
+        warning('Specific version requested, but install method is "native"')
+        warning('Native installer does not support version selection')
+        info('Switching to npm installation for version control')
+        install_method = 'npm'
 
     # Check if already installed
     current_version = get_claude_version()
 
     if current_version:
         if requested_version:
-            # Check if the installed version matches the requested one
+            # Specific version requested - check if it matches
             if current_version != requested_version:
                 info(f'Claude Code version {current_version} is installed, but version {requested_version} is requested')
-                info(f'Installing Claude Code version {requested_version}...')
+                info(f'Installing Claude Code version {requested_version} via npm...')
                 if install_claude_npm(upgrade=False, version=requested_version):
                     new_version = get_claude_version()
                     if new_version:
                         success(f'Claude Code version {new_version} installed successfully')
                     return True
-            else:
-                success(f'Claude Code version {current_version} is already installed (matches requested version)')
-                # Still set DISABLE_AUTOUPDATER since a specific version was requested
-                set_disable_autoupdater()
-                return True
-        else:
-            # No specific version requested (None) - interpret as "install latest if needed"
-            latest_version = get_latest_claude_version()
-
-            if latest_version:
-                # We know the latest version, compare with installed
-                if compare_versions(current_version, latest_version):
-                    # Current version is >= latest
-                    success(f'Claude Code version {current_version} is already up-to-date (latest: {latest_version})')
-                    return True
-                # Current version is older than latest - upgrade
-                info(f'Claude Code version {current_version} is installed, but {latest_version} is available')
-                info(f'Upgrading to latest version {latest_version}...')
-                if install_claude_npm(upgrade=True, version=latest_version):
-                    new_version = get_claude_version()
-                    if new_version:
-                        success(f'Claude Code upgraded to version {new_version}')
-                    return True
-                warning('Upgrade failed, continuing with current version')
-                return True  # Don't fail the entire installation
-            # Cannot determine latest version - keep current
-            warning('Cannot determine latest version from npm')
-            success(f'Claude Code version {current_version} is already installed')
+                error(f'Failed to install specific version {requested_version}')
+                return False
+            success(f'Claude Code version {current_version} is already installed (matches requested version)')
+            # Set DISABLE_AUTOUPDATER since a specific version was requested
+            set_disable_autoupdater()
             return True
 
+        # No specific version requested - check if update needed
+        latest_version = get_latest_claude_version()
+        if latest_version:
+            if compare_versions(current_version, latest_version):
+                # Current version is >= latest
+                success(f'Claude Code version {current_version} is already up-to-date (latest: {latest_version})')
+                return True
+            # Current version is older - upgrade via npm
+            info(f'Claude Code version {current_version} is installed, but {latest_version} is available')
+            info(f'Upgrading to latest version {latest_version} via npm...')
+            if install_claude_npm(upgrade=True, version=latest_version):
+                new_version = get_claude_version()
+                if new_version:
+                    success(f'Claude Code upgraded to version {new_version}')
+                return True
+            warning('Upgrade failed, continuing with current version')
+            return True  # Don't fail the entire installation
+
+        # Cannot determine latest version - keep current
+        warning('Cannot determine latest version from npm')
+        success(f'Claude Code version {current_version} is already installed')
+        return True
+
+    # Fresh installation - Claude not found
     info('Claude Code not found, installing...')
-    # Fresh installation
+
+    # Installation logic based on method
+    if install_method == 'npm':
+        # npm-only mode
+        info('Using npm installation (method: npm)...')
+        if install_claude_npm(upgrade=False, version=requested_version):
+            # Verify with retries to handle PATH synchronization delays
+            for attempt in range(3):
+                claude_path = find_command_robust('claude')
+                if claude_path:
+                    new_version = get_claude_version()
+                    if new_version:
+                        success(f'Claude Code version {new_version} installed successfully')
+                    return True
+                if attempt < 2:
+                    info(f'Waiting for PATH synchronization... (attempt {attempt + 1}/3)')
+                    time.sleep(2)
+
+        error('npm installation failed')
+        return False
+
+    if install_method == 'native':
+        # native-only mode
+        info('Using native installation (method: native)...')
+        if install_claude_native_cross_platform():
+            return True
+
+        error('Native installation failed and npm fallback is disabled (method: native)')
+        info('To enable npm fallback, use: export CLAUDE_INSTALL_METHOD=auto')
+        return False
+
+    # auto mode (default) - try native first, npm fallback
+    info('Trying native installation first (method: auto)...')
+    if install_claude_native_cross_platform():
+        return True
+
+    warning('Native installation failed, falling back to npm...')
     if install_claude_npm(upgrade=False, version=requested_version):
         # Verify with retries to handle PATH synchronization delays
         for attempt in range(3):
@@ -1391,22 +1651,21 @@ def ensure_claude() -> bool:
             if claude_path:
                 new_version = get_claude_version()
                 if new_version:
-                    success(f'Claude Code version {new_version} installed successfully')
+                    success(f'Claude Code version {new_version} installed successfully via npm fallback')
                 return True
             if attempt < 2:
                 info(f'Waiting for PATH synchronization... (attempt {attempt + 1}/3)')
                 time.sleep(2)
 
-    # Try native installer on Windows
-    if platform.system() == 'Windows' and install_claude_native():
-        return True
-
+    # All methods failed
     error('Claude Code installation failed with all methods')
     info('Please try manual installation:')
-    info(f'  npm install -g {CLAUDE_NPM_PACKAGE}')
     if platform.system() == 'Windows':
-        info('  or')
-        info(f'  irm {CLAUDE_INSTALLER_URL} | iex')
+        info(f'  Native: irm {CLAUDE_INSTALLER_URL} | iex')
+        info(f'  NPM: npm install -g {CLAUDE_NPM_PACKAGE}')
+    else:
+        info('  Native: curl -fsSL https://claude.ai/install.sh | bash')
+        info(f'  NPM: npm install -g {CLAUDE_NPM_PACKAGE}')
 
     return False
 

--- a/tests/test_install_claude.py
+++ b/tests/test_install_claude.py
@@ -734,7 +734,7 @@ class TestClaudeInstallation:
         mock_verify.return_value = (True, 'C:\\Users\\Test\\.local\\bin\\claude.exe', 'native')
         mock_ensure_path.return_value = True
 
-        result = install_claude.install_claude_native()
+        result = install_claude.install_claude_native_windows()
         assert result is True
 
 
@@ -810,7 +810,7 @@ class TestEnsureFunctions:
     @patch('install_claude.get_claude_version', return_value=None)
     @patch('install_claude.install_claude_npm', return_value=False)
     @patch('platform.system', return_value='Windows')
-    @patch('install_claude.install_claude_native', return_value=True)
+    @patch('install_claude.install_claude_native_cross_platform', return_value=True)
     def test_ensure_claude_native_fallback(self, mock_native, mock_system, mock_npm, mock_get_version):
         """Test Claude installation fallback to native installer."""
         # Verify mock configurations

--- a/tests/test_install_claude_additional.py
+++ b/tests/test_install_claude_additional.py
@@ -194,25 +194,59 @@ class TestNodeJsInstallationAdditional:
 class TestClaudeInstallationAdditional:
     """Additional tests for Claude installation."""
 
-    @patch('platform.system', return_value='Linux')
-    def test_install_claude_native_linux(self, mock_system):
-        """Test native Claude installation on Linux."""
-        # Verify platform mock
-        assert mock_system.return_value == 'Linux'
+    @patch('sys.platform', 'linux')
+    @patch('install_claude.urlopen')
+    @patch('install_claude.run_command')
+    @patch('install_claude.verify_claude_installation')
+    def test_install_claude_native_linux(self, mock_verify, mock_run, mock_urlopen):
+        """Test native Claude installation on Linux with mocked dependencies."""
+        # Mock urlopen to return installer script
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'#!/bin/bash\necho "Installing Claude"'
+        mock_response.__enter__ = lambda _: mock_response
+        mock_response.__exit__ = lambda *_: None
+        mock_urlopen.return_value = mock_response
 
-        # install_claude_native returns False for non-Windows platforms
+        # Mock run_command to succeed
+        mock_run.return_value = subprocess.CompletedProcess([], 0, '', '')
+
+        # Mock verification to succeed
+        mock_verify.return_value = (True, '/usr/local/bin/claude', 'native')
+
         result = install_claude.install_claude_native_linux()
-        assert result is False
+        assert result is True
 
-    @patch('platform.system', return_value='Darwin')
-    def test_install_claude_native_macos(self, mock_system):
-        """Test native Claude installation on macOS."""
-        # Verify platform mock
-        assert mock_system.return_value == 'Darwin'
+        # Verify external calls were made
+        mock_urlopen.assert_called()
+        mock_run.assert_called()
+        mock_verify.assert_called()
 
-        # install_claude_native returns False for non-Windows platforms
+    @patch('sys.platform', 'darwin')
+    @patch('install_claude.urlopen')
+    @patch('install_claude.run_command')
+    @patch('install_claude.verify_claude_installation')
+    def test_install_claude_native_macos(self, mock_verify, mock_run, mock_urlopen):
+        """Test native Claude installation on macOS with mocked dependencies."""
+        # Mock urlopen to return installer script
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'#!/bin/bash\necho "Installing Claude"'
+        mock_response.__enter__ = lambda _: mock_response
+        mock_response.__exit__ = lambda *_: None
+        mock_urlopen.return_value = mock_response
+
+        # Mock run_command to succeed
+        mock_run.return_value = subprocess.CompletedProcess([], 0, '', '')
+
+        # Mock verification to succeed
+        mock_verify.return_value = (True, '/usr/local/bin/claude', 'native')
+
         result = install_claude.install_claude_native_macos()
-        assert result is False
+        assert result is True
+
+        # Verify external calls were made
+        mock_urlopen.assert_called()
+        mock_run.assert_called()
+        mock_verify.assert_called()
 
     @patch('install_claude.urlopen')
     def test_install_claude_native_download_error(self, mock_urlopen):

--- a/tests/test_install_claude_additional.py
+++ b/tests/test_install_claude_additional.py
@@ -201,7 +201,7 @@ class TestClaudeInstallationAdditional:
         assert mock_system.return_value == 'Linux'
 
         # install_claude_native returns False for non-Windows platforms
-        result = install_claude.install_claude_native()
+        result = install_claude.install_claude_native_linux()
         assert result is False
 
     @patch('platform.system', return_value='Darwin')
@@ -211,14 +211,14 @@ class TestClaudeInstallationAdditional:
         assert mock_system.return_value == 'Darwin'
 
         # install_claude_native returns False for non-Windows platforms
-        result = install_claude.install_claude_native()
+        result = install_claude.install_claude_native_macos()
         assert result is False
 
     @patch('install_claude.urlopen')
     def test_install_claude_native_download_error(self, mock_urlopen):
         """Test native Claude installation with download error."""
         mock_urlopen.side_effect = urllib.error.URLError('Connection error')
-        result = install_claude.install_claude_native()
+        result = install_claude.install_claude_native_windows()
         assert result is False
 
 

--- a/tests/test_install_claude_critical.py
+++ b/tests/test_install_claude_critical.py
@@ -180,7 +180,7 @@ class TestSSLErrorHandling:
                 mock_temp.return_value.__enter__.return_value.write = MagicMock()
                 mock_run.return_value = subprocess.CompletedProcess([], 0)
 
-                result = install_claude.install_claude_native()
+                result = install_claude.install_claude_native_windows()
 
                 assert result is True
                 assert mock_ssl_context.called
@@ -346,7 +346,7 @@ class TestClaudeInstallationEdgeCases:
     @patch('scripts.install_claude.platform.system', return_value='Darwin')
     @patch('scripts.install_claude.get_claude_version', return_value=None)
     @patch('scripts.install_claude.install_claude_npm', return_value=False)
-    @patch('scripts.install_claude.install_claude_native', return_value=False)
+    @patch('scripts.install_claude.install_claude_native_cross_platform', return_value=False)
     def test_ensure_claude_all_methods_fail(self, mock_native, mock_npm, mock_get_version, mock_system):
         """Test Claude installation when all methods fail."""
         del mock_native, mock_npm, mock_get_version, mock_system  # Mark as intentionally unused


### PR DESCRIPTION
Implement native installers for Windows, macOS, and Linux with automatic fallback to npm method. This resolves Node.js v25+ compatibility issues by eliminating the Node.js dependency for most users.

Key changes:
- Add install_claude_native_windows() for Windows PowerShell installer
- Add install_claude_native_macos() for macOS shell installer
- Add install_claude_native_linux() for Linux shell installer
- Add install_claude_native_cross_platform() dispatcher
- Rewrite ensure_claude() for native-first approach with npm fallback
- Add CLAUDE_INSTALL_METHOD environment variable (auto/native/npm)
- Add CLAUDE_VERSION environment variable for specific version installation
- Update test files to reference refactored function names
- Maintain full backward compatibility with existing npm installations