### PR TITLE
Add version parameter support and migration for native installers

### DIFF
--- a/tests/test_install_claude_additional.py
+++ b/tests/test_install_claude_additional.py
@@ -405,7 +405,8 @@ class TestMainFlowAdditional:
         assert mock_git.return_value == 'C:\\Git\\bash.exe'
         assert mock_node.return_value is False
 
-        with patch('sys.exit') as mock_exit:
+        # Force npm installation method to ensure Node.js is required
+        with patch.dict('os.environ', {'CLAUDE_INSTALL_METHOD': 'npm'}), patch('sys.exit') as mock_exit:
             install_claude.main()
             mock_exit.assert_called_with(1)
 


### PR DESCRIPTION
Add comprehensive version parameter support to all native installer functions and implement automatic npm-to-native migration. This completes the native installation feature with proper version control.

Key changes:
- Add version parameter to install_claude_native_windows/macos/linux/cross_platform
- Pass version to native installer scripts (-Target for PS, argument for bash)
- Implement npm→native migration in auto mode when no specific version requested
- Fix conditional Node.js installation logic (only install when method=npm)
- Update ensure_claude() to try native with version first, npm as fallback
- Update tests to verify version parameter handling and migration logic

Benefits:
- Native installers now support specific version installation
- Users with npm installations auto-migrate to native for better stability
- Node.js only installed when actually needed (npm method)
- Version changes use native installer when possible
- Maintains backward compatibility with npm method