### PR TITLE
Add effortLevel support to environment configurations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ The golden config includes:
 - Hooks: `hooks` (files and events with command/prompt types)
 - MCP Servers: `mcp-servers` (http, sse, stdio transports)
 - Settings: `model`, `permissions`, `env-variables`, `os-env-variables`
-- Advanced: `command-defaults`, `user-settings`, `always-thinking-enabled`
+- Advanced: `command-defaults`, `user-settings`, `always-thinking-enabled`, `effort-level`
 - Extras: `company-announcements`, `attribution`, `status-line`
 
 #### Key Design Principles

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -84,6 +84,7 @@ ROOT_TO_USER_SETTINGS_KEY_MAP: dict[str, str] = {
     'always-thinking-enabled': 'alwaysThinkingEnabled',
     'company-announcements': 'companyAnnouncements',
     'env-variables': 'env',                     # Different names
+    'effort-level': 'effortLevel',              # Adaptive reasoning effort
 }
 
 
@@ -5050,6 +5051,7 @@ def create_additional_settings(
     company_announcements: list[str] | None = None,
     attribution: dict[str, str] | None = None,
     status_line: dict[str, Any] | None = None,
+    effort_level: str | None = None,
 ) -> bool:
     """Create {command_name}-additional-settings.json with environment-specific settings.
 
@@ -5073,6 +5075,9 @@ def create_additional_settings(
             'padding' key, and optional 'config' key for config file reference.
             Both the script and config file are downloaded to ~/.claude/hooks/ and
             the config path is appended as a command line argument.
+        effort_level: Optional effort level for adaptive reasoning.
+            Valid values: 'low', 'medium', 'high'. Controls how much thinking
+            is allocated based on task complexity.
 
     Returns:
         bool: True if successful, False otherwise.
@@ -5129,6 +5134,11 @@ def create_additional_settings(
     if always_thinking_enabled is not None:
         settings['alwaysThinkingEnabled'] = always_thinking_enabled
         info(f'Setting alwaysThinkingEnabled: {always_thinking_enabled}')
+
+    # Add effortLevel if explicitly set (None means not configured, leave as default)
+    if effort_level is not None:
+        settings['effortLevel'] = effort_level
+        info(f'Setting effortLevel: {effort_level}')
 
     # Add companyAnnouncements if explicitly set (None means not configured, leave as default)
     if company_announcements is not None:
@@ -6244,6 +6254,17 @@ def main() -> None:
         # Extract status_line configuration
         status_line = config.get('status-line')
 
+        # Extract and validate effort_level configuration
+        effort_level = config.get('effort-level')
+        if effort_level is not None:
+            valid_effort_levels = ('low', 'medium', 'high')
+            if effort_level not in valid_effort_levels:
+                warning(
+                    f'Invalid effort-level value: {effort_level!r}. '
+                    f'Valid values: {", ".join(valid_effort_levels)}. Skipping.',
+                )
+                effort_level = None
+
         # Extract user-settings configuration (global user-level settings)
         user_settings = config.get('user-settings')
 
@@ -6501,6 +6522,7 @@ def main() -> None:
                 company_announcements,
                 attribution,
                 status_line_arg,
+                effort_level,
             )
 
             # Step 15: Create launcher script
@@ -6613,6 +6635,8 @@ def main() -> None:
             print(f'   * Environment variables: {len(env_variables)} configured')
         if company_announcements:
             print(f'   * Company announcements: {len(company_announcements)} configured')
+        if effort_level:
+            print(f'   * Effort level: {effort_level}')
         if status_line and isinstance(status_line, dict):
             status_line_dict = cast(dict[str, Any], status_line)
             status_line_file_val = status_line_dict.get('file', '')

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -161,6 +161,7 @@ def golden_config() -> dict[str, Any]:
     - command-defaults: System prompt and mode
     - user-settings: User settings to merge
     - always-thinking-enabled: Thinking mode flag
+    - effort-level: Adaptive reasoning effort level
     - company-announcements: Announcement messages
     - attribution: Commit and PR attribution settings
     - status-line: Status line configuration

--- a/tests/e2e/expected/common.py
+++ b/tests/e2e/expected/common.py
@@ -30,6 +30,7 @@ EXPECTED_JSON_KEYS: Final[dict[str, list[str]]] = {
         'companyAnnouncements',
         'attribution',
         'statusLine',
+        'effortLevel',
     ],
     'mcp-config': [
         'mcpServers',

--- a/tests/e2e/golden_config.yaml
+++ b/tests/e2e/golden_config.yaml
@@ -176,6 +176,9 @@ user-settings:
 # Always-thinking mode
 always-thinking-enabled: true
 
+# Effort level for adaptive reasoning
+effort-level: "low"
+
 # Company announcements
 company-announcements:
   - "Welcome to E2E Testing Environment"

--- a/tests/e2e/test_full_setup.py
+++ b/tests/e2e/test_full_setup.py
@@ -97,6 +97,7 @@ class TestE2EFullSetup:
             company_announcements=golden_config.get('company-announcements'),
             attribution=golden_config.get('attribution'),
             status_line=golden_config.get('status-line'),
+            effort_level=golden_config.get('effort-level'),
         )
 
         # Create MCP config file (use configure_all_mcp_servers to get profile servers)
@@ -168,6 +169,7 @@ class TestE2EFullSetup:
             company_announcements=golden_config.get('company-announcements'),
             attribution=golden_config.get('attribution'),
             status_line=golden_config.get('status-line'),
+            effort_level=golden_config.get('effort-level'),
         )
 
         # Verify additional-settings file exists (written to claude_user_dir)

--- a/tests/e2e/test_javascript_hooks.py
+++ b/tests/e2e/test_javascript_hooks.py
@@ -42,6 +42,7 @@ class TestJavaScriptHooks:
             company_announcements=None,
             attribution=None,
             status_line=None,
+            effort_level=None,
         )
 
         settings_path = claude_dir / f'{cmd}-additional-settings.json'
@@ -89,6 +90,7 @@ class TestJavaScriptHooks:
             company_announcements=None,
             attribution=None,
             status_line=None,
+            effort_level=None,
         )
 
         settings_path = claude_dir / f'{cmd}-additional-settings.json'
@@ -131,6 +133,7 @@ class TestJavaScriptHooks:
             company_announcements=None,
             attribution=None,
             status_line=None,
+            effort_level=None,
         )
 
         settings_path = claude_dir / f'{cmd}-additional-settings.json'
@@ -173,6 +176,7 @@ class TestJavaScriptHooks:
             company_announcements=None,
             attribution=None,
             status_line=None,
+            effort_level=None,
         )
 
         settings_path = claude_dir / f'{cmd}-additional-settings.json'
@@ -227,6 +231,7 @@ class TestJavaScriptHooks:
             company_announcements=None,
             attribution=None,
             status_line=None,
+            effort_level=None,
         )
 
         settings_path = claude_dir / f'{cmd}-additional-settings.json'
@@ -282,6 +287,7 @@ class TestJavaScriptHooks:
             company_announcements=None,
             attribution=None,
             status_line=None,
+            effort_level=None,
         )
 
         settings_path = claude_dir / f'{cmd}-additional-settings.json'

--- a/tests/e2e/test_output_files.py
+++ b/tests/e2e/test_output_files.py
@@ -53,6 +53,7 @@ class TestOutputFiles:
             company_announcements=golden_config.get('company-announcements'),
             attribution=golden_config.get('attribution'),
             status_line=golden_config.get('status-line'),
+            effort_level=golden_config.get('effort-level'),
         )
 
         # File is written to claude_user_dir (= claude_dir)
@@ -88,6 +89,7 @@ class TestOutputFiles:
             company_announcements=golden_config.get('company-announcements'),
             attribution=golden_config.get('attribution'),
             status_line=golden_config.get('status-line'),
+            effort_level=golden_config.get('effort-level'),
         )
 
         # File is written to claude_user_dir (= claude_dir)
@@ -211,6 +213,7 @@ class TestOutputFiles:
             company_announcements=None,
             attribution=None,
             status_line=None,
+            effort_level=None,
         )
 
         # File is written to claude_user_dir (= claude_dir)

--- a/tests/e2e/test_path_handling.py
+++ b/tests/e2e/test_path_handling.py
@@ -112,6 +112,7 @@ class TestTildeExpansion:
             company_announcements=golden_config.get('company-announcements'),
             attribution=golden_config.get('attribution'),
             status_line=golden_config.get('status-line'),
+            effort_level=golden_config.get('effort-level'),
         )
 
         # File is written to claude_user_dir (= claude_dir)
@@ -237,6 +238,7 @@ class TestTildeExpansion:
             company_announcements=None,
             attribution=None,
             status_line=None,
+            effort_level=None,
         )
 
         # File is written to claude_user_dir (= claude_dir)
@@ -293,6 +295,7 @@ class TestTildeExpansion:
             company_announcements=None,
             attribution=None,
             status_line=status_line_config,
+            effort_level=None,
         )
 
         # File is written to claude_user_dir (= claude_dir)

--- a/tests/e2e/test_path_normalization.py
+++ b/tests/e2e/test_path_normalization.py
@@ -297,6 +297,7 @@ class TestPathSeparatorConsistency:
             company_announcements=None,
             attribution=None,
             status_line=None,
+            effort_level=None,
         )
 
         settings_path = claude_dir / f'{cmd}-additional-settings.json'
@@ -361,6 +362,7 @@ class TestPathSeparatorConsistency:
             company_announcements=None,
             attribution=None,
             status_line=status_line_config,
+            effort_level=None,
         )
 
         settings_path = claude_dir / f'{cmd}-additional-settings.json'
@@ -411,6 +413,7 @@ class TestPathSeparatorConsistency:
             company_announcements=golden_config.get('company-announcements'),
             attribution=golden_config.get('attribution'),
             status_line=golden_config.get('status-line'),
+            effort_level=golden_config.get('effort-level'),
         )
 
         settings_path = claude_dir / f'{cmd}-additional-settings.json'

--- a/tests/e2e/validators.py
+++ b/tests/e2e/validators.py
@@ -300,6 +300,7 @@ def validate_additional_settings(path: Path, config: dict[str, Any]) -> list[str
     - Hooks structure is correct if present
     - Environment variables are present
     - alwaysThinkingEnabled matches config if specified
+    - effortLevel matches config if specified
     - companyAnnouncements are present if specified
     - statusLine structure is correct if specified
 
@@ -358,6 +359,15 @@ def validate_additional_settings(path: Path, config: dict[str, Any]) -> list[str
         if actual != expected:
             errors.append(
                 f'alwaysThinkingEnabled: expected {expected!r}, got {actual!r}',
+            )
+
+    # effortLevel
+    if 'effort-level' in config:
+        expected = config['effort-level']
+        actual = data.get('effortLevel')
+        if actual != expected:
+            errors.append(
+                f'effortLevel: expected {expected!r}, got {actual!r}',
             )
 
     # companyAnnouncements

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -3305,6 +3305,81 @@ class TestCreateAdditionalSettings:
 
             assert 'alwaysThinkingEnabled' not in settings
 
+    def test_create_additional_settings_effort_level_low(self):
+        """Test effortLevel set to low."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            claude_dir = Path(tmpdir)
+
+            result = setup_environment.create_additional_settings(
+                {},
+                claude_dir,
+                'test-env',
+                effort_level='low',
+            )
+
+            assert result is True
+            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings = json.loads(settings_file.read_text())
+
+            assert 'effortLevel' in settings
+            assert settings['effortLevel'] == 'low'
+
+    def test_create_additional_settings_effort_level_medium(self):
+        """Test effortLevel set to medium."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            claude_dir = Path(tmpdir)
+
+            result = setup_environment.create_additional_settings(
+                {},
+                claude_dir,
+                'test-env',
+                effort_level='medium',
+            )
+
+            assert result is True
+            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings = json.loads(settings_file.read_text())
+
+            assert 'effortLevel' in settings
+            assert settings['effortLevel'] == 'medium'
+
+    def test_create_additional_settings_effort_level_high(self):
+        """Test effortLevel set to high."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            claude_dir = Path(tmpdir)
+
+            result = setup_environment.create_additional_settings(
+                {},
+                claude_dir,
+                'test-env',
+                effort_level='high',
+            )
+
+            assert result is True
+            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings = json.loads(settings_file.read_text())
+
+            assert 'effortLevel' in settings
+            assert settings['effortLevel'] == 'high'
+
+    def test_create_additional_settings_effort_level_none_not_included(self):
+        """Test effortLevel not included when None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            claude_dir = Path(tmpdir)
+
+            result = setup_environment.create_additional_settings(
+                {},
+                claude_dir,
+                'test-env',
+                effort_level=None,
+            )
+
+            assert result is True
+            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings = json.loads(settings_file.read_text())
+
+            assert 'effortLevel' not in settings
+
     def test_create_additional_settings_company_announcements(self):
         """Test companyAnnouncements set with multiple items."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -4086,6 +4161,67 @@ class TestMainFunction:
         ):
             setup_environment.main()
             mock_exit.assert_not_called()
