### PR TITLE
Add rm-rf fallback for npm ENOTEMPTY removal failure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -574,6 +574,26 @@ Tests that create or assert on Windows-style paths (using backslashes) MUST be m
 
 `Path(r'C:\Program Files\nodejs\node.exe')` on Linux becomes `PosixPath('C:\\Program Files\\nodejs\\node.exe')` (a single path component), so `Path(...).parent` returns `PosixPath('.')` instead of the expected Windows parent directory. `Path` uses the running OS's path semantics, not the path's apparent format.
 
+### Platform Detection Mock Completeness Rule
+
+When production code uses platform detection (`sys.platform`, `platform.system()`, or both), tests MUST mock ALL platform detection methods used in the complete code path under test, not just one.
+
+**The trap:** A test mocks `platform.system()` to simulate Windows, but the same function also checks `sys.platform` (or vice versa). The test passes on the simulated platform (e.g., Windows CI where `sys.platform` is already `'win32'`) but fails on other CI platforms where the un-mocked check evaluates differently.
+
+**Rules:**
+1. Before writing a platform-simulation test, read the COMPLETE production function and identify ALL platform checks (`sys.platform`, `platform.system()`, `os.name`, etc.)
+2. Mock ALL of them consistently for the simulated platform
+3. Prefer using ONE platform detection method per function. `sys.platform` is preferred for MyPy compatibility (see "Platform-Specific Code Patterns" section)
+4. When refactoring production code to change platform detection method, update ALL test mocks targeting that function
+
+**Quick reference -- equivalent values:**
+
+| Simulated Platform | `sys.platform` | `platform.system()` | `os.name` |
+|--------------------|----------------|---------------------|-----------|
+| Windows            | `'win32'`      | `'Windows'`         | `'nt'`    |
+| Linux              | `'linux'`      | `'Linux'`           | `'posix'` |
+| macOS              | `'darwin'`     | `'Darwin'`          | `'posix'` |
+
 ## Script Dependencies
 
 - **Python 3.12** required for all Python scripts

--- a/docs/installing-claude-code.md
+++ b/docs/installing-claude-code.md
@@ -159,10 +159,16 @@ If you installed the native version but `claude --version` still shows the old n
 
 **Symptoms:** A prominent boxed warning during installation stating "npm Claude Code installation was NOT removed", or `which claude` pointing to a path containing `npm` or `/usr/local/bin` instead of `~/.local/bin`.
 
-**Fix:** Remove the npm installation manually and restart your terminal:
+**Fix:** Remove the npm installation files directly and restart your terminal:
 
 ```bash
-sudo npm uninstall -g @anthropic-ai/claude-code
+# Determine your npm global prefix
+npm config get prefix
+# Output is typically /usr or /usr/local
+
+# Remove using the prefix (replace /usr with your prefix if different)
+sudo rm -rf /usr/lib/node_modules/@anthropic-ai/.claude-code-* /usr/lib/node_modules/@anthropic-ai/claude-code
+sudo rm -f /usr/bin/claude
 ```
 
 On Windows (run as Administrator):
