### PR TITLE
Pass version arg to bypass installer fresh install bug

### DIFF
--- a/scripts/install_claude.py
+++ b/scripts/install_claude.py
@@ -1311,9 +1311,13 @@ def install_claude_native_windows(version: str | None = None) -> bool:
             temp_path,
         ]
 
-        # Add version parameter if specified
-        if version:
-            cmd.append(version)  # PowerShell uses positional parameter
+        # CRITICAL: Always pass version argument to bypass Anthropic installer bug
+        # See: https://github.com/anthropics/claude-code/issues/14942
+        # Bug: installer skips copying when running version == target version,
+        # even if target file doesn't exist (fresh installations)
+        # Fix: pass "latest" when no specific version requested
+        version_arg = version or 'latest'
+        cmd.append(version_arg)
 
         version_msg = f' version {version}' if version else ''
         info(f'Installing Claude Code{version_msg} via native installer...')


### PR DESCRIPTION
The Anthropic Windows installer skips copying the binary when the running version matches the target version, even on fresh installations where the target file doesn't exist. Pass "latest" as version argument when no specific version is requested to work around this issue.

See: https://github.com/anthropics/claude-code/issues/14942