### PR TITLE
Add MCP server profile scope isolation

### DIFF
--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -2492,7 +2492,7 @@ class TestMainFunction:
         mock_install.return_value = True
         mock_deps.return_value = True
         mock_download.return_value = True
-        mock_mcp.return_value = True
+        mock_mcp.return_value = (True, [])
         mock_settings.return_value = True
         mock_launcher.return_value = Path('/tmp/launcher.sh')
         mock_register.return_value = True
@@ -3152,7 +3152,7 @@ class TestCommandNames:
         mock_install.return_value = True
         mock_deps.return_value = True
         mock_download.return_value = True
-        mock_mcp.return_value = True
+        mock_mcp.return_value = (True, [])
         mock_settings.return_value = True
         mock_launcher.return_value = Path('/tmp/launcher.sh')
         mock_register.return_value = True
@@ -3211,7 +3211,7 @@ class TestCommandNames:
         mock_install.return_value = True
         mock_deps.return_value = True
         mock_download.return_value = True
-        mock_mcp.return_value = True
+        mock_mcp.return_value = (True, [])
         mock_settings.return_value = True
         mock_launcher.return_value = Path('/tmp/launcher.sh')
         mock_register.return_value = True
@@ -3271,7 +3271,7 @@ class TestCommandNames:
         mock_install.return_value = True
         mock_deps.return_value = True
         mock_download.return_value = True
-        mock_mcp.return_value = True
+        mock_mcp.return_value = (True, [])
         mock_settings.return_value = True
         mock_launcher.return_value = Path('/tmp/launcher.sh')
         mock_register.return_value = True
@@ -3337,7 +3337,7 @@ class TestCommandNames:
         mock_install.return_value = True
         mock_deps.return_value = True
         mock_download.return_value = True
-        mock_mcp.return_value = True
+        mock_mcp.return_value = (True, [])
         mock_settings.return_value = True
         mock_launcher.return_value = Path('/tmp/launcher.sh')
         mock_register.return_value = True


### PR DESCRIPTION
Implements scope: profile for MCP servers, enabling true isolation where servers are visible only when using a specific profile command.

Profile-scoped servers are stored in {command}-mcp.json and loaded via --strict-mcp-config --mcp-config flags, preventing cross-contamination between different environment profiles.

Key changes:
- Add create_mcp_config_file() to generate profile MCP config JSON
- Modify configure_all_mcp_servers() to separate profile from regular servers
- Update launcher scripts to detect and use --strict-mcp-config when profile servers exist
- Add 15+ tests covering all profile scope scenarios