+
+    @patch('setup_environment.load_config_from_source')
+    @patch('setup_environment.validate_all_config_files')
+    @patch('setup_environment.install_claude')
+    @patch('setup_environment.install_dependencies')
+    @patch('setup_environment.process_resources')
+    @patch('setup_environment.process_skills')
+    @patch('setup_environment.configure_all_mcp_servers')
+    @patch('setup_environment.create_additional_settings')
+    @patch('setup_environment.create_launcher_script')
+    @patch('setup_environment.register_global_command')
+    @patch('setup_environment.is_admin', return_value=True)
+    @patch('pathlib.Path.mkdir')
+    def test_main_invalid_effort_level_warns_and_skips(
+        self,
+        mock_mkdir: MagicMock,
+        mock_is_admin: MagicMock,
+        mock_register: MagicMock,
+        mock_launcher: MagicMock,
+        mock_settings: MagicMock,
+        mock_mcp: MagicMock,
+        mock_skills: MagicMock,
+        mock_resources: MagicMock,
+        mock_deps: MagicMock,
+        mock_install: MagicMock,
+        mock_validate: MagicMock,
+        mock_load: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """main() warns and skips invalid effort-level value (non-fatal)."""
+        # Mocks required by @patch decorators but not directly asserted
+        del mock_mkdir, mock_is_admin, mock_skills, mock_resources, mock_deps
+        mock_load.return_value = (
+            {
+                'name': 'Effort Level Test',
+                'command-names': ['test-cmd'],
+                'effort-level': 'extreme',  # Invalid value
+            },
+            'test.yaml',
+        )
+        mock_validate.return_value = (True, [])
+        mock_install.return_value = True
+        mock_mcp.return_value = (True, [], {'global_count': 0, 'profile_count': 0, 'combined_count': 0})
+        mock_settings.return_value = True
+        mock_launcher.return_value = Path('/tmp/launcher.sh')
+        mock_register.return_value = True
+
+        with patch('sys.argv', ['setup_environment.py', 'test']), patch('sys.exit') as mock_exit:
+            setup_environment.main()
+            mock_exit.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert 'Invalid effort-level value' in captured.out
+        assert "'extreme'" in captured.out
+
+        # Verify create_additional_settings was called with effort_level=None
+        # (the invalid value should have been reset to None)
+        mock_settings.assert_called_once()
+        call_args = mock_settings.call_args
+        # effort_level is the 12th positional argument (0-indexed: position 11)
+        assert call_args[0][11] is None
 
 
 class TestDownloadFailureTracking:
@@ -5423,6 +5559,14 @@ class TestDetectSettingsConflicts:
         result = setup_environment.detect_settings_conflicts(user_settings, root_config)
         assert len(result) == 1
         assert result[0] == ('env', {'FOO': 'bar'}, {'FOO': 'baz'})
+
+    def test_effort_level_mapping_conflict(self) -> None:
+        """effort-level root key maps to effortLevel user-settings key."""
+        user_settings = {'effortLevel': 'high'}
+        root_config = {'effort-level': 'low'}
+        result = setup_environment.detect_settings_conflicts(user_settings, root_config)
+        assert len(result) == 1
+        assert result[0] == ('effortLevel', 'high', 'low')
 
     def test_multiple_conflicts_detected(self) -> None:
         """Multiple conflicts are all detected."""
@@ -7193,6 +7337,7 @@ class TestDetectSettingsConflictsComplete:
             ('always-thinking-enabled', 'alwaysThinkingEnabled'),
             ('company-announcements', 'companyAnnouncements'),
             ('env-variables', 'env'),
+            ('effort-level', 'effortLevel'),
         ],
     )
     def test_conflict_all_mapped_keys_exhaustive(


### PR DESCRIPTION
Add effort-level YAML config key mapping to effortLevel in additional-settings.json. Supports "low", "medium", and "high" values per Claude Code model configuration docs.

- Add effort-level to ROOT_TO_USER_SETTINGS_KEY_MAP for conflict detection
- Add effort_level parameter to create_additional_settings()
- Add extraction, validation, and non-fatal warning in main()
- Add effort_level to main() call site as 12th positional arg
- Add summary output for effort level configuration
- Update golden config, expected keys, and validators for E2E tests
- Update all 17 E2E call sites with effort_level parameter
- Add 4 unit tests for create_additional_settings effort_level values
- Add invalid effort-level validation test in TestMainFunction
- Add parametrized and standalone conflict detection tests
- Update conftest.py docstring and CLAUDE.md documentation