### PR TITLE
Update installMethod config after native Claude installation

### DIFF
--- a/tests/test_install_claude_additional.py
+++ b/tests/test_install_claude_additional.py
@@ -797,6 +797,7 @@ class TestNativeWindowsInstallerFunction:
     @patch('install_claude.verify_claude_installation')
     @patch('install_claude.ensure_local_bin_in_path_windows')
     @patch('install_claude.remove_npm_claude')
+    @patch('install_claude.update_install_method_config')
     @patch('tempfile.NamedTemporaryFile')
     @patch('os.unlink')
     @patch('time.sleep')
@@ -805,6 +806,7 @@ class TestNativeWindowsInstallerFunction:
         mock_sleep,
         mock_unlink,
         mock_temp,
+        mock_update_config,
         mock_remove_npm,
         mock_ensure_path,
         mock_verify,
@@ -829,6 +831,7 @@ class TestNativeWindowsInstallerFunction:
         mock_run.return_value = subprocess.CompletedProcess([], 0, '', '')
         mock_verify.return_value = (True, 'C:\\Users\\Test\\.local\\bin\\claude.exe', 'native')
         mock_remove_npm.return_value = True
+        mock_update_config.return_value = True
 
         result = install_claude._install_claude_native_windows_installer(version='latest')
 
@@ -838,6 +841,7 @@ class TestNativeWindowsInstallerFunction:
         mock_unlink.assert_called()
         mock_ensure_path.assert_called()
         mock_remove_npm.assert_called_once()
+        mock_update_config.assert_called_once_with('native')
         # Verify 'latest' was passed to the installer
         call_args = mock_run.call_args[0][0]
         assert 'latest' in call_args
@@ -1163,6 +1167,7 @@ class TestNativeMacOSInstallerFunction:
     @patch('install_claude.run_command')
     @patch('install_claude.verify_claude_installation')
     @patch('install_claude.remove_npm_claude')
+    @patch('install_claude.update_install_method_config')
     @patch('tempfile.NamedTemporaryFile')
     @patch('os.chmod')
     @patch('os.unlink')
@@ -1173,6 +1178,7 @@ class TestNativeMacOSInstallerFunction:
         mock_unlink,
         mock_chmod,
         mock_temp,
+        mock_update_config,
         mock_remove_npm,
         mock_verify,
         mock_run,
@@ -1192,6 +1198,7 @@ class TestNativeMacOSInstallerFunction:
         mock_run.return_value = subprocess.CompletedProcess([], 0, '', '')
         mock_verify.return_value = (True, '/Users/Test/.local/bin/claude', 'native')
         mock_remove_npm.return_value = True
+        mock_update_config.return_value = True
 
         result = install_claude._install_claude_native_macos_installer(version='latest')
 
@@ -1201,6 +1208,7 @@ class TestNativeMacOSInstallerFunction:
         mock_unlink.assert_called()
         mock_chmod.assert_called()
         mock_remove_npm.assert_called_once()
+        mock_update_config.assert_called_once_with('native')
 
     @patch('install_claude.urlopen')
     def test_install_claude_native_macos_installer_network_error(self, mock_urlopen):
@@ -1219,6 +1227,7 @@ class TestNativeLinuxInstallerFunction:
     @patch('install_claude.run_command')
     @patch('install_claude.verify_claude_installation')
     @patch('install_claude.remove_npm_claude')
+    @patch('install_claude.update_install_method_config')
     @patch('tempfile.NamedTemporaryFile')
     @patch('os.chmod')
     @patch('os.unlink')
@@ -1229,6 +1238,7 @@ class TestNativeLinuxInstallerFunction:
         mock_unlink,
         mock_chmod,
         mock_temp,
+        mock_update_config,
         mock_remove_npm,
         mock_verify,
         mock_run,
@@ -1248,6 +1258,7 @@ class TestNativeLinuxInstallerFunction:
         mock_run.return_value = subprocess.CompletedProcess([], 0, '', '')
         mock_verify.return_value = (True, '/home/test/.local/bin/claude', 'native')
         mock_remove_npm.return_value = True
+        mock_update_config.return_value = True
 
         result = install_claude._install_claude_native_linux_installer(version='latest')
 
@@ -1257,6 +1268,7 @@ class TestNativeLinuxInstallerFunction:
         mock_unlink.assert_called()
         mock_chmod.assert_called()
         mock_remove_npm.assert_called_once()
+        mock_update_config.assert_called_once_with('native')
 
     @patch('install_claude.urlopen')
     def test_install_claude_native_linux_installer_network_error(self, mock_urlopen):


### PR DESCRIPTION
Resolves System Diagnostics warnings on macOS caused by stale installMethod: "global" value in ~/.claude.json after npm removal.

- Add update_install_method_config() function with CLI-first strategy
- Integrate config update at 8 native installation points
- Add 11 comprehensive tests (9 unit + 2 integration)
- Fix 3 existing tests to mock new config update call

The function uses claude config set CLI command as primary method, with direct file modification as fallback for edge cases.