### PR TITLE
Ensure profile-only MCP servers trigger removal from all scopes

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -4343,6 +4343,13 @@ def configure_all_mcp_servers(
         # Add to profile config if profile scope present
         if has_profile:
             profile_servers.append(server)
+            # For profile-only servers, call configure_mcp_server to trigger removal
+            # from all scopes (user, local, project). The function will early-return
+            # after removal since scope == 'profile', skipping the claude mcp add.
+            if not has_global:
+                server_copy = server.copy()
+                server_copy['scope'] = 'profile'
+                configure_mcp_server(server_copy)
 
         # Configure for each non-profile scope via claude mcp add
         for scope in non_profile_scopes:


### PR DESCRIPTION
Profile-only servers (scope: profile) were not calling configure_mcp_server(), causing them to skip the removal logic that cleans up servers from user/local/project scopes before applying profile configuration.

This fix adds a call to configure_mcp_server() for profile-only servers, which triggers removal from all scopes while skipping the claude mcp add command (via early-return for scope == 'profile').

Added 5 comprehensive test methods to verify the fix and prevent regressions:
- Profile-only servers trigger removal from all 3 scopes
- Multi-scope servers work correctly with both removal and add
- User-scope servers unchanged (regression test)
- Multiple profile-only servers handled correctly
- Comprehensive scope mix integration test