@@ -172,6 +178,30 @@ npm uninstall -g @anthropic-ai/claude-code
 ```
 
 After removal, restart your terminal session so that `claude` resolves to the native binary at `~/.local/bin/claude`.
+
+### npm Removal Fails with ENOTEMPTY
+
+If removing the npm installation fails with an error like `ENOTEMPTY: directory not empty, rename ... -> .../.claude-code-ZjqcDZyQ`, this is a [known npm bug](https://github.com/npm/cli/issues/5825). The npm package manager creates temporary directories during uninstall, and if a stale temporary directory from a prior interrupted operation already exists, the rename fails.
+
+This issue is more common in WSL2 environments due to cross-filesystem interactions and VS Code Remote WSL file watchers holding handles on `node_modules` directories, but it can occur on any platform.
+
+**Fix:** Remove the files directly instead of using `npm uninstall`:
+
+```bash
+# Determine your npm global prefix
+npm config get prefix
+# Output is typically /usr or /usr/local
+
+# Remove using the prefix (replace /usr with your prefix if different)
+sudo rm -rf /usr/lib/node_modules/@anthropic-ai/.claude-code-* /usr/lib/node_modules/@anthropic-ai/claude-code
+sudo rm -f /usr/bin/claude
+# Optionally clean up the empty parent directory
+sudo rmdir /usr/lib/node_modules/@anthropic-ai 2>/dev/null || true
+```
+
+The `.claude-code-*` glob pattern removes stale temporary directories that prevent npm from operating. After removal, restart your terminal.
+
+**Note:** The installer automatically attempts this direct removal when `npm uninstall` fails. This manual procedure is only needed if the automatic fallback also fails (e.g., in non-interactive environments without cached sudo credentials).
 
 ### Claude Command Not Found After Install
 

--- a/scripts/install_claude.py
+++ b/scripts/install_claude.py
@@ -665,33 +665,35 @@ def _finalize_native_install() -> None:
 
     Performs the standard post-native-install cleanup sequence:
     1. Remove npm Claude Code installation to prevent PATH conflicts
-    2. Verify npm removal was successful (warn if still present)
-    3. Update installation method config to 'native'
+    2. Update installation method config to 'native'
 
-    Should be called after verify_claude_installation() confirms
-    source == 'native'. This function handles all cleanup and config
-    updates as an atomic operation.
+    When remove_npm_claude() reports success (True), the secondary
+    npm-list verification is skipped. Direct file removal may leave
+    stale npm registry metadata causing ``npm list -g`` to falsely
+    report the package as installed, which would trigger a spurious
+    warning.
     """
-    if not remove_npm_claude():
-        _warn_npm_removal_failed()
-    if _check_npm_claude_installed():
+    if not remove_npm_claude() and _check_npm_claude_installed():
         warning('npm Claude Code package is STILL installed after removal attempt')
-        _warn_npm_removal_failed()
     update_install_method_config('native')
 
 
 def _warn_npm_removal_failed(npm_path: str | None = None) -> None:
     """Display a prominent warning when npm Claude Code removal fails.
 
-    Provides clear manual removal instructions that are impossible to miss
-    in terminal output. Called by callers of remove_npm_claude() when
-    it returns False.
+    Provides clear manual removal instructions using direct file deletion
+    rather than ``npm uninstall``, since npm uninstall can also fail with
+    the same ENOTEMPTY error (npm/cli#5825).
 
     Args:
-        npm_path: Path to npm executable for the manual command.
-                  If None, uses 'npm' as default.
+        npm_path: Path to npm executable, used to query the global prefix
+                  for accurate removal paths. If None, uses common defaults.
     """
-    npm_cmd = npm_path or 'npm'
+    # Determine the prefix for accurate paths
+    prefix = None
+    if npm_path:
+        prefix = _get_npm_global_prefix(npm_path)
+
     print()
     warning('=' * 70)
     warning('  WARNING: npm Claude Code installation was NOT removed')
@@ -700,9 +702,17 @@ def _warn_npm_removal_failed(npm_path: str | None = None) -> None:
     warning('')
     warning('  To fix manually, run:')
     if sys.platform == 'win32':
+        npm_cmd = npm_path or 'npm'
         warning(f'    {npm_cmd} uninstall -g {CLAUDE_NPM_PACKAGE}')
     else:
-        warning(f'    sudo {npm_cmd} uninstall -g {CLAUDE_NPM_PACKAGE}')
+        if prefix:
+            pkg_parent = f'{prefix}/lib/node_modules/@anthropic-ai'
+            warning(f'    sudo rm -rf {pkg_parent}/.claude-code-* {pkg_parent}/claude-code')
+            warning(f'    sudo rm -f {prefix}/bin/claude')
+        else:
+            pkg_parent = '/usr/lib/node_modules/@anthropic-ai'
+            warning(f'    sudo rm -rf {pkg_parent}/.claude-code-* {pkg_parent}/claude-code')
+            warning('    sudo rm -f /usr/bin/claude')
     warning('')
     warning('  After removal, restart your terminal to use the native version.')
     warning('=' * 70)
@@ -747,26 +757,55 @@ def _check_npm_claude_installed() -> bool:
     return result.returncode == 0
 
 
+def _get_npm_global_prefix(npm_path: str) -> str | None:
+    """Determine the npm global installation prefix directory.
+
+    Runs ``npm config get prefix`` to discover where npm stores global
+    packages. This path is used to locate package directories and binary
+    symlinks for direct file removal when ``npm uninstall`` fails.
+
+    Args:
+        npm_path: Absolute path to the npm executable.
+
+    Returns:
+        The npm global prefix path (e.g., ``/usr``, ``/usr/local``),
+        or None if the command fails or returns an empty string.
+    """
+    try:
+        result = subprocess.run(
+            [npm_path, 'config', 'get', 'prefix'],
+            capture_output=True,
+            encoding='utf-8',
+            errors='replace',
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    return None
+
+
 def remove_npm_claude() -> bool:
     """Remove npm-installed Claude Code to prevent PATH conflicts.
 
-    Removes npm global installation of @anthropic-ai/claude-code using the
-    standard npm uninstall command. This eliminates PATH precedence issues
-    where npm version shadows native installation.
+    Removes npm global installation of @anthropic-ai/claude-code using a
+    multi-tier strategy:
 
-    On Unix systems, if direct uninstall fails with permission errors, uses
-    the three-tier sudo fallback strategy (interactive, cached credentials,
-    /dev/tty). As a last resort, attempts direct file removal of the npm
-    claude binary.
+    1. ``npm uninstall -g`` (direct, then with sudo on Unix)
+    2. Dynamic prefix ``rm -rf`` fallback using ``npm config get prefix``
+       to locate and remove package files directly
+    3. Static binary removal at common paths as last resort
 
-    Should only be called AFTER verify_claude_installation() confirms
-    native installation success (source == 'native').
+    On total failure, displays manual removal instructions via
+    ``_warn_npm_removal_failed()``.
 
     Returns:
-        True if npm installation was removed or did not exist, False if removal failed.
+        True if npm installation was removed or did not exist, False if
+        removal failed.
 
     Note:
-        Safe to call even if npm is not installed - returns True in that case.
+        Safe to call even if npm is not installed -- returns True in that case.
         Permission failures are handled gracefully without user-facing errors.
     """
     npm_path = find_command('npm')
@@ -808,9 +847,56 @@ def remove_npm_claude() -> bool:
             # No sudo mechanism available -- provide guidance
             warning('Cannot use sudo (non-interactive mode, no terminal available)')
             info('When running via curl | bash, sudo cannot prompt for a password.')
-            info(f'Manual removal may be needed: sudo {npm_path} uninstall -g {CLAUDE_NPM_PACKAGE}')
 
-    # Direct file removal as last resort
+    # Dynamic prefix rm-rf fallback (Unix only)
+    # When npm uninstall fails (e.g., ENOTEMPTY from npm/cli#5825),
+    # remove package files directly using the npm global prefix path.
+    if sys.platform != 'win32':
+        prefix = _get_npm_global_prefix(npm_path)
+        if prefix:
+            parent_dir = Path(prefix) / 'lib' / 'node_modules' / '@anthropic-ai'
+            pkg_dir = parent_dir / 'claude-code'
+            bin_path = Path(prefix) / 'bin' / 'claude'
+
+            # Build rm-rf target list with Python-side glob expansion.
+            # subprocess.run() does NOT expand globs without shell=True,
+            # so we expand .claude-code-* using Path.glob() first.
+            rm_targets: list[str] = []
+
+            # Stale temp directories from interrupted npm operations
+            if parent_dir.exists():
+                rm_targets.extend(str(d) for d in parent_dir.glob('.claude-code-*'))
+
+            # Package directory
+            if pkg_dir.exists():
+                rm_targets.append(str(pkg_dir))
+
+            # Binary symlink
+            if bin_path.exists() or bin_path.is_symlink():
+                rm_targets.append(str(bin_path))
+
+            if rm_targets:
+                info('Attempting direct file removal using npm prefix path...')
+                rm_cmd = ['rm', '-rf'] + rm_targets
+                rm_result = _run_with_sudo_fallback(
+                    rm_cmd,
+                    capture_output=True,
+                    timeout=30,
+                    tty_timeout=60,
+                )
+
+                if rm_result is not None and rm_result.returncode == 0:
+                    # Clean up empty parent directory
+                    if parent_dir.exists() and not any(parent_dir.iterdir()):
+                        with contextlib.suppress(OSError):
+                            parent_dir.rmdir()
+
+                    # Verify removal via file-based check (not npm list)
+                    if not pkg_dir.exists() and not bin_path.exists():
+                        success('Removed npm Claude installation via direct file removal')
+                        return True
+
+    # Direct binary removal as last resort
     # Most effective on Windows where npm globals are user-writable
     if sys.platform == 'win32':
         npm_binary_paths = [
@@ -821,6 +907,7 @@ def remove_npm_claude() -> bool:
     else:
         npm_binary_paths = [
             Path('/usr/local/bin/claude'),
+            Path('/usr/bin/claude'),
             get_real_user_home() / '.npm-global' / 'bin' / 'claude',
         ]
 
@@ -841,10 +928,9 @@ def remove_npm_claude() -> bool:
         info('Note: npm registry may still list the package, but the binary is gone')
         return True
 
-    # All attempts failed - provide guidance
-    warning('Could not remove npm installation automatically')
-    info(f'Manual removal may be needed: sudo {npm_path} uninstall -g {CLAUDE_NPM_PACKAGE}')
-    info('This does not affect your native Claude installation.')
+    # Self-warn on total failure. Callers (e.g., _finalize_native_install())
+    # must NOT call _warn_npm_removal_failed() separately to avoid double-warning.
+    _warn_npm_removal_failed(npm_path)
     return False
 
 

--- a/scripts/install_claude.py
+++ b/scripts/install_claude.py
@@ -831,7 +831,7 @@ def remove_npm_claude() -> bool:
         return True
 
     # Non-sudo uninstall failed - try with sudo on Unix systems
-    if platform.system() != 'Windows':
+    if sys.platform != 'win32':
         sudo_result = _run_with_sudo_fallback(
             [npm_path, 'uninstall', '-g', CLAUDE_NPM_PACKAGE],
             capture_output=True,

--- a/tests/e2e/test_npm_fallback.py
+++ b/tests/e2e/test_npm_fallback.py
@@ -344,15 +344,17 @@ class TestRemoveNpmClaudeSudoGatingE2E:
                 ],
             ),
             patch.object(install_claude, '_run_with_sudo_fallback', return_value=None),
+            patch.object(install_claude, '_get_npm_global_prefix', return_value=None),
             patch('pathlib.Path.exists', return_value=False),
+            patch('pathlib.Path.is_symlink', return_value=False),
         ):
             result = install_claude.remove_npm_claude()
 
         assert result is False
         captured = capsys.readouterr()
         combined = captured.out + captured.err
-        assert 'does not affect' in combined.lower(), (
-            'Should reassure that native installation is unaffected'
+        assert 'was not removed' in combined.lower(), (
+            'Should warn that npm installation was NOT removed'
         )
 
     def test_remove_npm_claude_error_output_suppressed(

--- a/tests/e2e/test_npm_fallback.py
+++ b/tests/e2e/test_npm_fallback.py
@@ -304,7 +304,7 @@ class TestRemoveNpmClaudeSudoGatingE2E:
         mock_sudo.return_value = subprocess.CompletedProcess([], 0, '', '')
 
         with (
-            patch('platform.system', return_value='Linux'),
+            patch('sys.platform', 'linux'),
             patch.object(
                 install_claude, 'find_command', return_value='/usr/bin/npm',
             ),

--- a/tests/test_install_claude.py
+++ b/tests/test_install_claude.py
@@ -2423,15 +2423,14 @@ class TestRemoveNpmClaude:
         ]
 
     @patch('install_claude._warn_npm_removal_failed')
-    @patch('platform.system', return_value='Windows')
+    @patch('sys.platform', 'win32')
     @patch('install_claude.run_command')
     @patch('install_claude.find_command')
     def test_remove_npm_claude_uninstall_failure(
-        self, mock_find: MagicMock, mock_run: MagicMock, mock_system: MagicMock,
+        self, mock_find: MagicMock, mock_run: MagicMock,
         mock_warn: MagicMock,
     ) -> None:
         """Test remove_npm_claude returns False when npm uninstall fails on Windows."""
-        assert mock_system.return_value == 'Windows'
         mock_find.return_value = '/usr/local/bin/npm'
         # First call: npm list -g returns 0 (package found)
         # Second call: npm uninstall -g returns non-zero (failure)
@@ -2465,16 +2464,15 @@ class TestRemoveNpmClaude:
         args = mock_run.call_args_list[0][0][0]
         assert args[0] == r'C:\Program Files\nodejs\npm.cmd'
 
-    @patch('platform.system', return_value='Linux')
+    @patch('sys.platform', 'linux')
     @patch('install_claude._run_with_sudo_fallback')
     @patch('install_claude.run_command')
     @patch('install_claude.find_command')
     def test_remove_npm_claude_sudo_with_tty(
         self, mock_find: MagicMock, mock_run: MagicMock,
-        mock_sudo: MagicMock, mock_system: MagicMock,
+        mock_sudo: MagicMock,
     ) -> None:
         """Test sudo retry via _run_with_sudo_fallback when initial uninstall fails."""
-        assert mock_system.return_value == 'Linux'
         mock_find.return_value = '/usr/bin/npm'
         mock_run.side_effect = [
             MagicMock(returncode=0),  # npm list -g (package found)
@@ -2491,17 +2489,15 @@ class TestRemoveNpmClaude:
         assert sudo_args[0] == '/usr/bin/npm'
         assert 'uninstall' in sudo_args
 
-    @patch('platform.system', return_value='Linux')
     @patch('sys.platform', 'linux')
     @patch('install_claude._run_with_sudo_fallback')
     @patch('install_claude.run_command')
     @patch('install_claude.find_command')
     def test_remove_npm_claude_no_tty_no_cached_creds(
         self, mock_find: MagicMock, mock_run: MagicMock,
-        mock_sudo: MagicMock, mock_system: MagicMock,
+        mock_sudo: MagicMock,
     ) -> None:
         """Test direct file removal fallback when sudo is unavailable."""
-        assert mock_system.return_value == 'Linux'
         mock_find.return_value = '/usr/bin/npm'
         mock_run.side_effect = [
             MagicMock(returncode=0),  # npm list -g (package found)
@@ -2516,16 +2512,15 @@ class TestRemoveNpmClaude:
         assert result is False
         mock_sudo.assert_called_once()
 
-    @patch('platform.system', return_value='Linux')
+    @patch('sys.platform', 'linux')
     @patch('install_claude._run_with_sudo_fallback')
     @patch('install_claude.run_command')
     @patch('install_claude.find_command')
     def test_remove_npm_claude_no_tty_cached_creds(
         self, mock_find: MagicMock, mock_run: MagicMock,
-        mock_sudo: MagicMock, mock_system: MagicMock,
+        mock_sudo: MagicMock,
     ) -> None:
         """Test sudo retry via _run_with_sudo_fallback with cached credentials."""
-        assert mock_system.return_value == 'Linux'
         mock_find.return_value = '/usr/bin/npm'
         mock_run.side_effect = [
             MagicMock(returncode=0),  # npm list -g (package found)
@@ -2541,17 +2536,15 @@ class TestRemoveNpmClaude:
         sudo_args = mock_sudo.call_args[0][0]
         assert sudo_args[0] == '/usr/bin/npm'
 
-    @patch('platform.system', return_value='Linux')
     @patch('sys.platform', 'linux')
     @patch('install_claude._run_with_sudo_fallback')
     @patch('install_claude.run_command')
     @patch('install_claude.find_command')
     def test_remove_npm_claude_sudo_file_not_found(
         self, mock_find: MagicMock, mock_run: MagicMock,
-        mock_sudo: MagicMock, mock_system: MagicMock,
+        mock_sudo: MagicMock,
     ) -> None:
         """Test graceful handling when sudo is unavailable (returns None)."""
-        assert mock_system.return_value == 'Linux'
         mock_find.return_value = '/usr/bin/npm'
         mock_run.side_effect = [
             MagicMock(returncode=0),  # npm list -g (package found)
@@ -2566,16 +2559,15 @@ class TestRemoveNpmClaude:
         assert result is False
         mock_sudo.assert_called_once()
 
-    @patch('platform.system', return_value='Linux')
+    @patch('sys.platform', 'linux')
     @patch('subprocess.run')
     @patch('install_claude.run_command')
     @patch('install_claude.find_command')
     def test_remove_npm_claude_first_attempt_succeeds_no_sudo(
         self, mock_find: MagicMock, mock_run: MagicMock,
-        mock_subprocess: MagicMock, mock_system: MagicMock,
+        mock_subprocess: MagicMock,
     ) -> None:
         """Test no sudo attempt when initial uninstall succeeds (regression test)."""
-        assert mock_system.return_value == 'Linux'
         mock_find.return_value = '/usr/bin/npm'
         mock_run.side_effect = [
             MagicMock(returncode=0),  # npm list -g (package found)
@@ -2589,17 +2581,16 @@ class TestRemoveNpmClaude:
         mock_subprocess.assert_not_called()
 
     @patch('install_claude._warn_npm_removal_failed')
-    @patch('platform.system', return_value='Windows')
+    @patch('sys.platform', 'win32')
     @patch('subprocess.run')
     @patch('install_claude.run_command')
     @patch('install_claude.find_command')
     def test_remove_npm_claude_windows_no_sudo(
         self, mock_find: MagicMock, mock_run: MagicMock,
-        mock_subprocess: MagicMock, mock_system: MagicMock,
+        mock_subprocess: MagicMock,
         mock_warn: MagicMock,
     ) -> None:
         """Test no sudo attempt on Windows even when uninstall fails."""
-        assert mock_system.return_value == 'Windows'
         mock_find.return_value = r'C:\Program Files\nodejs\npm.cmd'
         mock_run.side_effect = [
             MagicMock(returncode=0),  # npm list -g (package found)

--- a/tests/test_install_claude.py
+++ b/tests/test_install_claude.py
@@ -2422,11 +2422,13 @@ class TestRemoveNpmClaude:
             '/usr/local/bin/npm', 'uninstall', '-g', '@anthropic-ai/claude-code',
         ]
 
+    @patch('install_claude._warn_npm_removal_failed')
     @patch('platform.system', return_value='Windows')
     @patch('install_claude.run_command')
     @patch('install_claude.find_command')
     def test_remove_npm_claude_uninstall_failure(
         self, mock_find: MagicMock, mock_run: MagicMock, mock_system: MagicMock,
+        mock_warn: MagicMock,
     ) -> None:
         """Test remove_npm_claude returns False when npm uninstall fails on Windows."""
         assert mock_system.return_value == 'Windows'
@@ -2442,6 +2444,7 @@ class TestRemoveNpmClaude:
 
         assert result is False
         assert mock_run.call_count == 2
+        mock_warn.assert_called_once()
 
     @patch('install_claude.run_command')
     @patch('install_claude.find_command')
@@ -2585,6 +2588,7 @@ class TestRemoveNpmClaude:
         # subprocess.run should NOT be called at all (no sudo needed)
         mock_subprocess.assert_not_called()
 
+    @patch('install_claude._warn_npm_removal_failed')
     @patch('platform.system', return_value='Windows')
     @patch('subprocess.run')
     @patch('install_claude.run_command')
@@ -2592,6 +2596,7 @@ class TestRemoveNpmClaude:
     def test_remove_npm_claude_windows_no_sudo(
         self, mock_find: MagicMock, mock_run: MagicMock,
         mock_subprocess: MagicMock, mock_system: MagicMock,
+        mock_warn: MagicMock,
     ) -> None:
         """Test no sudo attempt on Windows even when uninstall fails."""
         assert mock_system.return_value == 'Windows'
@@ -2606,6 +2611,164 @@ class TestRemoveNpmClaude:
         assert result is False
         # subprocess.run should NOT be called (Windows, no sudo)
         mock_subprocess.assert_not_called()
+        mock_warn.assert_called_once()
+
+
+class TestGetNpmGlobalPrefix:
+    """Tests for _get_npm_global_prefix() helper."""
+
+    @patch('subprocess.run')
+    def test_returns_prefix_on_success(self, mock_run: MagicMock) -> None:
+        """Successful prefix retrieval."""
+        mock_run.return_value = MagicMock(returncode=0, stdout='/usr\n')
+        result = install_claude._get_npm_global_prefix('/usr/bin/npm')
+        assert result == '/usr'
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args == ['/usr/bin/npm', 'config', 'get', 'prefix']
+
+    @patch('subprocess.run')
+    def test_returns_none_on_failure(self, mock_run: MagicMock) -> None:
+        """Returns None when npm config command fails."""
+        mock_run.return_value = MagicMock(returncode=1, stdout='')
+        result = install_claude._get_npm_global_prefix('/usr/bin/npm')
+        assert result is None
+
+    @patch('subprocess.run')
+    def test_returns_none_on_empty_output(self, mock_run: MagicMock) -> None:
+        """Returns None when npm returns empty prefix."""
+        mock_run.return_value = MagicMock(returncode=0, stdout='  \n')
+        result = install_claude._get_npm_global_prefix('/usr/bin/npm')
+        assert result is None
+
+    @patch('subprocess.run', side_effect=subprocess.TimeoutExpired(cmd=[], timeout=10))
+    def test_returns_none_on_timeout(self, mock_run: MagicMock) -> None:
+        """Returns None when npm config times out."""
+        result = install_claude._get_npm_global_prefix('/usr/bin/npm')
+        assert result is None
+        mock_run.assert_called_once()
+
+    @patch('subprocess.run', side_effect=FileNotFoundError)
+    def test_returns_none_on_file_not_found(self, mock_run: MagicMock) -> None:
+        """Returns None when npm executable not found."""
+        result = install_claude._get_npm_global_prefix('/nonexistent/npm')
+        assert result is None
+        mock_run.assert_called_once()
+
+    @patch('subprocess.run')
+    def test_strips_whitespace(self, mock_run: MagicMock) -> None:
+        """Output whitespace is stripped."""
+        mock_run.return_value = MagicMock(returncode=0, stdout='  /usr/local  \n')
+        result = install_claude._get_npm_global_prefix('/usr/bin/npm')
+        assert result == '/usr/local'
+
+
+class TestRemoveNpmClaudeRmrfFallback:
+    """Tests for rm-rf fallback in remove_npm_claude()."""
+
+    @patch('sys.platform', 'linux')
+    @patch('platform.system', return_value='Linux')
+    @patch('install_claude._run_with_sudo_fallback')
+    @patch('install_claude.run_command')
+    @patch('install_claude.find_command')
+    def test_rmrf_fallback_success(
+        self, mock_find: MagicMock, mock_run: MagicMock, mock_sudo: MagicMock, mock_system: MagicMock, tmp_path: Path,
+    ) -> None:
+        """rm-rf fallback succeeds after npm uninstall and sudo both fail."""
+        assert mock_system.return_value == 'Linux'
+        mock_find.return_value = '/usr/bin/npm'
+        mock_run.side_effect = [
+            MagicMock(returncode=0),  # npm list -g (found)
+            MagicMock(returncode=1),  # npm uninstall -g (ENOTEMPTY)
+        ]
+
+        # Create mock directory structure for glob expansion
+        parent_dir = tmp_path / 'lib' / 'node_modules' / '@anthropic-ai'
+        parent_dir.mkdir(parents=True)
+        (parent_dir / '.claude-code-ABC123').mkdir()
+        (parent_dir / 'claude-code').mkdir()
+        bin_dir = tmp_path / 'bin'
+        bin_dir.mkdir()
+        (bin_dir / 'claude').touch()
+
+        # First sudo: npm uninstall via sudo fails
+        # Second sudo: rm -rf via sudo succeeds
+        mock_sudo.side_effect = [
+            subprocess.CompletedProcess([], 1, '', ''),
+            subprocess.CompletedProcess([], 0, '', ''),
+        ]
+
+        with patch('install_claude._get_npm_global_prefix', return_value=str(tmp_path)):
+            install_claude.remove_npm_claude()
+
+        # rm -rf was attempted (second sudo call)
+        assert mock_sudo.call_count == 2
+
+    @patch('sys.platform', 'linux')
+    @patch('platform.system', return_value='Linux')
+    @patch('install_claude._run_with_sudo_fallback')
+    @patch('install_claude.run_command')
+    @patch('install_claude.find_command')
+    def test_rmrf_no_prefix_falls_through(
+        self, mock_find: MagicMock, mock_run: MagicMock, mock_sudo: MagicMock, mock_system: MagicMock,
+    ) -> None:
+        """rm-rf fallback is skipped when prefix is unavailable."""
+        assert mock_system.return_value == 'Linux'
+        mock_find.return_value = '/usr/bin/npm'
+        mock_run.side_effect = [
+            MagicMock(returncode=0),  # npm list -g (found)
+            MagicMock(returncode=1),  # npm uninstall -g fails
+        ]
+        # sudo npm uninstall fails
+        mock_sudo.return_value = subprocess.CompletedProcess([], 1, '', '')
+
+        with patch('install_claude._get_npm_global_prefix', return_value=None), \
+             patch('install_claude._warn_npm_removal_failed'):
+            result = install_claude.remove_npm_claude()
+
+        # Should fall through to static binary removal (which also fails)
+        assert result is False
+
+    @patch('sys.platform', 'linux')
+    @patch('platform.system', return_value='Linux')
+    @patch('install_claude._run_with_sudo_fallback')
+    @patch('install_claude.run_command')
+    @patch('install_claude.find_command')
+    def test_rmrf_expands_glob_in_python(
+        self, mock_find: MagicMock, mock_run: MagicMock, mock_sudo: MagicMock, mock_system: MagicMock, tmp_path: Path,
+    ) -> None:
+        """Glob .claude-code-* is expanded via Path.glob(), not passed raw to subprocess."""
+        assert mock_system.return_value == 'Linux'
+        mock_find.return_value = '/usr/bin/npm'
+        mock_run.side_effect = [
+            MagicMock(returncode=0),  # npm list -g (found)
+            MagicMock(returncode=1),  # npm uninstall -g fails
+        ]
+        # First sudo: npm uninstall fails; second: rm -rf succeeds
+        mock_sudo.side_effect = [
+            subprocess.CompletedProcess([], 1, '', ''),
+            subprocess.CompletedProcess([], 0, '', ''),
+        ]
+
+        # Create mock directory structure with stale temp dirs
+        parent_dir = tmp_path / 'lib' / 'node_modules' / '@anthropic-ai'
+        parent_dir.mkdir(parents=True)
+        (parent_dir / '.claude-code-ABC123').mkdir()
+        (parent_dir / '.claude-code-XYZ789').mkdir()
+        (parent_dir / 'claude-code').mkdir()
+        bin_dir = tmp_path / 'bin'
+        bin_dir.mkdir()
+        (bin_dir / 'claude').touch()
+
+        with patch('install_claude._get_npm_global_prefix', return_value=str(tmp_path)):
+            install_claude.remove_npm_claude()
+
+        # Verify the rm -rf command received expanded paths, not raw glob
+        if mock_sudo.call_count >= 2:
+            rm_call_args = mock_sudo.call_args_list[1][0][0]  # Second sudo call args
+            # Should NOT contain any glob pattern like '.claude-code-*'
+            for arg in rm_call_args:
+                assert '*' not in arg, f'Raw glob pattern found in subprocess args: {arg}'
 
 
 class TestDevTtySudoAvailable:
@@ -2740,29 +2903,60 @@ class TestRunWithSudoFallback:
 
 
 class TestWarnNpmRemovalFailed:
-    """Tests for _warn_npm_removal_failed() helper."""
+    """Tests for _warn_npm_removal_failed() warning display."""
 
     def test_produces_output(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Produces visible warning output."""
-        install_claude._warn_npm_removal_failed()
+        with patch('install_claude._get_npm_global_prefix', return_value=None):
+            install_claude._warn_npm_removal_failed()
         captured = capsys.readouterr()
-        assert 'WARNING' in captured.err or 'WARNING' in captured.out
-        assert 'npm Claude Code installation was NOT removed' in (captured.err + captured.out)
+        combined = captured.err + captured.out
+        assert 'WARNING' in combined
+        assert 'npm Claude Code installation was NOT removed' in combined
+
+    @patch('install_claude._get_npm_global_prefix', return_value='/usr')
+    @patch('sys.platform', 'linux')
+    def test_unix_shows_rmrf_instructions(self, mock_prefix: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+        """Unix instructions show rm -rf, not npm uninstall."""
+        assert mock_prefix.return_value == '/usr'
+        install_claude._warn_npm_removal_failed(npm_path='/usr/bin/npm')
+        captured = capsys.readouterr()
+        combined = captured.err + captured.out
+        assert 'sudo rm -rf' in combined
+        assert 'sudo rm -f' in combined
+        assert '/usr/lib/node_modules/@anthropic-ai' in combined
+        assert '/usr/bin/claude' in combined
+
+    @patch('install_claude._get_npm_global_prefix', return_value=None)
+    @patch('sys.platform', 'linux')
+    def test_unix_no_prefix_uses_defaults(self, mock_prefix: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+        """Fallback paths when prefix is unavailable."""
+        assert mock_prefix.return_value is None
+        install_claude._warn_npm_removal_failed(npm_path='/usr/bin/npm')
+        captured = capsys.readouterr()
+        combined = captured.err + captured.out
+        assert '/usr/lib/node_modules/@anthropic-ai' in combined
+        assert '/usr/bin/claude' in combined
 
     @patch('sys.platform', 'win32')
-    def test_windows_command(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """Shows non-sudo command on Windows."""
-        install_claude._warn_npm_removal_failed(npm_path='npm')
+    def test_windows_shows_npm_uninstall(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Windows instructions still show npm uninstall."""
+        install_claude._warn_npm_removal_failed(npm_path=r'C:\npm.cmd')
         captured = capsys.readouterr()
         combined = captured.err + captured.out
-        assert 'sudo' not in combined or 'npm uninstall -g' in combined
+        assert 'npm' in combined
+        assert 'uninstall' in combined
 
-    def test_custom_npm_path(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """Uses custom npm path in the manual command."""
-        install_claude._warn_npm_removal_failed(npm_path='/custom/npm')
+    @patch('install_claude._get_npm_global_prefix', return_value='/usr/local')
+    @patch('sys.platform', 'linux')
+    def test_uses_dynamic_prefix(self, mock_prefix: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+        """Uses dynamic prefix path when available."""
+        assert mock_prefix.return_value == '/usr/local'
+        install_claude._warn_npm_removal_failed(npm_path='/usr/bin/npm')
         captured = capsys.readouterr()
         combined = captured.err + captured.out
-        assert '/custom/npm' in combined
+        assert '/usr/local/lib/node_modules/@anthropic-ai' in combined
+        assert '/usr/local/bin/claude' in combined
 
 
 class TestCheckNpmClaudeInstalled:
@@ -2800,44 +2994,76 @@ class TestCheckNpmClaudeInstalled:
 
 
 class TestFinalizeNativeInstall:
-    """Tests for _finalize_native_install() helper function."""
+    """Tests for _finalize_native_install() cleanup sequence."""
 
-    def test_calls_sequence(self) -> None:
-        """Verify _finalize_native_install calls remove, check, and config update."""
-        with patch('install_claude.remove_npm_claude', return_value=True) as mock_remove, \
-                patch('install_claude._check_npm_claude_installed', return_value=False) as mock_check, \
-                patch('install_claude.update_install_method_config') as mock_config:
-            install_claude._finalize_native_install()
-            mock_remove.assert_called_once()
-            mock_check.assert_called_once()
-            mock_config.assert_called_once_with('native')
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude._check_npm_claude_installed')
+    @patch('install_claude.remove_npm_claude', return_value=True)
+    def test_skips_npm_check_on_successful_removal(
+        self, mock_remove: MagicMock, mock_check: MagicMock, mock_config: MagicMock,
+    ) -> None:
+        """_check_npm_claude_installed is NOT called when removal succeeds."""
+        install_claude._finalize_native_install()
 
-    def test_warns_on_removal_failure(self) -> None:
-        """Verify warning is issued when npm removal fails."""
-        with patch('install_claude.remove_npm_claude', return_value=False), \
-                patch('install_claude._check_npm_claude_installed', return_value=False), \
-                patch('install_claude.update_install_method_config'), \
-                patch('install_claude._warn_npm_removal_failed') as mock_warn:
-            install_claude._finalize_native_install()
-            mock_warn.assert_called_once()
+        mock_remove.assert_called_once()
+        mock_check.assert_not_called()
+        mock_config.assert_called_once_with('native')
 
-    def test_warns_on_npm_still_installed(self) -> None:
-        """Verify warning when npm is still installed after removal attempt."""
-        with patch('install_claude.remove_npm_claude', return_value=True), \
-                patch('install_claude._check_npm_claude_installed', return_value=True), \
-                patch('install_claude.update_install_method_config'), \
-                patch('install_claude._warn_npm_removal_failed') as mock_warn:
-            install_claude._finalize_native_install()
-            mock_warn.assert_called_once()
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude._check_npm_claude_installed', return_value=True)
+    @patch('install_claude.remove_npm_claude', return_value=False)
+    def test_checks_npm_on_failed_removal(
+        self, mock_remove: MagicMock, mock_check: MagicMock, mock_config: MagicMock,
+    ) -> None:
+        """_check_npm_claude_installed IS called when removal fails."""
+        install_claude._finalize_native_install()
 
-    def test_both_failures(self) -> None:
-        """Verify both warnings when removal fails AND npm still detected."""
-        with patch('install_claude.remove_npm_claude', return_value=False), \
-                patch('install_claude._check_npm_claude_installed', return_value=True), \
-                patch('install_claude.update_install_method_config'), \
-                patch('install_claude._warn_npm_removal_failed') as mock_warn:
+        mock_remove.assert_called_once()
+        mock_check.assert_called_once()
+        mock_config.assert_called_once_with('native')
+
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude._check_npm_claude_installed', return_value=False)
+    @patch('install_claude.remove_npm_claude', return_value=False)
+    def test_no_extra_warning_when_npm_check_returns_false(
+        self, mock_remove: MagicMock, mock_check: MagicMock, mock_config: MagicMock,
+    ) -> None:
+        """No additional warning when npm is already gone despite failure return."""
+        install_claude._finalize_native_install()
+
+        mock_remove.assert_called_once()
+        mock_check.assert_called_once()
+        mock_config.assert_called_once_with('native')
+
+    @patch('install_claude.update_install_method_config')
+    def test_always_updates_config_to_native(
+        self, mock_config: MagicMock,
+    ) -> None:
+        """Config is always updated to 'native' regardless of removal outcome."""
+        with patch('install_claude.remove_npm_claude', return_value=True):
             install_claude._finalize_native_install()
-            assert mock_warn.call_count == 2
+        mock_config.assert_called_once_with('native')
+
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude._warn_npm_removal_failed')
+    @patch('install_claude._check_npm_claude_installed', return_value=True)
+    @patch('install_claude.remove_npm_claude', return_value=False)
+    def test_does_not_call_warn_directly(
+        self, mock_remove: MagicMock, mock_check: MagicMock, mock_warn: MagicMock, mock_config: MagicMock,
+    ) -> None:
+        """_finalize_native_install does not call _warn_npm_removal_failed directly.
+
+        Warning display is handled by remove_npm_claude() itself when all
+        removal strategies are exhausted. _finalize_native_install() must NOT
+        call _warn_npm_removal_failed() separately to avoid double-warning.
+        """
+        install_claude._finalize_native_install()
+
+        mock_remove.assert_called_once()
+        mock_check.assert_called_once()
+        mock_config.assert_called_once_with('native')
+        # _warn_npm_removal_failed should NOT be called directly by _finalize_native_install
+        mock_warn.assert_not_called()
 
 
 class TestVerifyClaudeInstallationUsrLocalBin:


### PR DESCRIPTION
When npm uninstall fails with ENOTEMPTY (npm/cli#5825), the installer now falls back to direct file removal using the npm global prefix path before resorting to static binary removal.

The multi-tier removal strategy is:
1. npm uninstall -g (direct, then with sudo on Unix)
2. Dynamic prefix rm-rf using npm config get prefix
3. Static binary removal at common paths as last resort

Additional fixes:
- Skip spurious npm-list verification in _finalize_native_install() when remove_npm_claude() reports success, since direct file removal can leave stale npm registry metadata
- Update _warn_npm_removal_failed() to show rm-rf instructions instead of npm uninstall, which can fail with the same ENOTEMPTY error
- Add /usr/bin/claude to static binary fallback paths
- Move warning display into remove_npm_claude() to prevent double-warning from callers
- Add ENOTEMPTY troubleshooting section to documentation