### PR TITLE
Replace broken backoff with linear additive strategy and cross-thread coordination

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -433,14 +433,16 @@ This pattern is applied consistently to both npm install and npm uninstall opera
 
 ### Download Retry Configuration
 
-The setup scripts include robust retry logic for handling GitHub API rate limiting during file downloads:
+The setup scripts include robust retry logic for handling GitHub API rate limiting:
 
-- **Retry attempts:** 10 (with exponential backoff)
-- **Initial delay:** 2 seconds, doubling each retry
-- **Maximum delay cap:** 60 seconds per retry
-- **Jitter:** Random 0-25% added to prevent synchronized retries
+- **Retry attempts:** 10 (with linear additive backoff)
+- **Base delay:** 1 second for the first retry
+- **Additive increment:** +2 seconds per subsequent attempt (sequence: 1s, 3s, 5s, 7s, ...)
+- **Maximum delay cap:** 60 seconds per retry (before jitter)
+- **Jitter:** Random 0-25% added to all retries to prevent synchronized requests
 - **Stagger delay:** 0.5 second delay between launching concurrent download threads
-- **Total worst-case wait:** ~6 minutes per file (covers extended rate limit windows)
+- **Cross-thread coordination:** `RateLimitCoordinator` shares rate-limit state across threads
+- **Header respect:** `Retry-After` and `x-ratelimit-reset` headers used as minimum floor
 
 ### Hooks Configuration Structure
 

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -16,6 +16,7 @@ import glob as glob_module
 import json
 import os
 import platform
+import random
 import re
 import shlex
 import shutil
@@ -23,6 +24,7 @@ import ssl
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import urllib.error
 import urllib.parse
@@ -3619,35 +3621,80 @@ def install_dependencies(dependencies: dict[str, list[str]] | None) -> bool:
     return True
 
 
+class RateLimitCoordinator:
+    """Thread-safe coordinator for cross-thread rate-limit state.
+
+    Maintains a global earliest-retry-time that any thread can update
+    when receiving a rate-limit response. Uses time.monotonic() for
+    clock-jump immunity.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._earliest_retry_time: float = 0.0
+
+    def report_rate_limit(self, wait_seconds: float) -> None:
+        """Update global rate-limit floor.
+
+        Args:
+            wait_seconds: Duration in seconds to wait from now.
+        """
+        with self._lock:
+            new_earliest = time.monotonic() + wait_seconds
+            self._earliest_retry_time = max(self._earliest_retry_time, new_earliest)
+
+    def get_wait_time(self) -> float:
+        """Return seconds to wait before next request.
+
+        Returns:
+            Non-negative float: remaining wait time.
+        """
+        with self._lock:
+            remaining = self._earliest_retry_time - time.monotonic()
+            return max(0.0, remaining)
+
+
 def fetch_with_retry[T](
     request_func: Callable[[], T],
     url: str,
     max_retries: int = 10,
-    initial_backoff: float = 2.0,
+    base_delay: float = 1.0,
+    additive_increment: float = 2.0,
+    max_delay: float = 60.0,
+    rate_limiter: RateLimitCoordinator | None = None,
 ) -> T:
     """Execute a fetch operation with retry logic for rate limiting.
 
-    Implements exponential backoff with jitter as recommended by GitHub API documentation.
-    Respects Retry-After and x-ratelimit-reset headers when available.
+    Implements linear additive backoff with jitter. Respects Retry-After and
+    x-ratelimit-reset headers as a minimum floor (never overrides a larger
+    calculated backoff). A shared RateLimitCoordinator propagates rate-limit
+    state across concurrent download threads.
 
     Args:
-        request_func: Function that performs the actual request and returns result
-        url: URL being fetched (for logging purposes)
-        max_retries: Maximum number of retry attempts (default: 10)
-        initial_backoff: Initial backoff time in seconds (default: 2.0)
+        request_func: Function that performs the actual request and returns result.
+        url: URL being fetched (for logging purposes).
+        max_retries: Maximum number of retry attempts (default: 10).
+        base_delay: Base delay in seconds for the first retry (default: 1.0).
+        additive_increment: Seconds added per subsequent attempt (default: 2.0).
+        max_delay: Maximum delay cap in seconds before jitter (default: 60.0).
+        rate_limiter: Optional coordinator sharing rate-limit state across threads.
 
     Returns:
-        Result from request_func
+        Result from request_func.
 
     Raises:
