### PR TITLE
Add root detection guard and enhance npm fallback diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ export CLAUDE_ENV_CONFIG='https://gitlab.company.com/namespace/project/-/raw/mai
 export CLAUDE_ENV_CONFIG='https://raw.githubusercontent.com/org/repo/main/config.yaml' && export GITHUB_TOKEN='ghp_<your-token>' && curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash
 ```
 
+> **Important:** Do not run the setup scripts as root or with `sudo`. The scripts will request elevated permissions only when needed. Running as root creates configuration under `/root/` instead of your home directory. For Docker/CI environments, set `CLAUDE_ALLOW_ROOT=1`.
+
 **✅ After setup, use the simple command:**
 ```bash
 <command-name>  # Works in all Windows shells (PowerShell, CMD, Git Bash)
@@ -219,6 +221,8 @@ curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/
 
 The installer uses the native shell installer from Anthropic with automatic npm fallback if needed.
 
+> **Important:** Do not run the setup scripts as root or with `sudo`. The scripts will request elevated permissions only when needed (e.g., for npm global installs). Running as root creates configuration under `/root/` instead of your home directory. For Docker/CI environments, set `CLAUDE_ALLOW_ROOT=1`.
+
 ### Environment Variables
 
 Control the installation behavior with these environment variables:
