### PR TITLE
Mock load_config_from_source in root guard tests and add timeout safety nets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
     name: Test Python on ${{ matrix.os }}
     if: ${{ ! startsWith(github.head_ref, 'release-please--branches--') }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false
@@ -78,6 +79,7 @@ jobs:
     name: Test Install Scripts
     if: ${{ ! startsWith(github.head_ref, 'release-please--branches--') }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
 
     strategy:
       fail-fast: false
@@ -111,6 +113,7 @@ jobs:
     name: E2E Tests (${{ matrix.os }})
     if: ${{ ! startsWith(github.head_ref, 'release-please--branches--') }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,7 @@ asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 norecursedirs = ["scripts"]
+timeout = 120
 filterwarnings = [
     "ignore:coroutine 'AsyncMockMixin._execute_mock_call' was never awaited:RuntimeWarning",
 ]

--- a/tests/e2e/test_root_guard.py
+++ b/tests/e2e/test_root_guard.py
@@ -150,7 +150,10 @@ class TestRootGuardSetupEnvironment:
             patch('platform.system', return_value='Linux'),
             patch('os.geteuid', create=True, return_value=0),
             patch.dict('os.environ', {'CLAUDE_ALLOW_ROOT': '1'}),
-            patch('sys.argv', ['setup_environment.py', 'python']), contextlib.suppress(SystemExit, Exception),
+            patch('sys.argv', ['setup_environment.py', 'python']),
+            patch.object(setup_environment, 'load_config_from_source',
+                         side_effect=Exception('Config loading stopped by test')),
+            contextlib.suppress(SystemExit, Exception),
         ):
             setup_environment.main()
 
@@ -206,7 +209,10 @@ class TestRootGuardSetupEnvironment:
         with (
             patch('platform.system', return_value='Windows'),
             patch.object(setup_environment, 'is_admin', return_value=False),
-            patch('sys.argv', ['setup_environment.py', 'python']), contextlib.suppress(SystemExit, Exception),
+            patch('sys.argv', ['setup_environment.py', 'python']),
+            patch.object(setup_environment, 'load_config_from_source',
+                         side_effect=Exception('Config loading stopped by test')),
+            contextlib.suppress(SystemExit, Exception),
         ):
             setup_environment.main()
 

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -8314,6 +8314,8 @@ class TestRootGuard:
             patch('os.geteuid', create=True, return_value=0),
             patch.dict('os.environ', {'CLAUDE_ALLOW_ROOT': '1'}),
             patch('sys.argv', ['setup_environment.py', 'python']),
+            patch.object(setup_environment, 'load_config_from_source',
+                         side_effect=Exception('Config loading stopped by test')),
             contextlib.suppress(SystemExit, Exception),
         ):
             setup_environment.main()
@@ -8324,6 +8326,8 @@ class TestRootGuard:
             patch('platform.system', return_value='Windows'),
             patch.object(setup_environment, 'is_admin', return_value=False),
             patch('sys.argv', ['setup_environment.py', 'python']),
+            patch.object(setup_environment, 'load_config_from_source',
+                         side_effect=Exception('Config loading stopped by test')),
             contextlib.suppress(SystemExit, Exception),
         ):
             setup_environment.main()


### PR DESCRIPTION
Root guard tests calling main() without mocking load_config_from_source caused intermittent hangs on macOS CI due to unmocked network operations. Add side_effect=Exception mock to 4 affected test methods to prevent execution past the root guard check.

Also add global pytest timeout (120s) and CI job timeout-minutes to catch any future test hangs early.