### PR TITLE
Resolve Unix MCP server command generation with npx/npm

### DIFF
--- a/tests/e2e/golden_config.yaml
+++ b/tests/e2e/golden_config.yaml
@@ -93,6 +93,12 @@ mcp-servers:
     env:
       - "E2E_STDIO_DEBUG=1"
       - "E2E_STDIO_LOG_LEVEL=debug"
+  # NPX transport (local scope) - tests Windows cmd /c wrapping
+  - name: "e2e-npx-server"
+    scope: "local"
+    command: "npx @modelcontextprotocol/server-memory"
+    env:
+      - "E2E_NPX_DEBUG=1"
 
 # Model configuration
 model: "sonnet"
@@ -104,6 +110,7 @@ permissions:
     - "mcp__e2e-http-server"
     - "mcp__e2e-sse-server"
     - "mcp__e2e-stdio-server"
+    - "mcp__e2e-npx-server"
     - "Read"
     - "Glob"
     - "Grep"

--- a/tests/e2e/validators.py
+++ b/tests/e2e/validators.py
@@ -220,6 +220,18 @@ def _validate_mcp_server_config(name: str, server: dict[str, Any]) -> list[str]:
                 "Expected command to be 'cmd' with args starting with '/c', 'npx'",
             )
 
+    # Non-Windows: cmd /c wrapper must NOT be present
+    # This catches bugs where Windows-specific wrapping is incorrectly applied on Unix
+    if sys.platform != 'win32':
+        command = server.get('command', '')
+        if command == 'cmd':
+            args = server.get('args', [])
+            if args and len(args) >= 2 and args[0] == '/c':
+                errors.append(
+                    f"Server '{name}': Windows-specific 'cmd /c' wrapper found on Unix. "
+                    "This indicates a cross-platform bug in MCP server configuration.",
+                )
+
     # Validate transport-specific fields
     server_type = server.get('type', '')
     if server_type in ('http', 'sse') and 'url' not in server:


### PR DESCRIPTION
The configure_mcp_server() function was missing a platform check before applying Windows-specific cmd /c wrapping for npx/npm commands. This caused npx-based MCP servers to fail on Unix systems with incorrect command formatting.

Changes:
- Extract build_platform_aware_command() helper to eliminate DRY violation
- Add platform check in configure_mcp_server() via shared helper
- Update parse_mcp_command() to use shared helper function
- Add E2E negative validation for Unix (catches cmd /c on non-Windows)
- Add npx-based MCP server to golden config for cross-platform testing
- Add comprehensive unit tests for platform-aware command building