### PR TITLE
Expand tildes in user-scope STDIO MCP commands on Windows

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -4229,7 +4229,10 @@ def configure_mcp_server(server: dict[str, Any]) -> bool:
 
                 # Build command string for STDIO
                 # npx needs cmd /c wrapper on Windows even in bash
-                command_str = f'cmd /c {command}' if 'npx' in command else command
+                # Expand tildes using Python (produces C:\Users\...) and convert to forward slashes
+                # This prevents Git Bash from expanding ~ to /c/Users/... (Unix format)
+                expanded_command = expand_tildes_in_command(command).replace('\\', '/')
+                command_str = f'cmd /c {expanded_command}' if 'npx' in expanded_command else expanded_command
 
                 bash_cmd = (
                     f'export PATH="{unix_explicit_path}:$PATH" && '


### PR DESCRIPTION
User-scope STDIO MCP commands containing tildes (~) were passed directly to Git Bash without Python-side expansion. Git Bash expanded ~ to Unix-style paths (/c/Users/...) which Windows cannot resolve, causing MCP servers to fail with "os error 3". This fix applies Python-side tilde expansion before building the command string, preventing Git Bash from performing Unix-style expansion. Includes comprehensive test coverage with 8 tests.