### PR TITLE
Escape HTTP MCP server URLs in Windows CMD execution

### DIFF
--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -164,6 +164,52 @@ class TestUtilityFunctions:
         assert setup_environment.find_command('git') == '/usr/bin/git'
 
 
+class TestEscapeForCmd:
+    """Test CMD special character escaping function."""
+
+    def test_escape_ampersand(self):
+        """Test escaping ampersand character."""
+        url = 'https://example.com?param1=value1&param2=value2'
+        escaped = setup_environment.escape_for_cmd(url)
+        assert escaped == 'https://example.com?param1=value1^&param2=value2'
+
+    def test_escape_multiple_special_chars(self):
+        """Test escaping multiple special characters."""
+        arg = 'test&value|with<special>chars^and%percent'
+        escaped = setup_environment.escape_for_cmd(arg)
+        assert escaped == 'test^&value^|with^<special^>chars^^and^%percent'
+
+    def test_escape_empty_string(self):
+        """Test escaping empty string returns empty string."""
+        assert setup_environment.escape_for_cmd('') == ''
+
+    def test_escape_no_special_chars(self):
+        """Test escaping string without special chars returns unchanged."""
+        url = 'https://example.com/path/to/resource'
+        assert setup_environment.escape_for_cmd(url) == url
+
+    def test_escape_supabase_url(self):
+        """Test escaping real-world Supabase MCP URL with & query parameter."""
+        url = 'https://mcp.supabase.com/mcp?project_ref=xkeujjyicwuxwxelliae&read_only=true'
+        escaped = setup_environment.escape_for_cmd(url)
+        assert escaped == 'https://mcp.supabase.com/mcp?project_ref=xkeujjyicwuxwxelliae^&read_only=true'
+
+    def test_escape_url_with_multiple_query_params(self):
+        """Test escaping URL with multiple ampersands in query string."""
+        url = 'https://api.example.com?key=abc&token=xyz&mode=read&format=json'
+        escaped = setup_environment.escape_for_cmd(url)
+        expected = 'https://api.example.com?key=abc^&token=xyz^&mode=read^&format=json'
+        assert escaped == expected
+
+    def test_escape_already_escaped(self):
+        """Test that already escaped characters get double-escaped."""
+        # This is correct behavior - if someone passes already escaped string,
+        # we escape the caret too
+        arg = 'test^&value'
+        escaped = setup_environment.escape_for_cmd(arg)
+        assert escaped == 'test^^^&value'
+
+
 class TestTildeExpansion:
     """Test tilde expansion in commands."""
 


### PR DESCRIPTION
Completes the URL escaping fix for Windows by handling the remaining direct execution paths that were missed in commit 4f475ca. Previous fix addressed PowerShell scripts and Unix bash commands but missed two critical Windows CMD execution paths.

Changes:
- Add escape_for_cmd() function to escape CMD special characters (^, &, |, <, >, %)
- Fix direct execution fallback path to use escaped URLs on Windows
- Fix retry path to use escaped URLs on Windows
- Add 7 comprehensive tests for URL escaping functionality

The ^ character is escaped first to prevent double-escaping of subsequently escaped characters.

Resolves Windows CMD interpretation of & as command separator in HTTP MCP URLs.