-        HTTPError: If all retry attempts fail
-        RuntimeError: If an unexpected state is reached (should never occur)
+        HTTPError: If all retry attempts fail.
+        RuntimeError: If an unexpected state is reached (should never occur).
     """
-    import random
-
     last_exception: urllib.error.HTTPError | None = None
 
     for attempt in range(max_retries + 1):
+        # Respect cross-thread rate-limit floor before each request
+        if rate_limiter is not None:
+            coord_wait = rate_limiter.get_wait_time()
+            if coord_wait > 0:
+                time.sleep(coord_wait)
+
         try:
             return request_func()
         except urllib.error.HTTPError as e:
@@ -3663,19 +3710,30 @@ def fetch_with_retry[T](
                     raise
 
                 if attempt < max_retries:
-                    # Calculate wait time
-                    if retry_after:
-                        wait_time = float(retry_after)
-                    elif reset_time:
-                        wait_time = max(0, int(reset_time) - int(time.time()))
-                    else:
-                        # Exponential backoff with jitter
-                        wait_time = initial_backoff * (2**attempt)
-                        # Add jitter (0-25% of wait time)
-                        wait_time += random.uniform(0, wait_time * 0.25)
+                    # Per-thread linear additive backoff
+                    per_thread_delay = base_delay + (attempt * additive_increment)
 
-                    # Cap wait time at 60 seconds
-                    wait_time = min(wait_time, 60)
+                    # Parse header value as floor (not override)
+                    header_wait: float | None = None
+                    if retry_after:
+                        with contextlib.suppress(ValueError):
+                            header_wait = float(retry_after)
+                    elif reset_time:
+                        with contextlib.suppress(ValueError):
+                            header_wait = max(0.0, int(reset_time) - time.time())
+
+                    # Header is a floor: use the larger of header and calculated backoff
+                    wait_time = max(header_wait, per_thread_delay) if header_wait is not None else per_thread_delay
+
+                    # Cap before jitter
+                    wait_time = min(wait_time, max_delay)
+
+                    # Add jitter to all retries (0-25% of wait time)
+                    wait_time += random.uniform(0, wait_time * 0.25)
+
+                    # Report to coordinator so other threads respect this floor
+                    if rate_limiter is not None:
+                        rate_limiter.report_rate_limit(wait_time)
 
                     filename = url.split('/')[-1].split('?')[0]
                     info(f'Rate limited, retrying {filename} in {wait_time:.1f}s (attempt {attempt + 1}/{max_retries})')
@@ -3693,10 +3751,15 @@ def fetch_with_retry[T](
     raise RuntimeError(msg)
 
 
-def fetch_url_with_auth(url: str, auth_headers: dict[str, str] | None = None, auth_param: str | None = None) -> str:
+def fetch_url_with_auth(
+    url: str,
+    auth_headers: dict[str, str] | None = None,
+    auth_param: str | None = None,
+    rate_limiter: RateLimitCoordinator | None = None,
+) -> str:
     """Fetch URL content, trying without auth first, then with auth if needed.
 
-    Includes retry logic with exponential backoff for rate limiting (HTTP 429).
+    Includes retry logic with linear additive backoff for rate limiting (HTTP 429).
     May raise HTTPError if the request fails after authentication and retry attempts,
     or URLError if there's a network error (including SSL issues).
 
