### PR TITLE
Prevent MSYS path conversion in run_bash_command

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -695,8 +695,14 @@ def run_bash_command(
 
     debug_log(f'Executing: {args}')
 
+    # Disable MSYS path conversion on Windows to preserve /c flags and other arguments
+    # that would otherwise be incorrectly converted to Windows drive paths (e.g., /c -> C:/)
+    env = os.environ.copy()
+    if sys.platform == 'win32':
+        env['MSYS_NO_PATHCONV'] = '1'
+
     try:
-        result = subprocess.run(args, capture_output=capture_output, text=True)
+        result = subprocess.run(args, capture_output=capture_output, text=True, env=env)
         debug_log(f'Exit code: {result.returncode}')
         if capture_output:
             stdout_preview = result.stdout[:500] if result.stdout else '(empty)'


### PR DESCRIPTION
Set MSYS_NO_PATHCONV=1 environment variable on Windows to prevent Git Bash from converting /c cmd.exe flags to C:/ drive paths. This fixes MCP server configuration where user-scoped servers failed due to corrupted command arguments. The fix is isolated to Windows platform and preserves existing environment variables. Includes comprehensive test coverage with 8 test cases covering Windows, Linux, and macOS platforms.