### PR TITLE
Improve console output formatting and separate hooks from settings

### DIFF
--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -864,11 +864,18 @@ class TestCreateAdditionalSettings:
                 ],
             }
 
+            # First download hook files
+            setup_environment.download_hook_files(
+                hooks,
+                claude_dir,
+                config_source='https://example.com/config.yaml',
+            )
+
+            # Then create additional settings
             result = setup_environment.create_additional_settings(
                 hooks,
                 claude_dir,
                 'test-env',
-                config_source='https://example.com/config.yaml',
             )
 
             assert result is True

--- a/tests/test_setup_environment_additional.py
+++ b/tests/test_setup_environment_additional.py
@@ -1033,11 +1033,18 @@ class TestCreateAdditionalSettingsComplex:
                 ],
             }
 
+            # First download hook files
+            setup_environment.download_hook_files(
+                hooks,
+                claude_dir,
+                config_source='https://example.com/config.yaml',
+            )
+
+            # Then create additional settings
             result = setup_environment.create_additional_settings(
                 hooks,
                 claude_dir,
                 'test',
-                config_source='https://example.com/config.yaml',
             )
 
             assert result is True


### PR DESCRIPTION
- Remove URL from system prompt summary, show only mode (replacing/appending)
- Change "OS env variables set" to "OS environment variables: N configured"
- Separate hooks downloading (Step 11) from settings creation (Step 12)
- Update step numbering to 14 total steps
- Add download_hook_files() function for cleaner separation