### PR TITLE
Unify MCP server STDIO execution to use bash and remove retry logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,13 @@ When configuring MCP servers, permissions are automatically added to `additional
 }
 ```
 
+### Environment Variables for Debugging
+
+The setup scripts support these environment variables for debugging and customization:
+
+- `CLAUDE_CODE_TOOLBOX_DEBUG`: Set to `1`, `true`, or `yes` to enable verbose debug logging during MCP server configuration and other operations
+- `CLAUDE_CODE_GIT_BASH_PATH`: Override the Git Bash executable path (useful for non-standard installations where Git Bash is not in the default location)
+
 ### Hooks Configuration Structure
 
 Hooks use this structure in environment YAML:


### PR DESCRIPTION
This change addresses two critical issues in MCP server configuration:

1. Unifies STDIO Windows execution to use run_bash_command() like HTTP transport, ensuring consistent cross-platform behavior and eliminating execution method divergence.

2. Removes problematic retry logic that was missing PATH export and could cause configuration failures.

3. Improves error handling by always logging stderr on first failure instead of only in debug mode.

4. Documents CLAUDE_CODE_TOOLBOX_DEBUG and CLAUDE_CODE_GIT_BASH_PATH environment variables for troubleshooting.

The STDIO transport previously used run_command() with env dict while HTTP used run_bash_command() with Unix-style paths. This inconsistency was an incomplete migration artifact, not an intentional design. Both transports now use the same bash-based execution method with proper path conversion.