@@ -3704,6 +3767,7 @@ def fetch_url_with_auth(url: str, auth_headers: dict[str, str] | None = None, au
         url: URL to fetch
         auth_headers: Optional pre-computed auth headers
         auth_param: Optional auth parameter for getting headers
+        rate_limiter: Optional coordinator sharing rate-limit state across threads
 
     Returns:
         str: Content of the URL
@@ -3726,12 +3790,31 @@ def fetch_url_with_auth(url: str, auth_headers: dict[str, str] | None = None, au
 
     def _do_fetch() -> str:
         """Internal fetch logic wrapped for retry."""
-        # First try without auth (for public repos)
+        # Skip unauthenticated attempt when auth headers are already known
+        if auth_state['headers']:
+            try:
+                request = Request(url)
+                for header, value in auth_state['headers'].items():
+                    request.add_header(header, value)
+                return str(urlopen(request).read().decode('utf-8'))
+            except urllib.error.URLError as e:
+                if 'SSL' in str(e) or 'certificate' in str(e).lower():
+                    warning('SSL certificate verification failed, trying with unverified context')
+                    ctx = ssl.create_default_context()
+                    ctx.check_hostname = False
+                    ctx.verify_mode = ssl.CERT_NONE
+
+                    request = Request(url)
+                    for header, value in auth_state['headers'].items():
+                        request.add_header(header, value)
+                    return str(urlopen(request, context=ctx).read().decode('utf-8'))
+                raise
+
+        # Try without auth first (for public repos)
         try:
             request = Request(url)
             response = urlopen(request)
-            content: str = response.read().decode('utf-8')
-            return content
+            return str(response.read().decode('utf-8'))
         except urllib.error.HTTPError as e:
             if e.code in (401, 403, 404):
                 # Authentication might be needed
@@ -3784,19 +3867,20 @@ def fetch_url_with_auth(url: str, auth_headers: dict[str, str] | None = None, au
             raise
 
     # Wrap with retry logic for rate limiting
-    return fetch_with_retry(_do_fetch, url)
+    return fetch_with_retry(_do_fetch, url, rate_limiter=rate_limiter)
 
 
 def fetch_url_bytes_with_auth(
     url: str,
     auth_headers: dict[str, str] | None = None,
     auth_param: str | None = None,
+    rate_limiter: RateLimitCoordinator | None = None,
 ) -> bytes:
     """Fetch URL content as bytes, trying without auth first, then with auth if needed.
 
     Similar to fetch_url_with_auth but returns raw bytes without decoding.
     Use this for binary files like .tar.gz, .zip, images, etc.
-    Includes retry logic with exponential backoff for rate limiting (HTTP 429).
+    Includes retry logic with linear additive backoff for rate limiting (HTTP 429).
     May raise HTTPError if the request fails after authentication and retry attempts,
     or URLError if there's a network error (including SSL issues).
 
@@ -3804,6 +3888,7 @@ def fetch_url_bytes_with_auth(
         url: URL to fetch
         auth_headers: Optional pre-computed auth headers
         auth_param: Optional auth parameter for getting headers
+        rate_limiter: Optional coordinator sharing rate-limit state across threads
 
     Returns:
         bytes: Raw content of the URL
@@ -3826,12 +3911,31 @@ def fetch_url_bytes_with_auth(
 
     def _do_fetch() -> bytes:
         """Internal fetch logic wrapped for retry."""
-        # First try without auth (for public repos)
+        # Skip unauthenticated attempt when auth headers are already known
+        if auth_state['headers']:
+            try:
+                request = Request(url)
+                for header, value in auth_state['headers'].items():
+                    request.add_header(header, value)
+                return bytes(urlopen(request).read())
+            except urllib.error.URLError as e:
+                if 'SSL' in str(e) or 'certificate' in str(e).lower():
+                    warning('SSL certificate verification failed, trying with unverified context')
+                    ctx = ssl.create_default_context()
+                    ctx.check_hostname = False
+                    ctx.verify_mode = ssl.CERT_NONE
+
+                    request = Request(url)
+                    for header, value in auth_state['headers'].items():
+                        request.add_header(header, value)
+                    return bytes(urlopen(request, context=ctx).read())
+                raise
+
+        # Try without auth first (for public repos)
         try:
             request = Request(url)
             response = urlopen(request)
-            content: bytes = response.read()
-            return content
+            return bytes(response.read())
         except urllib.error.HTTPError as e:
             if e.code in (401, 403, 404):
                 # Authentication might be needed
@@ -3880,7 +3984,7 @@ def fetch_url_bytes_with_auth(
             raise
 
     # Wrap with retry logic for rate limiting
-    return fetch_with_retry(_do_fetch, url)
+    return fetch_with_retry(_do_fetch, url, rate_limiter=rate_limiter)
 
 
 def extract_front_matter(file_path: Path) -> dict[str, Any] | None:
@@ -3927,6 +4031,7 @@ def handle_resource(
     config_source: str,
     base_url: str | None = None,
     auth_param: str | None = None,
+    rate_limiter: RateLimitCoordinator | None = None,
 ) -> bool:
     """Handle a resource - either download from URL or copy from local path.
 
@@ -3936,6 +4041,7 @@ def handle_resource(
         config_source: Where the config was loaded from
         base_url: Optional base URL from config
         auth_param: Optional auth parameter for private repos
+        rate_limiter: Optional coordinator sharing rate-limit state across threads
 
     Returns:
         bool: True if successful, False otherwise
@@ -3955,11 +4061,11 @@ def handle_resource(
             # Download from URL
             if is_binary_file(resolved_path):
                 # Binary file - fetch as bytes and write bytes
-                content_bytes = fetch_url_bytes_with_auth(resolved_path, auth_param=auth_param)
+                content_bytes = fetch_url_bytes_with_auth(resolved_path, auth_param=auth_param, rate_limiter=rate_limiter)
                 destination.write_bytes(content_bytes)
             else:
                 # Text file - fetch as text and write text
-                content = fetch_url_with_auth(resolved_path, auth_param=auth_param)
+                content = fetch_url_with_auth(resolved_path, auth_param=auth_param, rate_limiter=rate_limiter)
                 destination.write_text(content, encoding='utf-8')
             success(f'Downloaded: {filename}')
         else:
@@ -4017,10 +4123,13 @@ def process_resources(
         destination = destination_dir / filename
         download_tasks.append((resource, destination))
 
+    # Per-batch coordinator shares rate-limit state across download threads
+    rate_limiter = RateLimitCoordinator()
+
     def download_single_resource(task: tuple[str, Path]) -> bool:
         """Download a single resource and return success status."""
         resource, destination = task
-        return handle_resource(resource, destination, config_source, base_url, auth_param)
+        return handle_resource(resource, destination, config_source, base_url, auth_param, rate_limiter)
 
     # Execute downloads in parallel with stagger delay to avoid rate limiting
     results = execute_parallel_safe(download_tasks, download_single_resource, False, stagger_delay=0.5)
@@ -4098,10 +4207,13 @@ def process_file_downloads(
 
         valid_downloads.append((str(source), dest_path))
 
+    # Per-batch coordinator shares rate-limit state across download threads
+    rate_limiter = RateLimitCoordinator()
+
     def download_single_file(download_info: tuple[str, Path]) -> bool:
         """Download a single file and return success status."""
         source, dest_path = download_info
-        return handle_resource(source, dest_path, config_source, base_url, auth_param)
+        return handle_resource(source, dest_path, config_source, base_url, auth_param, rate_limiter)
 
     # Execute downloads in parallel with stagger delay to avoid rate limiting
     if valid_downloads:
@@ -4127,6 +4239,7 @@ def process_skill(
     skills_dir: Path,
     config_source: str,
     auth_param: str | None = None,
+    rate_limiter: RateLimitCoordinator | None = None,
 ) -> bool:
     """Process and install a single skill.
 
@@ -4138,6 +4251,7 @@ def process_skill(
         skills_dir: Base skills directory (.claude/skills/)
         config_source: Where the config was loaded from
         auth_param: Optional authentication parameter for private repos
+        rate_limiter: Optional coordinator sharing rate-limit state across threads
 
     Returns:
         bool: True if skill installed successfully, False otherwise
@@ -4182,11 +4296,11 @@ def process_skill(
             try:
                 if is_binary_file(file_path):
                     # Binary file - fetch as bytes and write bytes
-                    content_bytes = fetch_url_bytes_with_auth(source_url, auth_param=auth_param)
+                    content_bytes = fetch_url_bytes_with_auth(source_url, auth_param=auth_param, rate_limiter=rate_limiter)
                     destination.write_bytes(content_bytes)
                 else:
                     # Text file - fetch as text and write text
-                    content = fetch_url_with_auth(source_url, auth_param=auth_param)
+                    content = fetch_url_with_auth(source_url, auth_param=auth_param, rate_limiter=rate_limiter)
                     destination.write_text(content, encoding='utf-8')
                 success(f'  Downloaded: {file_path}')
                 success_count += 1
@@ -4244,9 +4358,12 @@ def process_skills(
 
     info(f'Processing {len(skills_config)} skill(s)...')
 
+    # Per-batch coordinator shares rate-limit state across skill download threads
+    rate_limiter = RateLimitCoordinator()
+
     def install_single_skill(skill_config: dict[str, Any]) -> bool:
         """Install a single skill and return success status."""
-        return process_skill(skill_config, skills_dir, config_source, auth_param)
+        return process_skill(skill_config, skills_dir, config_source, auth_param, rate_limiter)
 
     # Execute skill installations in parallel with stagger delay to avoid rate limiting
     results = execute_parallel_safe(skills_config, install_single_skill, False, stagger_delay=0.5)
@@ -5029,10 +5146,13 @@ def download_hook_files(
         destination = hooks_dir / filename
         download_tasks.append((file, destination))
 
+    # Per-batch coordinator shares rate-limit state across download threads
+    rate_limiter = RateLimitCoordinator()
+
     def download_single_hook(task: tuple[str, Path]) -> bool:
         """Download a single hook file and return success status."""
         file, destination = task
-        return handle_resource(file, destination, config_source, base_url, auth_param)
+        return handle_resource(file, destination, config_source, base_url, auth_param, rate_limiter)
 
     # Execute downloads in parallel with stagger delay to avoid rate limiting
     results = execute_parallel_safe(download_tasks, download_single_hook, False, stagger_delay=0.5)

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -6531,7 +6531,7 @@ class TestMCPServerNeedsNodejsDetection:
 
 
 class TestFetchWithRetry:
-    """Test fetch retry logic for rate limiting."""
+    """Test fetch retry logic for rate limiting with linear additive backoff."""
 
     @patch('setup_environment.time.sleep')
     def test_fetch_with_retry_success_first_attempt(self, mock_sleep: MagicMock) -> None:
@@ -6567,8 +6567,8 @@ class TestFetchWithRetry:
         mock_sleep.assert_called_once()
 
     @patch('setup_environment.time.sleep')
-    def test_fetch_with_retry_respects_retry_after_header(self, mock_sleep: MagicMock) -> None:
-        """Test that Retry-After header is respected."""
+    def test_fetch_with_retry_respects_retry_after_header_as_floor(self, mock_sleep: MagicMock) -> None:
+        """Test that Retry-After header is used as floor, not override."""
         call_count = 0
 
         def request_func() -> str:
@@ -6583,8 +6583,7 @@ class TestFetchWithRetry:
 
         result = setup_environment.fetch_with_retry(request_func, 'https://example.com/file')
         assert result == 'content'
-        # Verify wait time was 5 seconds (from header)
-        assert mock_sleep.call_args[0][0] == 5.0
+        assert mock_sleep.call_args[0][0] >= 5.0
 
     @patch('setup_environment.time.sleep')
     def test_fetch_with_retry_max_retries_exceeded(self, mock_sleep: MagicMock) -> None:
@@ -6598,7 +6597,7 @@ class TestFetchWithRetry:
             setup_environment.fetch_with_retry(request_func, 'https://example.com/file', max_retries=2)
 
         assert exc_info.value.code == 429
-        assert mock_sleep.call_count == 2  # Retried twice
+        assert mock_sleep.call_count == 2
 
     @patch('setup_environment.time.sleep')
     def test_fetch_with_retry_non_rate_limit_error_not_retried(self, mock_sleep: MagicMock) -> None:
@@ -6650,9 +6649,10 @@ class TestFetchWithRetry:
         assert exc_info.value.code == 403
         mock_sleep.assert_not_called()
 
+    @patch('setup_environment.random.uniform', return_value=0.0)
     @patch('setup_environment.time.sleep')
-    def test_fetch_with_retry_exponential_backoff(self, mock_sleep: MagicMock) -> None:
-        """Test that exponential backoff is applied."""
+    def test_fetch_with_retry_linear_additive_backoff(self, mock_sleep: MagicMock, mock_random: MagicMock) -> None:
+        """Test that linear additive backoff is applied."""
         call_count = 0
 
         def request_func() -> str:
@@ -6665,24 +6665,19 @@ class TestFetchWithRetry:
 
         result = setup_environment.fetch_with_retry(
             request_func, 'https://example.com/file',
-            max_retries=3, initial_backoff=1.0,
+            max_retries=3, base_delay=1.0, additive_increment=2.0,
         )
         assert result == 'content'
-        assert call_count == 4  # Initial + 3 retries
+        assert call_count == 4
         assert mock_sleep.call_count == 3
+        assert mock_random.called
 
-        # Verify backoff pattern (with jitter, times should be within range)
         sleep_times = [call[0][0] for call in mock_sleep.call_args_list]
-        # First retry: ~1s (1 * 2^0 + jitter)
-        assert 1.0 <= sleep_times[0] <= 1.25
-        # Second retry: ~2s (1 * 2^1 + jitter)
-        assert 2.0 <= sleep_times[1] <= 2.5
-        # Third retry: ~4s (1 * 2^2 + jitter)
-        assert 4.0 <= sleep_times[2] <= 5.0
+        assert sleep_times == [1.0, 3.0, 5.0]
 
 
 class TestFetchWithRetryNewDefaults:
-    """Test fetch retry logic with new default parameters."""
+    """Test fetch retry default parameters for linear additive backoff."""
 
     def test_default_max_retries_is_10(self) -> None:
         """Test that default max_retries is 10."""
@@ -6691,16 +6686,25 @@ class TestFetchWithRetryNewDefaults:
         sig = inspect.signature(setup_environment.fetch_with_retry)
         assert sig.parameters['max_retries'].default == 10
 
-    def test_default_initial_backoff_is_2(self) -> None:
-        """Test that default initial_backoff is 2.0."""
+    def test_default_base_delay_is_1(self) -> None:
+        """Test that default base_delay is 1.0."""
         import inspect
 
         sig = inspect.signature(setup_environment.fetch_with_retry)
-        assert sig.parameters['initial_backoff'].default == 2.0
+        assert sig.parameters['base_delay'].default == 1.0
 
+    def test_default_additive_increment_is_2(self) -> None:
+        """Test that default additive_increment is 2.0."""
+        import inspect
+
+        sig = inspect.signature(setup_environment.fetch_with_retry)
+        assert sig.parameters['additive_increment'].default == 2.0
+
+    @patch('setup_environment.random.uniform', return_value=0.0)
     @patch('setup_environment.time.sleep')
-    def test_backoff_sequence_with_new_defaults(self, mock_sleep: MagicMock) -> None:
-        """Test exponential backoff sequence with default parameters."""
+    def test_backoff_sequence_with_defaults(self, mock_sleep: MagicMock, mock_random: MagicMock) -> None:
+        """Test linear additive backoff sequence with default parameters."""
+        assert mock_random is not None  # Ensures random.uniform is mocked
         call_count = 0
 
         def request_func() -> str:
@@ -6713,20 +6717,17 @@ class TestFetchWithRetryNewDefaults:
             return 'content'
 
         result = setup_environment.fetch_with_retry(
-            request_func, 'https://example.com/file', max_retries=3, initial_backoff=2.0,
+            request_func, 'https://example.com/file', max_retries=3,
         )
         assert result == 'content'
         sleep_times = [call[0][0] for call in mock_sleep.call_args_list]
-        # First retry: ~2s (2 * 2^0 + jitter)
-        assert 2.0 <= sleep_times[0] <= 2.5
-        # Second retry: ~4s (2 * 2^1 + jitter)
-        assert 4.0 <= sleep_times[1] <= 5.0
-        # Third retry: ~8s (2 * 2^2 + jitter)
-        assert 8.0 <= sleep_times[2] <= 10.0
+        assert sleep_times == [1.0, 3.0, 5.0]
 
+    @patch('setup_environment.random.uniform', return_value=0.0)
     @patch('setup_environment.time.sleep')
-    def test_backoff_capped_at_60_seconds(self, mock_sleep: MagicMock) -> None:
-        """Test that backoff never exceeds 60 seconds."""
+    def test_backoff_capped_at_max_delay(self, mock_sleep: MagicMock, mock_random: MagicMock) -> None:
+        """Test that backoff never exceeds max_delay (before jitter)."""
+        assert mock_random is not None  # Ensures random.uniform is mocked
         call_count = 0
 
         def request_func() -> str:
@@ -6740,13 +6741,379 @@ class TestFetchWithRetryNewDefaults:
 
         result = setup_environment.fetch_with_retry(
             request_func, 'https://example.com/file',
-            max_retries=10, initial_backoff=2.0,
+            max_retries=10, base_delay=1.0, additive_increment=10.0, max_delay=30.0,
         )
         assert result == 'content'
         sleep_times = [call[0][0] for call in mock_sleep.call_args_list]
-        # After attempt 5+, backoff should be capped at 60s (with jitter up to 75s max)
-        for sleep_time in sleep_times[5:]:
-            assert sleep_time <= 75.0  # 60s + 25% jitter
+        for sleep_time in sleep_times:
+            assert sleep_time <= 30.0  # 60s + 25% jitter
+
+
+class TestRateLimitCoordinator:
+    """Test the RateLimitCoordinator thread-safe rate-limit state manager."""
+
+    def test_initial_state_no_wait(self) -> None:
+        """Test that a fresh coordinator reports zero wait time."""
+        coordinator = setup_environment.RateLimitCoordinator()
+        assert coordinator.get_wait_time() == 0.0
+
+    @patch('setup_environment.time.monotonic')
+    def test_report_sets_wait_time(self, mock_monotonic: MagicMock) -> None:
+        """Test that reporting a rate limit sets a positive wait time."""
+        mock_monotonic.return_value = 100.0
+        coordinator = setup_environment.RateLimitCoordinator()
+        coordinator.report_rate_limit(5.0)
+        assert coordinator.get_wait_time() == 5.0
+
+    @patch('setup_environment.time.monotonic')
+    def test_report_advances_floor_only(self, mock_monotonic: MagicMock) -> None:
+        """Test that a shorter wait does not regress the floor."""
+        mock_monotonic.return_value = 100.0
+        coordinator = setup_environment.RateLimitCoordinator()
+        coordinator.report_rate_limit(10.0)
+        coordinator.report_rate_limit(3.0)
+        assert coordinator.get_wait_time() == 10.0
+
+    @patch('setup_environment.time.monotonic')
+    def test_report_extends_floor(self, mock_monotonic: MagicMock) -> None:
+        """Test that a longer wait advances the floor."""
+        mock_monotonic.return_value = 100.0
+        coordinator = setup_environment.RateLimitCoordinator()
+        coordinator.report_rate_limit(5.0)
+        coordinator.report_rate_limit(15.0)
+        assert coordinator.get_wait_time() == 15.0
+
+    @patch('setup_environment.time.monotonic')
+    def test_wait_decreases_over_time(self, mock_monotonic: MagicMock) -> None:
+        """Test that wait time decreases as monotonic time advances."""
+        mock_monotonic.return_value = 100.0
+        coordinator = setup_environment.RateLimitCoordinator()
+        coordinator.report_rate_limit(10.0)
+        mock_monotonic.return_value = 107.0
+        assert coordinator.get_wait_time() == pytest.approx(3.0)
+        mock_monotonic.return_value = 111.0
+        assert coordinator.get_wait_time() == 0.0
+
+    def test_thread_safety_concurrent_reports(self) -> None:
+        """Test that concurrent reports do not corrupt coordinator state."""
+        import threading
+
+        coordinator = setup_environment.RateLimitCoordinator()
+        errors: list[str] = []
+
+        def reporter(wait: float) -> None:
+            try:
+                for _ in range(100):
+                    coordinator.report_rate_limit(wait)
+                    coordinator.get_wait_time()
+            except Exception as e:
+                errors.append(str(e))
+
+        threads = [threading.Thread(target=reporter, args=(float(i),)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f'Thread safety errors: {errors}'
+        assert coordinator.get_wait_time() >= 0.0
+
+
+class TestFetchWithRetryCoordinatorIntegration:
+    """Integration tests for fetch_with_retry with RateLimitCoordinator."""
+
+    @patch('setup_environment.random.uniform', return_value=0.0)
+    @patch('setup_environment.time.sleep')
+    def test_coordinator_floor_respected_before_request(
+        self, mock_sleep: MagicMock, mock_random: MagicMock,
+    ) -> None:
+        """Test that coordinator wait is applied before making a request."""
+        assert mock_random is not None  # Ensures random.uniform is mocked
+        coordinator = setup_environment.RateLimitCoordinator()
+        coordinator.report_rate_limit(3.0)
+
+        call_count = 0
+
+        def request_func() -> str:
+            nonlocal call_count
+            call_count += 1
+            return 'content'
+
+        result = setup_environment.fetch_with_retry(
+            request_func, 'https://example.com/file', rate_limiter=coordinator,
+        )
+        assert result == 'content'
+        assert call_count == 1
+        assert mock_sleep.call_count >= 1
+
+    @patch('setup_environment.random.uniform', return_value=0.0)
+    @patch('setup_environment.time.sleep')
+    def test_429_reports_to_coordinator(self, mock_sleep: MagicMock, mock_random: MagicMock) -> None:
+        """Test that 429 response updates the coordinator."""
+        assert mock_sleep is not None  # Ensures time.sleep is mocked
+        assert mock_random is not None  # Ensures random.uniform is mocked
+        coordinator = setup_environment.RateLimitCoordinator()
+        call_count = 0
+
+        def request_func() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise urllib.error.HTTPError('https://example.com', 429, 'Too Many Requests', {}, None)
+            return 'content'
+
+        setup_environment.fetch_with_retry(
+            request_func, 'https://example.com/file', rate_limiter=coordinator,
+        )
+        assert call_count == 2
+
+    @patch('setup_environment.random.uniform', return_value=0.0)
+    @patch('setup_environment.time.sleep')
+    def test_no_coordinator_still_works(self, mock_sleep: MagicMock, mock_random: MagicMock) -> None:
+        """Test that fetch_with_retry works without a coordinator."""
+        assert mock_sleep is not None  # Ensures time.sleep is mocked
+        assert mock_random is not None  # Ensures random.uniform is mocked
+        call_count = 0
+
+        def request_func() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise urllib.error.HTTPError('https://example.com', 429, 'Too Many Requests', {}, None)
+            return 'content'
+
+        result = setup_environment.fetch_with_retry(
+            request_func, 'https://example.com/file', rate_limiter=None,
+        )
+        assert result == 'content'
+        assert call_count == 2
+
+
+class TestLinearAdditiveBackoffSequence:
+    """Test the linear additive backoff formula in detail."""
+
+    @patch('setup_environment.random.uniform', return_value=0.0)
+    @patch('setup_environment.time.sleep')
+    def test_exact_sequence_1_3_5_7_9(self, mock_sleep: MagicMock, mock_random: MagicMock) -> None:
+        """Test deterministic sequence with jitter disabled: 1, 3, 5, 7, 9."""
+        assert mock_random is not None  # Ensures random.uniform is mocked
+        call_count = 0
+
+        def request_func() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 5:
+                raise urllib.error.HTTPError('https://example.com', 429, 'Too Many Requests', {}, None)
+            return 'content'
+
+        setup_environment.fetch_with_retry(
+            request_func, 'https://example.com/file',
+            max_retries=5, base_delay=1.0, additive_increment=2.0,
+        )
+
+        sleep_times = [call[0][0] for call in mock_sleep.call_args_list]
+        assert sleep_times == [1.0, 3.0, 5.0, 7.0, 9.0]
+
+    @patch('setup_environment.random.uniform', return_value=0.0)
+    @patch('setup_environment.time.sleep')
+    def test_header_as_floor_not_override(self, mock_sleep: MagicMock, mock_random: MagicMock) -> None:
+        """Test that header is floor: calculated backoff wins when larger."""
+        assert mock_random is not None  # Ensures random.uniform is mocked
+        call_count = 0
+
+        def request_func() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise urllib.error.HTTPError(
+                    'https://example.com', 429, 'Too Many Requests', {'retry-after': '1'}, None,
+                )
+            if call_count == 2:
+                raise urllib.error.HTTPError(
+                    'https://example.com', 429, 'Too Many Requests', {'retry-after': '1'}, None,
+                )
+            return 'content'
+
+        setup_environment.fetch_with_retry(
+            request_func, 'https://example.com/file',
+            max_retries=3, base_delay=1.0, additive_increment=2.0,
+        )
+
+        sleep_times = [call[0][0] for call in mock_sleep.call_args_list]
+        assert sleep_times[0] == 1.0
+        assert sleep_times[1] == 3.0
+
+    @patch('setup_environment.random.uniform', return_value=0.0)
+    @patch('setup_environment.time.sleep')
+    def test_header_wins_when_larger(self, mock_sleep: MagicMock, mock_random: MagicMock) -> None:
+        """Test that header wins when it exceeds calculated backoff."""
+        assert mock_random is not None  # Ensures random.uniform is mocked
+        call_count = 0
+
+        def request_func() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise urllib.error.HTTPError(
+                    'https://example.com', 429, 'Too Many Requests', {'retry-after': '30'}, None,
+                )
+            return 'content'
+
+        setup_environment.fetch_with_retry(
+            request_func, 'https://example.com/file',
+            max_retries=3, base_delay=1.0, additive_increment=2.0,
+        )
+
+        sleep_times = [call[0][0] for call in mock_sleep.call_args_list]
+        assert sleep_times[0] == 30.0
+
+    @patch('setup_environment.time.sleep')
+    def test_jitter_applied_to_all_retries(self, mock_sleep: MagicMock) -> None:
+        """Test that jitter is applied and within expected bounds."""
+        call_count = 0
+
+        def request_func() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 3:
+                raise urllib.error.HTTPError('https://example.com', 429, 'Too Many Requests', {}, None)
+            return 'content'
+
+        setup_environment.fetch_with_retry(
+            request_func, 'https://example.com/file',
+            max_retries=3, base_delay=1.0, additive_increment=2.0,
+        )
+
+        sleep_times = [call[0][0] for call in mock_sleep.call_args_list]
+        expected_bases = [1.0, 3.0, 5.0]
+        for i, (actual, base) in enumerate(zip(sleep_times, expected_bases, strict=True)):
+            assert actual >= base, f'Retry {i}: {actual} < {base}'
+            assert actual <= base * 1.25, f'Retry {i}: {actual} > {base * 1.25}'
+
+
+class TestDoFetchAuthSkipOptimization:
+    """Test auth-skip optimization in _do_fetch internal functions."""
+
+    @patch('setup_environment.urlopen')
+    def test_skips_unauth_when_headers_known(self, mock_urlopen: MagicMock) -> None:
+        """Test that only one urlopen call is made when auth headers are pre-set."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'content'
+        mock_urlopen.return_value = mock_response
+
+        def call_first_arg(func, *_args, **_kwargs):
+            return func()
+
+        with patch('setup_environment.detect_repo_type', return_value='github'), \
+             patch('setup_environment.fetch_with_retry', side_effect=call_first_arg):
+            result = setup_environment.fetch_url_with_auth(
+                'https://api.github.com/repos/test/file',
+                auth_headers={'Authorization': 'token abc123'},
+            )
+
+        assert result == 'content'
+        assert mock_urlopen.call_count == 1
+
+    @patch('setup_environment.urlopen')
+    def test_tries_unauth_first_when_no_headers(self, mock_urlopen: MagicMock) -> None:
+        """Test normal unauthenticated-first flow when no auth headers provided."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'content'
+        mock_urlopen.return_value = mock_response
+
+        def call_first_arg(func, *_args, **_kwargs):
+            return func()
+
+        with patch('setup_environment.detect_repo_type', return_value='other'), \
+             patch('setup_environment.fetch_with_retry', side_effect=call_first_arg):
+            result = setup_environment.fetch_url_with_auth(
+                'https://example.com/file',
+            )
+
+        assert result == 'content'
+        assert mock_urlopen.call_count == 1
+
+
+class TestRateLimitCoordinatorMultiThread:
+    """Integration test for RateLimitCoordinator with parallel fetch."""
+
+    @patch('setup_environment.random.uniform', return_value=0.0)
+    @patch('setup_environment.time.sleep')
+    def test_parallel_fetch_shares_coordinator(self, mock_sleep: MagicMock, mock_random: MagicMock) -> None:
+        """Test that two threads sharing a coordinator both respect rate limits."""
+        import threading
+
+        assert mock_sleep is not None  # Ensures time.sleep is mocked
+        assert mock_random is not None  # Ensures random.uniform is mocked
+
+        coordinator = setup_environment.RateLimitCoordinator()
+        results: list[str] = []
+        errors: list[str] = []
+
+        def fetch_worker(worker_id: int) -> None:
+            try:
+                call_count = 0
+
+                def request_func() -> str:
+                    nonlocal call_count
+                    call_count += 1
+                    if call_count == 1:
+                        raise urllib.error.HTTPError(
+                            'https://example.com', 429, 'Too Many Requests', {}, None,
+                        )
+                    return f'content-{worker_id}'
+
+                result = setup_environment.fetch_with_retry(
+                    request_func, f'https://example.com/file{worker_id}',
+                    rate_limiter=coordinator,
+                )
+                results.append(result)
+            except Exception as e:
+                errors.append(str(e))
+
+        threads = [threading.Thread(target=fetch_worker, args=(i,)) for i in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f'Thread errors: {errors}'
+        assert len(results) == 2
+        assert 'content-0' in results
+        assert 'content-1' in results
+
+
+class TestFetchWithRetryXRateLimitReset:
+    """Test x-ratelimit-reset header parsing and floor behavior."""
+
+    @patch('setup_environment.random.uniform', return_value=0.0)
+    @patch('setup_environment.time.time')
+    @patch('setup_environment.time.sleep')
+    def test_x_ratelimit_reset_as_floor(
+        self, mock_sleep: MagicMock, mock_time: MagicMock, mock_random: MagicMock,
+    ) -> None:
+        """Test epoch timestamp conversion and floor behavior for x-ratelimit-reset."""
+        assert mock_random is not None  # Ensures random.uniform is mocked
+        mock_time.return_value = 1000.0
+        call_count = 0
+
+        def request_func() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise urllib.error.HTTPError(
+                    'https://example.com', 429, 'Too Many Requests',
+                    {'x-ratelimit-reset': '1020'}, None,
+                )
+            return 'content'
+
+        setup_environment.fetch_with_retry(
+            request_func, 'https://example.com/file',
+            max_retries=3, base_delay=1.0, additive_increment=2.0,
+        )
+
+        sleep_times = [call[0][0] for call in mock_sleep.call_args_list]
+        assert sleep_times[0] == 20.0
 
 
 class TestParallelWorkersConfiguration:


### PR DESCRIPTION
The Retry-After header from GitHub (typically 1s) was overriding the calculated exponential backoff, causing every retry to wait exactly 1.0s instead of escalating delays. Replace exponential backoff with linear additive backoff (1s, 3s, 5s, 7s...) and treat Retry-After/x-ratelimit-reset headers as a minimum floor rather than an override. Add thread-safe RateLimitCoordinator that shares rate-limit state across concurrent download threads via dependency injection. Optimize _do_fetch() to skip redundant unauthenticated requests when auth headers are already known.