### PR TITLE
Enable multi-token authentication in bootstrap scripts

### DIFF
--- a/scripts/linux/setup-environment.sh
+++ b/scripts/linux/setup-environment.sh
@@ -70,20 +70,16 @@ if [ -z "$CONFIG" ]; then
     exit 1
 fi
 
-# Build auth arguments if tokens are present
+# Build auth arguments
+# GITHUB_TOKEN and GITLAB_TOKEN are read directly by Python for per-URL authentication
+# Only pass --auth for explicit override (CLAUDE_ENV_AUTH) or generic token (REPO_TOKEN)
 AUTH_ARGS=""
-if [ -n "${GITLAB_TOKEN:-}" ]; then
-    echo -e "${CYAN}[INFO]${NC} GitLab token found, will use for authentication"
-    AUTH_ARGS="--auth PRIVATE-TOKEN:$GITLAB_TOKEN"
-elif [ -n "${GITHUB_TOKEN:-}" ]; then
-    echo -e "${CYAN}[INFO]${NC} GitHub token found, will use for authentication"
-    AUTH_ARGS="--auth Authorization:Bearer\ $GITHUB_TOKEN"
+if [ -n "${CLAUDE_ENV_AUTH:-}" ]; then
+    echo -e "${CYAN}[INFO]${NC} Using provided authentication"
+    AUTH_ARGS="--auth $CLAUDE_ENV_AUTH"
 elif [ -n "${REPO_TOKEN:-}" ]; then
     echo -e "${CYAN}[INFO]${NC} Generic repo token found, will use for authentication"
     AUTH_ARGS="--auth $REPO_TOKEN"
-elif [ -n "${CLAUDE_ENV_AUTH:-}" ]; then
-    echo -e "${CYAN}[INFO]${NC} Using provided authentication"
-    AUTH_ARGS="--auth $CLAUDE_ENV_AUTH"
 fi
 
 # Download and run the Python script with uv

--- a/scripts/macos/setup-environment.sh
+++ b/scripts/macos/setup-environment.sh
@@ -70,20 +70,16 @@ if [ -z "$CONFIG" ]; then
     exit 1
 fi
 
-# Build auth arguments if tokens are present
+# Build auth arguments
+# GITHUB_TOKEN and GITLAB_TOKEN are read directly by Python for per-URL authentication
+# Only pass --auth for explicit override (CLAUDE_ENV_AUTH) or generic token (REPO_TOKEN)
 AUTH_ARGS=""
-if [ -n "${GITLAB_TOKEN:-}" ]; then
-    echo -e "${CYAN}[INFO]${NC} GitLab token found, will use for authentication"
-    AUTH_ARGS="--auth PRIVATE-TOKEN:$GITLAB_TOKEN"
-elif [ -n "${GITHUB_TOKEN:-}" ]; then
-    echo -e "${CYAN}[INFO]${NC} GitHub token found, will use for authentication"
-    AUTH_ARGS="--auth Authorization:Bearer\ $GITHUB_TOKEN"
+if [ -n "${CLAUDE_ENV_AUTH:-}" ]; then
+    echo -e "${CYAN}[INFO]${NC} Using provided authentication"
+    AUTH_ARGS="--auth $CLAUDE_ENV_AUTH"
 elif [ -n "${REPO_TOKEN:-}" ]; then
     echo -e "${CYAN}[INFO]${NC} Generic repo token found, will use for authentication"
     AUTH_ARGS="--auth $REPO_TOKEN"
-elif [ -n "${CLAUDE_ENV_AUTH:-}" ]; then
-    echo -e "${CYAN}[INFO]${NC} Using provided authentication"
-    AUTH_ARGS="--auth $CLAUDE_ENV_AUTH"
 fi
 
 # Download and run the Python script with uv

--- a/scripts/windows/setup-environment.ps1
+++ b/scripts/windows/setup-environment.ps1
@@ -81,20 +81,16 @@ try {
 
     Write-Host "[INFO] Using configuration: $config" -ForegroundColor Yellow
 
-    # Check for authentication token
+    # Build auth arguments
+    # GITHUB_TOKEN and GITLAB_TOKEN are read directly by Python for per-URL authentication
+    # Only pass --auth for explicit override (CLAUDE_ENV_AUTH) or generic token (REPO_TOKEN)
     $authArgs = @()
-    if ($env:GITLAB_TOKEN) {
-        Write-Host "[INFO] GitLab token found, will use for authentication" -ForegroundColor Cyan
-        $authArgs = @('--auth', "PRIVATE-TOKEN:$($env:GITLAB_TOKEN)")
-    } elseif ($env:GITHUB_TOKEN) {
-        Write-Host "[INFO] GitHub token found, will use for authentication" -ForegroundColor Cyan
-        $authArgs = @('--auth', "Authorization:Bearer $($env:GITHUB_TOKEN)")
+    if ($env:CLAUDE_ENV_AUTH) {
+        Write-Host "[INFO] Using provided authentication" -ForegroundColor Cyan
+        $authArgs = @('--auth', $env:CLAUDE_ENV_AUTH)
     } elseif ($env:REPO_TOKEN) {
         Write-Host "[INFO] Generic repo token found, will use for authentication" -ForegroundColor Cyan
         $authArgs = @('--auth', $env:REPO_TOKEN)
-    } elseif ($env:CLAUDE_ENV_AUTH) {
-        Write-Host "[INFO] Using provided authentication" -ForegroundColor Cyan
-        $authArgs = @('--auth', $env:CLAUDE_ENV_AUTH)
     }
 
     # Run with uv (it will handle Python 3.12 installation automatically)


### PR DESCRIPTION
Remove GITHUB_TOKEN and GITLAB_TOKEN from --auth parameter passing to allow Python's per-URL authentication logic to work correctly. This enables simultaneous use of multiple tokens for different providers while preserving backward compatibility with CLAUDE_ENV_AUTH and REPO_TOKEN.