### PR TITLE
Add Node.js version check fixes for native Claude Code installation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,34 @@ In `auto` mode, both `native` and `unknown` sources attempt the native installer
 - More reliable auto-updates via official Anthropic installers
 - Maintains full backward compatibility with existing npm installations
 
+### Node.js Compatibility Check Parameter
+
+The `ensure_nodejs()` function accepts a `check_claude_compat` parameter:
+
+| Parameter                   | Default | Behavior                                                             |
+|-----------------------------|---------|----------------------------------------------------------------------|
+| `check_claude_compat=True`  | Yes     | Checks Node.js v25+ SlowBuffer incompatibility (for npm Claude Code) |
+| `check_claude_compat=False` | No      | Only checks minimum version >= 18.0.0 (for general-purpose Node.js)  |
+
+**Usage contexts:**
+- `install_claude.py` main() calls `ensure_nodejs()` (default `True`) -- Claude Code npm runtime needs compatible Node.js
+- `setup_environment.py` `install_nodejs_if_requested()` calls `ensure_nodejs(check_claude_compat=False)` -- `install-nodejs: true` config needs Node.js for general purposes (MCP servers, npx tools), not for Claude Code itself
+
+### Version-Aware Compatibility
+
+The `check_nodejs_compatibility()` function supports version-aware checking via the `CLAUDE_NPM_SLOWBUFFER_FIXED_VERSION` constant:
+
+| Constant Value | Behavior                                                                           |
+|----------------|------------------------------------------------------------------------------------|
+| `None`         | Node.js v25+ is always rejected for npm Claude Code (current default)              |
+| Version string | Node.js v25+ is accepted if installed Claude Code npm version >= the fixed version |
+
+The check works as follows:
+- When Claude Code is installed, `get_claude_version()` detects the installed version
+- If `CLAUDE_NPM_SLOWBUFFER_FIXED_VERSION` is set and the installed version meets the threshold, v25+ is accepted
+- If the installed version is unknown or below the threshold, v25+ is rejected (conservative default)
+- Monitor [GitHub issue #9628](https://github.com/anthropics/claude-code/issues/9628) for when this gets fixed
+
 ### Root Detection Guard
 
 All Linux and macOS scripts (both bash bootstrap scripts and Python entry points) refuse to run as root/sudo by default:

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -3477,7 +3477,9 @@ def install_nodejs_if_requested(config: dict[str, Any]) -> bool:
     # Late import to avoid circular dependency (install_claude imports from setup_environment)
     from install_claude import ensure_nodejs as _ensure_nodejs
 
-    if not _ensure_nodejs():
+    # Node.js is needed for general purposes (e.g., npx MCP servers),
+    # not for Claude Code's npm package itself.
+    if not _ensure_nodejs(check_claude_compat=False):
         error('Node.js installation failed')
         return False
 

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -1962,12 +1962,12 @@ class TestInstallNodejsIfRequested:
 
     @patch('install_claude.ensure_nodejs')
     def test_true_calls_ensure_nodejs(self, mock_ensure):
-        """Test that function calls ensure_nodejs when install-nodejs is True."""
+        """Test that function calls ensure_nodejs with check_claude_compat=False."""
         mock_ensure.return_value = True
         config = {'install-nodejs': True}
         result = setup_environment.install_nodejs_if_requested(config)
         assert result is True
-        mock_ensure.assert_called_once()
+        mock_ensure.assert_called_once_with(check_claude_compat=False)
 
     @patch('install_claude.ensure_nodejs')
     def test_installation_failure_returns_false(self, mock_ensure):
@@ -1998,6 +1998,16 @@ class TestInstallNodejsIfRequested:
         config = {'install-nodejs': True}
         setup_environment.install_nodejs_if_requested(config)
         mock_refresh.assert_not_called()
+
+    @patch('install_claude.ensure_nodejs')
+    def test_nodejs_v25_accepted_via_install_nodejs_flag(self, mock_ensure):
+        """Node.js v25 is accepted when install-nodejs: true (general purpose)."""
+        mock_ensure.return_value = True
+        config = {'install-nodejs': True}
+        result = setup_environment.install_nodejs_if_requested(config)
+        assert result is True
+        # Verify check_claude_compat=False was passed (v25 would be accepted)
+        mock_ensure.assert_called_once_with(check_claude_compat=False)
 
 
 class TestFetchUrlWithAuth:


### PR DESCRIPTION
Implements 4-phase solution to fix Node.js v25+ compatibility checking:

Phase 1: Add check_claude_compat parameter to ensure_nodejs()
- Add optional parameter to skip v25+ check for general-purpose Node.js
- Pass check_claude_compat=False in install_nodejs_if_requested()
- Fixes architectural defect where native installation was blocked by v25+

Phase 2: Fix Homebrew to install LTS version
- Change brew install node to node@22 (LTS)
- Add brew link --force --overwrite for keg-only formula
- Ensure macOS installs compatible Node.js version

Phase 3: Add post-install compatibility check
- Add _verify_nodejs_version() helper for consistent validation
- Apply check_nodejs_compatibility() to freshly installed Node.js
- Fix asymmetry between pre-existing and post-install checks

Phase 4: Add version-aware compatibility checking
- Add CLAUDE_NPM_SLOWBUFFER_FIXED_VERSION constant (initially None)
- Modify check_nodejs_compatibility() to accept claude_code_version
- Wire up get_claude_version() in ensure_nodejs() and _verify_nodejs_version()
- Future-proof for when Anthropic fixes SlowBuffer issue (#9628)