@@ -233,6 +237,12 @@ Control the installation behavior with these environment variables:
 
 - Specify a particular version to install (e.g., `1.0.128`)
 - Forces npm installation method (native installers don't support version selection)
+
+#### CLAUDE_ALLOW_ROOT
+
+- Set to `1` to allow running as root on Linux/macOS (default: scripts refuse to run as root)
+- Only the exact value `1` is accepted (`true`, `yes`, or empty strings do not bypass the guard)
+- Use for Docker containers, CI/CD pipelines, or other legitimate root execution environments
 
 **Examples:**
 
@@ -279,6 +289,12 @@ curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/
 - Uninstall npm version: `npm uninstall -g @anthropic-ai/claude-code`
 - Run the installer again (it will use native method by default)
 - Your configurations are preserved (both methods use the same config directory)
+
+#### Script refuses to run as root
+
+- This is intentional - running as root creates configuration under `/root/` instead of your home directory
+- Run as your regular user instead (the script requests sudo only when needed)
+- For Docker/CI: set `CLAUDE_ALLOW_ROOT=1` before running the script
 
 ## 🤝 Contributing
 

--- a/scripts/linux/install-claude-linux.sh
+++ b/scripts/linux/install-claude-linux.sh
@@ -25,6 +25,21 @@ if [[ "$OSTYPE" != "linux"* ]]; then
     exit 1
 fi
 
+# Refuse to run as root unless explicitly allowed
+if [ "$(id -u)" -eq 0 ] && [ "${CLAUDE_ALLOW_ROOT:-}" != "1" ]; then
+    echo -e "${RED}[FAIL]${NC} This script should NOT be run as root or with sudo"
+    echo ""
+    echo -e "${YELLOW}[WARN]${NC} Running as root creates configuration under /root/,"
+    echo -e "${YELLOW}[WARN]${NC} not for the regular user you intend to configure."
+    echo ""
+    echo -e "${CYAN}[INFO]${NC} Instead, run as your regular user:"
+    echo -e "${CYAN}[INFO]${NC}   curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/install-claude-linux.sh | bash"
+    echo ""
+    echo -e "${CYAN}[INFO]${NC} The installer will request sudo only when needed (e.g., npm)."
+    echo -e "${CYAN}[INFO]${NC} To force root execution: CLAUDE_ALLOW_ROOT=1 bash <script>"
+    exit 1
+fi
+
 # Check if uv is installed
 if ! command -v uv >/dev/null 2>&1; then
     echo -e "${CYAN}[INFO]${NC} Installing uv (Python package manager)..."

--- a/scripts/linux/setup-environment.sh
+++ b/scripts/linux/setup-environment.sh
@@ -28,6 +28,21 @@ if [[ "$OSTYPE" != "linux"* ]]; then
     exit 1
 fi
 
+# Refuse to run as root unless explicitly allowed
+if [ "$(id -u)" -eq 0 ] && [ "${CLAUDE_ALLOW_ROOT:-}" != "1" ]; then
+    echo -e "${RED}[FAIL]${NC} This script should NOT be run as root or with sudo"
+    echo ""
+    echo -e "${YELLOW}[WARN]${NC} Running as root creates configuration under /root/,"
+    echo -e "${YELLOW}[WARN]${NC} not for the regular user you intend to configure."
+    echo ""
+    echo -e "${CYAN}[INFO]${NC} Instead, run as your regular user:"
+    echo -e "${CYAN}[INFO]${NC}   curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/linux/setup-environment.sh | bash"
+    echo ""
+    echo -e "${CYAN}[INFO]${NC} The installer will request sudo only when needed (e.g., npm)."
+    echo -e "${CYAN}[INFO]${NC} To force root execution: CLAUDE_ALLOW_ROOT=1 bash <script>"
+    exit 1
+fi
+
 # Check if uv is installed
 if ! command -v uv >/dev/null 2>&1; then
     echo -e "${CYAN}[INFO]${NC} Installing uv (Python package manager)..."

--- a/scripts/macos/install-claude-macos.sh
+++ b/scripts/macos/install-claude-macos.sh
@@ -25,6 +25,21 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
     exit 1
 fi
 
+# Refuse to run as root unless explicitly allowed
+if [ "$(id -u)" -eq 0 ] && [ "${CLAUDE_ALLOW_ROOT:-}" != "1" ]; then
+    echo -e "${RED}[FAIL]${NC} This script should NOT be run as root or with sudo"
+    echo ""
+    echo -e "${YELLOW}[WARN]${NC} Running as root creates configuration under /root/,"
+    echo -e "${YELLOW}[WARN]${NC} not for the regular user you intend to configure."
+    echo ""
+    echo -e "${CYAN}[INFO]${NC} Instead, run as your regular user:"
+    echo -e "${CYAN}[INFO]${NC}   curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/install-claude-macos.sh | bash"
+    echo ""
+    echo -e "${CYAN}[INFO]${NC} The installer will request sudo only when needed (e.g., npm)."
+    echo -e "${CYAN}[INFO]${NC} To force root execution: CLAUDE_ALLOW_ROOT=1 bash <script>"
+    exit 1
+fi
+
 # Check if uv is installed
 if ! command -v uv >/dev/null 2>&1; then
     echo -e "${CYAN}[INFO]${NC} Installing uv (Python package manager)..."

--- a/scripts/macos/setup-environment.sh
+++ b/scripts/macos/setup-environment.sh
@@ -28,6 +28,21 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
     exit 1
 fi
 
+# Refuse to run as root unless explicitly allowed
+if [ "$(id -u)" -eq 0 ] && [ "${CLAUDE_ALLOW_ROOT:-}" != "1" ]; then
+    echo -e "${RED}[FAIL]${NC} This script should NOT be run as root or with sudo"
+    echo ""
+    echo -e "${YELLOW}[WARN]${NC} Running as root creates configuration under /root/,"
+    echo -e "${YELLOW}[WARN]${NC} not for the regular user you intend to configure."
+    echo ""
+    echo -e "${CYAN}[INFO]${NC} Instead, run as your regular user:"
+    echo -e "${CYAN}[INFO]${NC}   curl -fsSL https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/macos/setup-environment.sh | bash"
+    echo ""
+    echo -e "${CYAN}[INFO]${NC} The installer will request sudo only when needed (e.g., npm)."
+    echo -e "${CYAN}[INFO]${NC} To force root execution: CLAUDE_ALLOW_ROOT=1 bash <script>"
+    exit 1
+fi
+
 # Check if uv is installed
 if ! command -v uv >/dev/null 2>&1; then
     echo -e "${CYAN}[INFO]${NC} Installing uv (Python package manager)..."

--- a/tests/e2e/test_npm_fallback.py
+++ b/tests/e2e/test_npm_fallback.py
@@ -1,0 +1,768 @@
+"""E2E tests for npm sudo fallback, native installer diagnostics, and error messaging.
+
+Tests verify that:
+- Sudo uses the resolved npm_path (not bare 'npm')
+- Non-interactive environments get TTY-aware guidance
+- Interactive environments get password/sudoers guidance
+- Sudo timeout is handled gracefully (30-second limit)
+- Enhanced error messages appear on total npm failure
+- Pre-warning appears when sudo is predicted via needs_sudo_for_npm()
+- capture_output=True is set on the sudo subprocess call
+- Native installer captures and logs stderr on failure
+- Native installer captures and logs stdout on success
+- ensure_claude() shows numbered troubleshooting steps on total failure
+- ensure_claude() logs diagnostic info at npm fallback points
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from scripts import install_claude
+
+
+class TestNpmSudoFallback:
+    """E2E tests for TTY-aware sudo fallback in install_claude_npm()."""
+
+    def test_sudo_uses_resolved_npm_path(self) -> None:
+        """Verify sudo command uses the full resolved npm path, not bare 'npm'."""
+        mock_subprocess = MagicMock()
+        mock_subprocess.return_value = subprocess.CompletedProcess([], 0, '', '')
+
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch.object(install_claude, 'find_command_robust', return_value='/usr/local/bin/npm'),
+            patch.object(install_claude, 'needs_sudo_for_npm', return_value=False),
+            patch.object(
+                install_claude, 'run_command',
+                return_value=subprocess.CompletedProcess([], 1, '', 'permission denied'),
+            ),
+            patch('subprocess.run', mock_subprocess),
+            patch('pathlib.Path.exists', return_value=True),
+        ):
+            result = install_claude.install_claude_npm()
+
+        assert result is True
+        # Verify the sudo call used the resolved path
+        sudo_cmd = mock_subprocess.call_args[0][0]
+        assert sudo_cmd[0] == 'sudo'
+        assert sudo_cmd[1] == '/usr/local/bin/npm', (
+            f'Expected resolved npm path, got bare command: {sudo_cmd[1]}'
+        )
+
+    def test_non_interactive_error_guidance(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Verify non-interactive (no TTY) environments get pipe-specific guidance."""
+        mock_subprocess = MagicMock()
+        mock_subprocess.return_value = subprocess.CompletedProcess([], 1, '', 'sudo: no tty')
+
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch.object(install_claude, 'find_command_robust', return_value='/usr/bin/npm'),
+            patch.object(install_claude, 'needs_sudo_for_npm', return_value=False),
+            patch.object(
+                install_claude, 'run_command',
+                return_value=subprocess.CompletedProcess([], 1, '', 'permission denied'),
+            ),
+            patch('subprocess.run', mock_subprocess),
+            patch('pathlib.Path.exists', return_value=True),
+            patch('sys.stdin') as mock_stdin,
+        ):
+            mock_stdin.isatty.return_value = False
+            result = install_claude.install_claude_npm()
+
+        assert result is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'non-interactive' in combined.lower(), (
+            'Should mention non-interactive mode when no TTY'
+        )
+        assert 'curl | bash' in combined or 'curl' in combined.lower(), (
+            'Should mention pipe scenario'
+        )
+        assert 'CLAUDE_INSTALL_METHOD=native' in combined, (
+            'Should suggest native installer alternative'
+        )
+
+    def test_interactive_error_guidance(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Verify interactive (TTY available) environments get password/sudoers guidance."""
+        mock_subprocess = MagicMock()
+        mock_subprocess.return_value = subprocess.CompletedProcess([], 1, '', 'incorrect password')
+
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch.object(install_claude, 'find_command_robust', return_value='/usr/bin/npm'),
+            patch.object(install_claude, 'needs_sudo_for_npm', return_value=False),
+            patch.object(
+                install_claude, 'run_command',
+                return_value=subprocess.CompletedProcess([], 1, '', 'permission denied'),
+            ),
+            patch('subprocess.run', mock_subprocess),
+            patch('pathlib.Path.exists', return_value=True),
+            patch('sys.stdin') as mock_stdin,
+        ):
+            mock_stdin.isatty.return_value = True
+            result = install_claude.install_claude_npm()
+
+        assert result is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'password' in combined.lower(), 'Should mention password check'
+        assert 'sudoers' in combined.lower(), 'Should mention sudoers check'
+
+    def test_sudo_timeout_handled_gracefully(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Verify subprocess.TimeoutExpired is caught and produces warning."""
+        mock_subprocess = MagicMock()
+        mock_subprocess.side_effect = subprocess.TimeoutExpired(cmd=['sudo', 'npm'], timeout=30)
+
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch.object(install_claude, 'find_command_robust', return_value='/usr/bin/npm'),
+            patch.object(install_claude, 'needs_sudo_for_npm', return_value=False),
+            patch.object(
+                install_claude, 'run_command',
+                return_value=subprocess.CompletedProcess([], 1, '', 'permission denied'),
+            ),
+            patch('subprocess.run', mock_subprocess),
+            patch('pathlib.Path.exists', return_value=True),
+            patch('sys.stdin') as mock_stdin,
+        ):
+            mock_stdin.isatty.return_value = True
+            result = install_claude.install_claude_npm()
+
+        assert result is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'timed out' in combined.lower(), 'Should mention timeout'
+
+    def test_enhanced_error_on_total_failure(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Verify comprehensive manual installation options appear on total npm failure."""
+        mock_subprocess = MagicMock()
+        mock_subprocess.return_value = subprocess.CompletedProcess([], 1, '', 'failed')
+
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch.object(install_claude, 'find_command_robust', return_value='/usr/bin/npm'),
+            patch.object(install_claude, 'needs_sudo_for_npm', return_value=False),
+            patch.object(
+                install_claude, 'run_command',
+                return_value=subprocess.CompletedProcess([], 1, '', 'permission denied'),
+            ),
+            patch('subprocess.run', mock_subprocess),
+            patch('pathlib.Path.exists', return_value=True),
+            patch('sys.stdin') as mock_stdin,
+        ):
+            mock_stdin.isatty.return_value = True
+            result = install_claude.install_claude_npm()
+
+        assert result is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        # Enhanced error should include manual installation options
+        assert 'manual installation' in combined.lower(), (
+            'Should mention manual installation options'
+        )
+        assert 'npm config set prefix' in combined, (
+            'Should suggest npm prefix configuration'
+        )
+        assert 'CLAUDE_INSTALL_METHOD=native' in combined, (
+            'Should suggest native installer alternative'
+        )
+        assert 'claude.ai/install.sh' in combined, (
+            'Should provide direct native install URL'
+        )
+
+    def test_pre_warning_when_sudo_predicted(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Verify pre-warning message when needs_sudo_for_npm() predicts sudo requirement."""
+        mock_subprocess = MagicMock()
+        mock_subprocess.return_value = subprocess.CompletedProcess([], 0, '', '')
+
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch.object(install_claude, 'find_command_robust', return_value='/usr/bin/npm'),
+            patch.object(install_claude, 'needs_sudo_for_npm', return_value=True),
+            patch.object(
+                install_claude, 'run_command',
+                return_value=subprocess.CompletedProcess([], 1, '', 'EACCES'),
+            ),
+            patch('subprocess.run', mock_subprocess),
+            patch('pathlib.Path.exists', return_value=True),
+        ):
+            result = install_claude.install_claude_npm()
+
+        assert result is True
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'elevated permissions' in combined.lower(), (
+            'Should warn about elevated permissions when sudo predicted'
+        )
+
+    def test_sudo_capture_output_is_true(self) -> None:
+        """Verify subprocess.run for sudo is called with capture_output=True."""
+        mock_subprocess = MagicMock()
+        mock_subprocess.return_value = subprocess.CompletedProcess([], 0, '', '')
+
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch.object(install_claude, 'find_command_robust', return_value='/usr/bin/npm'),
+            patch.object(install_claude, 'needs_sudo_for_npm', return_value=False),
+            patch.object(
+                install_claude, 'run_command',
+                return_value=subprocess.CompletedProcess([], 1, '', 'permission denied'),
+            ),
+            patch('subprocess.run', mock_subprocess),
+            patch('pathlib.Path.exists', return_value=True),
+        ):
+            install_claude.install_claude_npm()
+
+        # Verify capture_output=True was passed
+        call_kwargs = mock_subprocess.call_args[1]
+        assert call_kwargs.get('capture_output') is True, (
+            'Sudo subprocess.run must use capture_output=True to suppress noisy output'
+        )
+
+
+class TestNativeInstallerDiagnostics:
+    """E2E tests for native installer diagnostic logging (stderr/stdout capture)."""
+
+    def test_linux_installer_logs_stderr_on_failure(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When the Linux native installer fails, stderr is captured and logged."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'#!/bin/bash\nexit 1'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+
+        with (
+            patch.object(install_claude, 'urlopen', return_value=mock_response),
+            patch('tempfile.NamedTemporaryFile') as mock_tmp,
+            patch('os.chmod'),
+            patch('os.unlink'),
+            patch.object(
+                install_claude, 'run_command',
+                return_value=subprocess.CompletedProcess(
+                    [], 1, stdout='', stderr='Error: glibc version too old',
+                ),
+            ),
+        ):
+            mock_tmp.return_value.__enter__.return_value.name = '/tmp/installer.sh'
+
+            result = install_claude._install_claude_native_linux_installer()
+
+        assert result is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'glibc version too old' in combined, (
+            'Should log stderr content from failed native installer'
+        )
+        assert 'exited with code 1' in combined, (
+            'Should log the exit code of failed native installer'
+        )
+
+    def test_macos_installer_logs_stderr_on_failure(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When the macOS native installer fails, stderr is captured and logged."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'#!/bin/bash\nexit 1'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+
+        with (
+            patch.object(install_claude, 'urlopen', return_value=mock_response),
+            patch('tempfile.NamedTemporaryFile') as mock_tmp,
+            patch('os.chmod'),
+            patch('os.unlink'),
+            patch.object(
+                install_claude, 'run_command',
+                return_value=subprocess.CompletedProcess(
+                    [], 1, stdout='', stderr='Error: Unsupported macOS version',
+                ),
+            ),
+        ):
+            mock_tmp.return_value.__enter__.return_value.name = '/tmp/installer.sh'
+
+            result = install_claude._install_claude_native_macos_installer()
+
+        assert result is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'Unsupported macOS version' in combined, (
+            'Should log stderr content from failed native installer'
+        )
+
+    def test_windows_installer_logs_stderr_on_failure(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When the Windows native installer fails, stderr is captured and logged."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'Write-Output "Installing"'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+
+        with (
+            patch.object(install_claude, 'urlopen', return_value=mock_response),
+            patch('tempfile.NamedTemporaryFile') as mock_tmp,
+            patch('os.unlink'),
+            patch.object(
+                install_claude, 'run_command',
+                return_value=subprocess.CompletedProcess(
+                    [], 1, stdout='', stderr='Error: PowerShell execution policy',
+                ),
+            ),
+        ):
+            mock_tmp.return_value.__enter__.return_value.name = 'C:\\Temp\\install.ps1'
+
+            result = install_claude._install_claude_native_windows_installer()
+
+        assert result is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'PowerShell execution policy' in combined, (
+            'Should log stderr content from failed native installer'
+        )
+
+    def test_linux_installer_logs_stdout_on_success(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When the Linux native installer succeeds, stdout is logged."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'#!/bin/bash\necho "OK"'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+
+        with (
+            patch.object(install_claude, 'urlopen', return_value=mock_response),
+            patch('tempfile.NamedTemporaryFile') as mock_tmp,
+            patch('os.chmod'),
+            patch('os.unlink'),
+            patch.object(
+                install_claude, 'run_command',
+                return_value=subprocess.CompletedProcess(
+                    [], 0, stdout='Claude installed to /home/user/.local/bin/claude', stderr='',
+                ),
+            ),
+            patch.object(
+                install_claude, 'verify_claude_installation',
+                return_value=(True, '/home/user/.local/bin/claude', 'native'),
+            ),
+            patch.object(install_claude, 'remove_npm_claude'),
+            patch.object(install_claude, 'update_install_method_config'),
+            patch('time.sleep'),
+        ):
+            mock_tmp.return_value.__enter__.return_value.name = '/tmp/installer.sh'
+
+            result = install_claude._install_claude_native_linux_installer()
+
+        assert result is True
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'Installer output' in combined, (
+            'Should log installer output on success'
+        )
+
+    def test_linux_installer_uses_capture_output_true(self) -> None:
+        """Native Linux installer calls run_command with capture_output=True."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'#!/bin/bash\nexit 0'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+
+        with (
+            patch.object(install_claude, 'urlopen', return_value=mock_response),
+            patch('tempfile.NamedTemporaryFile') as mock_tmp,
+            patch('os.chmod'),
+            patch('os.unlink'),
+            patch.object(install_claude, 'run_command') as mock_run,
+        ):
+            mock_tmp.return_value.__enter__.return_value.name = '/tmp/installer.sh'
+            mock_run.return_value = subprocess.CompletedProcess([], 1, '', '')
+
+            install_claude._install_claude_native_linux_installer()
+
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs.get('capture_output') is True, (
+            'Native installer must use capture_output=True for diagnostic logging'
+        )
+
+    def test_macos_installer_uses_capture_output_true(self) -> None:
+        """Native macOS installer calls run_command with capture_output=True."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'#!/bin/bash\nexit 0'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+
+        with (
+            patch.object(install_claude, 'urlopen', return_value=mock_response),
+            patch('tempfile.NamedTemporaryFile') as mock_tmp,
+            patch('os.chmod'),
+            patch('os.unlink'),
+            patch.object(install_claude, 'run_command') as mock_run,
+        ):
+            mock_tmp.return_value.__enter__.return_value.name = '/tmp/installer.sh'
+            mock_run.return_value = subprocess.CompletedProcess([], 1, '', '')
+
+            install_claude._install_claude_native_macos_installer()
+
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs.get('capture_output') is True, (
+            'Native macOS installer must use capture_output=True for diagnostic logging'
+        )
+
+    def test_windows_installer_uses_capture_output_true(self) -> None:
+        """Native Windows installer calls run_command with capture_output=True."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'Write-Output "test"'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+
+        with (
+            patch.object(install_claude, 'urlopen', return_value=mock_response),
+            patch('tempfile.NamedTemporaryFile') as mock_tmp,
+            patch('os.unlink'),
+            patch.object(install_claude, 'run_command') as mock_run,
+        ):
+            mock_tmp.return_value.__enter__.return_value.name = 'C:\\Temp\\install.ps1'
+            mock_run.return_value = subprocess.CompletedProcess([], 1, '', '')
+
+            install_claude._install_claude_native_windows_installer()
+
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs.get('capture_output') is True, (
+            'Native Windows installer must use capture_output=True for diagnostic logging'
+        )
+
+    def test_macos_installer_logs_stdout_on_success(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When the macOS native installer succeeds, stdout is logged."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'#!/bin/bash\necho "OK"'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+
+        with (
+            patch.object(install_claude, 'urlopen', return_value=mock_response),
+            patch('tempfile.NamedTemporaryFile') as mock_tmp,
+            patch('os.chmod'),
+            patch('os.unlink'),
+            patch.object(
+                install_claude, 'run_command',
+                return_value=subprocess.CompletedProcess(
+                    [], 0, stdout='Claude installed to /usr/local/bin/claude', stderr='',
+                ),
+            ),
+            patch.object(
+                install_claude, 'verify_claude_installation',
+                return_value=(True, '/usr/local/bin/claude', 'native'),
+            ),
+            patch.object(install_claude, 'remove_npm_claude'),
+            patch.object(install_claude, 'update_install_method_config'),
+            patch('time.sleep'),
+        ):
+            mock_tmp.return_value.__enter__.return_value.name = '/tmp/installer.sh'
+
+            result = install_claude._install_claude_native_macos_installer()
+
+        assert result is True
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'Installer output' in combined, (
+            'Should log installer output on success'
+        )
+
+
+class TestEnsureClaudeTroubleshooting:
+    """E2E tests for enhanced error messaging in ensure_claude()."""
+
+    def test_all_methods_failed_unix_troubleshooting(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When all methods fail on Unix, numbered troubleshooting steps appear."""
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch.object(install_claude, 'get_claude_version', return_value=None),
+            patch.object(
+                install_claude, 'install_claude_native_cross_platform', return_value=False,
+            ),
+            patch.object(install_claude, 'install_claude_npm', return_value=False),
+            patch.dict('os.environ', {'CLAUDE_INSTALL_METHOD': 'auto'}, clear=False),
+        ):
+            result = install_claude.ensure_claude()
+
+        assert result is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'Troubleshooting steps' in combined, (
+            'Should show "Troubleshooting steps" header'
+        )
+        assert 'sudo npm install' in combined, (
+            'Should suggest sudo npm install'
+        )
+        assert 'npm config set prefix' in combined, (
+            'Should suggest npm prefix configuration'
+        )
+        assert 'CLAUDE_INSTALL_METHOD=native' in combined, (
+            'Should suggest method override'
+        )
+        assert 'CLAUDE_INSTALL_METHOD=npm' in combined, (
+            'Should suggest npm-only override'
+        )
+
+    def test_all_methods_failed_windows_troubleshooting(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When all methods fail on Windows, platform-appropriate steps appear."""
+        with (
+            patch('platform.system', return_value='Windows'),
+            patch.object(install_claude, 'get_claude_version', return_value=None),
+            patch.object(
+                install_claude, 'install_claude_native_cross_platform', return_value=False,
+            ),
+            patch.object(install_claude, 'install_claude_npm', return_value=False),
+            patch.dict('os.environ', {'CLAUDE_INSTALL_METHOD': 'auto'}, clear=False),
+        ):
+            result = install_claude.ensure_claude()
+
+        assert result is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'irm' in combined, 'Should mention PowerShell irm command'
+        assert '$env:CLAUDE_INSTALL_METHOD' in combined, (
+            'Should use PowerShell env var syntax'
+        )
+
+    def test_fallback_diagnostic_suggests_method_override(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When native fails and npm fallback occurs, diagnostic info is logged."""
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch.object(install_claude, 'get_claude_version', return_value=None),
+            patch.object(
+                install_claude, 'install_claude_native_cross_platform', return_value=False,
+            ),
+            patch.object(install_claude, 'install_claude_npm', return_value=False),
+            patch.dict('os.environ', {'CLAUDE_INSTALL_METHOD': 'auto'}, clear=False),
+        ):
+            install_claude.ensure_claude()
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'CLAUDE_INSTALL_METHOD=native' in combined, (
+            'Should suggest CLAUDE_INSTALL_METHOD=native at fallback point'
+        )
+
+
+class TestWindowsPathLengthHandling:
+    """E2E tests for Windows PATH length limit handling.
+
+    Verifies that:
+    - refresh_path_from_registry() gracefully handles PATH exceeding 32762 chars
+    - add_directory_to_windows_path() skips session PATH update when too long
+    - Warning messages are produced for long PATH scenarios
+    - The _WIN_PATH_VALUE_MAX_LENGTH constant is correctly defined
+    """
+
+    def test_path_length_constant_defined(self) -> None:
+        """Verify _WIN_PATH_VALUE_MAX_LENGTH constant exists and has correct value."""
+        from scripts import setup_environment
+
+        assert hasattr(setup_environment, '_WIN_PATH_VALUE_MAX_LENGTH'), (
+            'Missing _WIN_PATH_VALUE_MAX_LENGTH constant in setup_environment'
+        )
+        assert setup_environment._WIN_PATH_VALUE_MAX_LENGTH == 32762, (
+            f'Expected 32762, got {setup_environment._WIN_PATH_VALUE_MAX_LENGTH}'
+        )
+
+    def test_refresh_path_graceful_on_long_path(self) -> None:
+        """When registry PATH exceeds limit, refresh_path_from_registry warns and keeps current PATH."""
+        from scripts import setup_environment
+
+        # Generate a PATH value that exceeds _WIN_PATH_VALUE_MAX_LENGTH
+        long_path = ';'.join([f'C:\\fake\\path{i}' for i in range(3000)])
+        assert len(long_path) > setup_environment._WIN_PATH_VALUE_MAX_LENGTH
+
+        mock_winreg = MagicMock()
+        mock_key = MagicMock()
+        mock_winreg.OpenKey.return_value.__enter__ = MagicMock(return_value=mock_key)
+        mock_winreg.OpenKey.return_value.__exit__ = MagicMock(return_value=None)
+        mock_winreg.QueryValueEx.return_value = (long_path, 1)
+        mock_winreg.HKEY_LOCAL_MACHINE = 0x80000002
+        mock_winreg.HKEY_CURRENT_USER = 0x80000001
+        mock_winreg.KEY_READ = 0x20019
+        mock_winreg.KEY_WOW64_64KEY = 0x0100
+        mock_winreg.REG_EXPAND_SZ = 2
+
+        with (
+            patch('sys.platform', 'win32'),
+            patch.object(setup_environment, 'winreg', mock_winreg, create=True),
+            patch.dict('os.environ', {'PATH': 'C:\\original'}, clear=False),
+        ):
+            result = setup_environment.refresh_path_from_registry()
+
+        # Should return True (graceful degradation) not crash
+        assert result is True, 'refresh_path_from_registry should return True for graceful degradation on long PATH'
+
+    def test_add_directory_warns_when_session_path_too_long(self) -> None:
+        """When session PATH would exceed limit, registry is updated but session PATH is not."""
+        from scripts import setup_environment
+
+        # Build a long existing session PATH that is under the limit itself
+        # but would exceed it after prepending the new directory
+        # We need the path to be long enough that adding another entry pushes it over
+        segment_count = 2100
+        long_session_path = ';'.join([f'C:\\path{i}' for i in range(segment_count)])
+
+        mock_winreg = MagicMock()
+        mock_key = MagicMock()
+        mock_winreg.OpenKey.return_value = mock_key
+        mock_winreg.QueryValueEx.return_value = ('C:\\existing', 1)
+        mock_winreg.HKEY_CURRENT_USER = 0x80000001
+        mock_winreg.KEY_READ = 0x20019
+        mock_winreg.KEY_WRITE = 0x20006
+        mock_winreg.REG_EXPAND_SZ = 2
+
+        home_dir = str(Path.home() / '.local' / 'bin')
+
+        with (
+            patch('sys.platform', 'win32'),
+            patch.object(setup_environment, 'winreg', mock_winreg, create=True),
+            patch.dict('os.environ', {'PATH': long_session_path}, clear=False),
+            patch('subprocess.run'),
+            patch('pathlib.Path.resolve', return_value=Path(home_dir)),
+            patch('pathlib.Path.exists', return_value=True),
+        ):
+            success_flag, message = setup_environment.add_directory_to_windows_path(home_dir)
+
+        # Should not crash - graceful handling
+        assert isinstance(success_flag, bool)
+        assert isinstance(message, str)
+
+
+class TestEnsureClaudeFullFlow:
+    """E2E tests for the complete ensure_claude() installation flow.
+
+    Tests the full native-first-then-npm-fallback pipeline end-to-end.
+    """
+
+    def test_auto_mode_native_success_skips_npm(self) -> None:
+        """When native installation succeeds in auto mode, npm is never attempted."""
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch.object(install_claude, 'get_claude_version', return_value=None),
+            patch.object(
+                install_claude, 'install_claude_native_cross_platform', return_value=True,
+            ),
+            patch.object(install_claude, 'install_claude_npm') as mock_npm,
+            patch.dict('os.environ', {'CLAUDE_INSTALL_METHOD': 'auto'}, clear=False),
+        ):
+            result = install_claude.ensure_claude()
+
+        assert result is True
+        mock_npm.assert_not_called()
+
+    def test_auto_mode_native_fails_tries_npm(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """When native fails in auto mode, npm fallback is attempted with diagnostic message."""
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch.object(install_claude, 'get_claude_version', return_value=None),
+            patch.object(
+                install_claude, 'install_claude_native_cross_platform', return_value=False,
+            ),
+            patch.object(install_claude, 'install_claude_npm', return_value=False),
+            patch.dict('os.environ', {'CLAUDE_INSTALL_METHOD': 'auto'}, clear=False),
+        ):
+            result = install_claude.ensure_claude()
+
+        assert result is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'falling back to npm' in combined.lower(), (
+            'Should show npm fallback diagnostic message'
+        )
+        assert 'CLAUDE_INSTALL_METHOD=native' in combined, (
+            'Should suggest method override at fallback point'
+        )
+
+    def test_native_only_mode_no_npm_fallback(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """When method=native, npm is never attempted even on failure."""
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch.object(install_claude, 'get_claude_version', return_value=None),
+            patch.object(
+                install_claude, 'install_claude_native_cross_platform', return_value=False,
+            ),
+            patch.object(install_claude, 'install_claude_npm') as mock_npm,
+            patch.dict('os.environ', {'CLAUDE_INSTALL_METHOD': 'native'}, clear=False),
+        ):
+            result = install_claude.ensure_claude()
+
+        assert result is False
+        mock_npm.assert_not_called()
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'npm fallback is disabled' in combined.lower(), (
+            'Should explain that npm fallback is disabled in native mode'
+        )
+
+    def test_npm_only_mode_no_native_attempt(self) -> None:
+        """When method=npm, native installer is never attempted."""
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch.object(install_claude, 'get_claude_version', return_value=None),
+            patch.object(
+                install_claude, 'install_claude_native_cross_platform',
+            ) as mock_native,
+            patch.object(install_claude, 'install_claude_npm', return_value=True),
+            patch.object(install_claude, 'find_command_robust', return_value='/usr/bin/claude'),
+            patch.object(install_claude, 'get_claude_version', return_value='1.0.130'),
+            patch.dict('os.environ', {'CLAUDE_INSTALL_METHOD': 'npm'}, clear=False),
+        ):
+            result = install_claude.ensure_claude()
+
+        assert result is True
+        mock_native.assert_not_called()
+
+    def test_already_installed_up_to_date_returns_true(self) -> None:
+        """When Claude is already installed and up to date, returns True immediately."""
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch.object(install_claude, 'get_claude_version', return_value='1.0.130'),
+            patch.object(install_claude, 'get_latest_claude_version', return_value='1.0.130'),
+            patch.object(install_claude, 'compare_versions', return_value=True),
+            patch.object(
+                install_claude, 'verify_claude_installation',
+                return_value=(True, '/usr/local/bin/claude', 'native'),
+            ),
+            patch.dict('os.environ', {'CLAUDE_INSTALL_METHOD': 'auto'}, clear=False),
+        ):
+            result = install_claude.ensure_claude()
+
+        assert result is True
+
+    def test_invalid_install_method_defaults_to_auto(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When CLAUDE_INSTALL_METHOD is invalid, falls back to 'auto' with warning."""
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch.object(install_claude, 'get_claude_version', return_value=None),
+            patch.object(
+                install_claude, 'install_claude_native_cross_platform', return_value=True,
+            ),
+            patch.dict('os.environ', {'CLAUDE_INSTALL_METHOD': 'invalid'}, clear=False),
+        ):
+            result = install_claude.ensure_claude()
+
+        assert result is True
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'invalid' in combined.lower(), (
+            'Should warn about invalid install method'
+        )

--- a/tests/e2e/test_root_guard.py
+++ b/tests/e2e/test_root_guard.py
@@ -1,0 +1,236 @@
+"""E2E tests for root detection guard behavior.
+
+Tests verify that:
+- Root detection guard prevents execution as root/sudo
+- CLAUDE_ALLOW_ROOT=1 override works correctly
+- Root guard only activates on Unix platforms (Linux/macOS)
+- Root guard produces correct error messages with actionable guidance
+- Root guard runs before any other setup logic
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from unittest.mock import patch
+
+import pytest
+
+from scripts import install_claude
+from scripts import setup_environment
+
+
+class TestRootGuardInstallClaude:
+    """E2E tests for root guard in install_claude.py main()."""
+
+    def test_root_guard_blocks_root_execution(self) -> None:
+        """Verify main() exits with code 1 when running as root without override."""
+        os.environ.pop('CLAUDE_ALLOW_ROOT', None)
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch('os.geteuid', create=True, return_value=0),
+            patch.dict('os.environ', {}, clear=False),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            install_claude.main()
+
+        assert exc_info.value.code == 1
+
+    def test_root_guard_allows_with_override(self) -> None:
+        """Verify main() proceeds when CLAUDE_ALLOW_ROOT=1 is set."""
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch('os.geteuid', create=True, return_value=0),
+            patch.dict('os.environ', {'CLAUDE_ALLOW_ROOT': '1', 'CLAUDE_INSTALL_METHOD': 'npm'}),
+            patch.object(install_claude, 'ensure_nodejs', return_value=True),
+            patch.object(install_claude, 'ensure_claude', return_value=True), contextlib.suppress(SystemExit),
+        ):
+            install_claude.main()
+
+    def test_root_guard_skipped_on_non_root(self) -> None:
+        """Verify root guard does not trigger for regular users (euid != 0)."""
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch('os.geteuid', create=True, return_value=1000),
+            patch.dict('os.environ', {'CLAUDE_INSTALL_METHOD': 'npm'}),
+            patch.object(install_claude, 'ensure_nodejs', return_value=True),
+            patch.object(install_claude, 'ensure_claude', return_value=True), contextlib.suppress(SystemExit),
+        ):
+            install_claude.main()
+
+    def test_root_guard_error_message_content(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Verify root guard produces informative error message with actionable guidance."""
+        os.environ.pop('CLAUDE_ALLOW_ROOT', None)
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch('os.geteuid', create=True, return_value=0),
+            patch.dict('os.environ', {}, clear=False),
+            pytest.raises(SystemExit),
+        ):
+            install_claude.main()
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'CLAUDE_ALLOW_ROOT' in combined, 'Error message should mention override variable'
+        assert 'root' in combined.lower() or 'sudo' in combined.lower(), \
+            'Error message should mention root/sudo'
+
+    def test_root_guard_activates_on_macos(self) -> None:
+        """Verify root guard also activates on macOS (Darwin)."""
+        os.environ.pop('CLAUDE_ALLOW_ROOT', None)
+        with (
+            patch('platform.system', return_value='Darwin'),
+            patch('os.geteuid', create=True, return_value=0),
+            patch.dict('os.environ', {}, clear=False),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            install_claude.main()
+
+        assert exc_info.value.code == 1
+
+    def test_root_guard_does_not_activate_on_windows(self) -> None:
+        """Verify root guard is not triggered on Windows even with admin rights."""
+        with (
+            patch('platform.system', return_value='Windows'),
+            patch.object(install_claude, 'ensure_git_bash_windows', return_value='C:\\Git\\bash.exe'),
+            patch.object(install_claude, 'ensure_claude', return_value=True),
+            patch.object(install_claude, 'configure_powershell_policy'),
+            patch.object(install_claude, 'update_path'),
+            patch.object(install_claude, 'find_command', return_value=None),
+            patch.object(install_claude, 'set_windows_env_var'),
+            patch.dict('os.environ', {'CLAUDE_INSTALL_METHOD': 'native'}), contextlib.suppress(SystemExit),
+        ):
+            install_claude.main()
+
+    def test_root_guard_with_empty_claude_allow_root(self) -> None:
+        """CLAUDE_ALLOW_ROOT='' (empty string) should NOT bypass root guard."""
+        os.environ.pop('CLAUDE_ALLOW_ROOT', None)
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch('os.geteuid', create=True, return_value=0),
+            patch.dict('os.environ', {'CLAUDE_ALLOW_ROOT': ''}, clear=False),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            install_claude.main()
+
+        assert exc_info.value.code == 1
+
+    def test_root_guard_with_non_one_value(self) -> None:
+        """CLAUDE_ALLOW_ROOT=true (not '1') should NOT bypass root guard."""
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch('os.geteuid', create=True, return_value=0),
+            patch.dict('os.environ', {'CLAUDE_ALLOW_ROOT': 'true'}, clear=False),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            install_claude.main()
+
+        assert exc_info.value.code == 1
+
+
+class TestRootGuardSetupEnvironment:
+    """E2E tests for root guard in setup_environment.py main()."""
+
+    def test_root_guard_blocks_root_execution(self) -> None:
+        """Verify setup_environment main() exits when running as root."""
+        os.environ.pop('CLAUDE_ALLOW_ROOT', None)
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch('os.geteuid', create=True, return_value=0),
+            patch.dict('os.environ', {}, clear=False),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            setup_environment.main()
+
+        assert exc_info.value.code == 1
+
+    def test_root_guard_allows_with_override(self) -> None:
+        """Verify setup_environment proceeds when CLAUDE_ALLOW_ROOT=1 is set."""
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch('os.geteuid', create=True, return_value=0),
+            patch.dict('os.environ', {'CLAUDE_ALLOW_ROOT': '1'}),
+            patch('sys.argv', ['setup_environment.py', 'python']), contextlib.suppress(SystemExit, Exception),
+        ):
+            setup_environment.main()
+
+    def test_root_guard_error_message_content(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Verify setup_environment root guard message contains key information."""
+        os.environ.pop('CLAUDE_ALLOW_ROOT', None)
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch('os.geteuid', create=True, return_value=0),
+            patch.dict('os.environ', {}, clear=False),
+            pytest.raises(SystemExit),
+        ):
+            setup_environment.main()
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert 'CLAUDE_ALLOW_ROOT' in combined, 'Should mention override variable'
+        assert 'root' in combined.lower() or 'sudo' in combined.lower()
+
+    def test_root_guard_activates_on_macos(self) -> None:
+        """Verify root guard on macOS for setup_environment."""
+        os.environ.pop('CLAUDE_ALLOW_ROOT', None)
+        with (
+            patch('platform.system', return_value='Darwin'),
+            patch('os.geteuid', create=True, return_value=0),
+            patch.dict('os.environ', {}, clear=False),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            setup_environment.main()
+
+        assert exc_info.value.code == 1
+
+    def test_root_guard_runs_before_argument_parsing(self) -> None:
+        """Verify root guard triggers even without valid CLI arguments.
+
+        The root guard MUST run before argparse to catch all invocations.
+        """
+        os.environ.pop('CLAUDE_ALLOW_ROOT', None)
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch('os.geteuid', create=True, return_value=0),
+            patch.dict('os.environ', {}, clear=False),
+            patch('sys.argv', ['setup_environment.py']),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            setup_environment.main()
+
+        # Should exit from root guard (code 1), NOT from argparse error (code 2)
+        assert exc_info.value.code == 1
+
+    def test_root_guard_skipped_on_windows(self) -> None:
+        """Verify Windows admin handling is separate from root guard."""
+        with (
+            patch('platform.system', return_value='Windows'),
+            patch.object(setup_environment, 'is_admin', return_value=False),
+            patch('sys.argv', ['setup_environment.py', 'python']), contextlib.suppress(SystemExit, Exception),
+        ):
+            setup_environment.main()
+
+    def test_root_guard_with_empty_claude_allow_root(self) -> None:
+        """CLAUDE_ALLOW_ROOT='' should NOT bypass root guard in setup_environment."""
+        os.environ.pop('CLAUDE_ALLOW_ROOT', None)
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch('os.geteuid', create=True, return_value=0),
+            patch.dict('os.environ', {'CLAUDE_ALLOW_ROOT': ''}, clear=False),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            setup_environment.main()
+
+        assert exc_info.value.code == 1
+
+    def test_root_guard_with_non_one_value(self) -> None:
+        """CLAUDE_ALLOW_ROOT=yes should NOT bypass root guard in setup_environment."""
+        with (
+            patch('platform.system', return_value='Linux'),
+            patch('os.geteuid', create=True, return_value=0),
+            patch.dict('os.environ', {'CLAUDE_ALLOW_ROOT': 'yes'}, clear=False),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            setup_environment.main()
+
+        assert exc_info.value.code == 1


### PR DESCRIPTION
Implement comprehensive Linux EACCES permission fix and root environment protection across all installation entry points. Add TTY-aware sudo handling, native installer diagnostics, and enhanced error messaging.

Production changes:
- Add root detection guard (EUID=0 check) to all 6 entry points (4 shell scripts + 2 Python scripts)
- Implement CLAUDE_ALLOW_ROOT=1 override for containerized environments
- Add TTY-aware sudo guidance in npm fallback flow
- Enhance native installer diagnostics with stderr capture and exit code logging
- Fix Windows PATH length issue with graceful degradation (32767 char limit)
- Improve error messaging on total installation failure

Test coverage:
- Add 43 new E2E tests across 2 new test files (test_root_guard.py: 16 tests, test_npm_fallback.py: 27 tests)
- Extend unit tests in 4 existing test files

Documentation:
- Update CLAUDE.md with CLAUDE_ALLOW_ROOT environment variable and root guard documentation
- Update README.md with root guard notes and troubleshooting guidance