### PR TITLE
Add HTTP 429 rate limiting with exponential backoff for parallel downloads

### DIFF
--- a/tests/test_setup_environment_parallel.py
+++ b/tests/test_setup_environment_parallel.py
@@ -116,8 +116,8 @@ class TestExecuteParallel:
         assert call_order == [1, 2, 3, 4, 5]  # Sequential order preserved
 
     def test_default_max_workers(self) -> None:
-        """Test that default max_workers is 5."""
-        assert DEFAULT_PARALLEL_WORKERS == 5
+        """Test that default max_workers is 3 (reduced from 5 to minimize rate limiting)."""
+        assert DEFAULT_PARALLEL_WORKERS == 3
 
     def test_custom_max_workers(self) -> None:
         """Test that custom max_workers is respected."""


### PR DESCRIPTION
- Implement fetch_with_retry() with exponential backoff and jitter
- Respect Retry-After and x-ratelimit-reset headers
- Handle HTTP 429 and 403 rate limit errors
- Make parallel workers configurable via CLAUDE_PARALLEL_WORKERS env var
- Reduce default parallel workers from 5 to 3 to minimize rate limiting
- Add comprehensive test coverage (10 new tests)