### PR TITLE
Rename additional-settings.json to settings.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -452,7 +452,7 @@ For private repository access:
 
 ### MCP Server Permissions
 
-When configuring MCP servers, permissions are automatically added to `additional-settings.json`:
+When configuring MCP servers, permissions are automatically added to `settings.json`:
 ```json
 {
   "permissions": {
@@ -543,16 +543,16 @@ Step comments and print statements in `main()` (e.g., `# Step N:`, `Step N: ...`
 1. Test with local file: Create test YAML, run with `./test.yaml`
 2. Test with remote URL to verify warning messages appear
 3. Verify global command registration works
-4. Verify additional-settings.json structure
+4. Verify settings.json structure
 5. Check that hooks execute properly after setup
 
 ### When creating custom environment configs
 1. Create your YAML configuration file
 2. Test local installation flow with your config
 3. Verify all referenced files are accessible
-4. Verify additional-settings.json structure is correct:
-   - `~/.config/claude/additional-settings.json` on Linux/macOS
-   - `%LOCALAPPDATA%\Claude\additional-settings.json` on Windows
+4. Verify settings.json structure is correct:
+   - `~/.config/claude/settings.json` on Linux/macOS
+   - `%LOCALAPPDATA%\Claude\settings.json` on Windows
 5. Ensure hooks trigger correctly
 
 ### Mock Target Alignment Rule

--- a/docs/cross-shell-launcher-architecture.md
+++ b/docs/cross-shell-launcher-architecture.md
@@ -74,8 +74,8 @@ fi
 # Read prompt and get Windows path for settings
 PROMPT_CONTENT=$(tr -d '\r' < "$PROMPT_PATH")
 # Try to get Windows path format; fallback to Unix path if cygpath is not available
-SETTINGS_WIN="$(cygpath -m "$HOME/.claude/additional-settings.json" 2>/dev/null ||
-  echo "$HOME/.claude/additional-settings.json")"
+SETTINGS_WIN="$(cygpath -m "$HOME/.claude/settings.json" 2>/dev/null ||
+  echo "$HOME/.claude/settings.json")"
 
 exec claude --append-system-prompt "$PROMPT_CONTENT" --settings "$SETTINGS_WIN" "$@"
 ```
@@ -183,11 +183,11 @@ PROMPT_CONTENT=$(tr -d '\r' < "$PROMPT_PATH")
 Using `cygpath -m` provides Windows-compatible paths with forward slashes:
 
 ```bash
-SETTINGS_WIN="$(cygpath -m "$HOME/.claude/additional-settings.json")"
-# Result: C:/Users/username/.claude/additional-settings.json
+SETTINGS_WIN="$(cygpath -m "$HOME/.claude/settings.json")"
+# Result: C:/Users/username/.claude/settings.json
 ```
 
-> **Current Implementation:** The actual settings file path is `$HOME/.claude/{command_name}-additional-settings.json` (e.g., `python-additional-settings.json`), prefixed with the command name for environment isolation.
+> **Current Implementation:** The actual settings file path is `$HOME/.claude/{command_name}-settings.json` (e.g., `python-settings.json`), prefixed with the command name for environment isolation.
 
 ### Technical Deep Dive
 
@@ -348,7 +348,7 @@ claude-my-env --debug 2>&1 | grep -i settings
 Check the resolved paths:
 
 ```bash
-bash -c 'echo "Home: $HOME"; cygpath -m "$HOME/.claude/additional-settings.json"'
+bash -c 'echo "Home: $HOME"; cygpath -m "$HOME/.claude/settings.json"'
 ```
 
 #### Script Permissions

--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -448,7 +448,7 @@ Sets an HTTP header for both `http` and `sse` transports.
 
 #### Automatic Permission Pre-Allowing
 
-MCP server names are automatically added to the `permissions.allow` list as `mcp__servername` in the additional settings file. You do not need to manually add MCP server permissions.
+MCP server names are automatically added to the `permissions.allow` list as `mcp__servername` in the settings file. You do not need to manually add MCP server permissions.
 
 ### Model and Reasoning
 
@@ -529,7 +529,7 @@ permissions:
 
 #### `env-variables`
 
-Claude-level environment variables set in the additional settings file. These are available within Claude Code sessions only.
+Claude-level environment variables set in the settings file. These are available within Claude Code sessions only.
 
 - **Type:** `dict[str, str] | None`
 - **Default:** `None`
@@ -863,7 +863,7 @@ Here is a conceptual overview of what the setup script does when you run it with
 12. **Write user settings** -- Merges `user-settings` into `~/.claude/settings.json`.
 13. **Write global config** -- Merges `global-config` into `~/.claude.json`.
 14. **Download hooks** -- Downloads hook script files. (Only if `command-names` is specified.)
-15. **Configure settings** -- Creates the additional settings file for the command.
+15. **Configure settings** -- Creates the settings file for the command.
 16. **Write manifest** -- Creates an installation tracking manifest.
 17. **Create launcher** -- Creates the launcher script for the command.
 18. **Register commands** -- Creates global command wrappers.

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -6287,7 +6287,7 @@ def download_hook_files(
     return all(results)
 
 
-def create_additional_settings(
+def create_settings(
     hooks: dict[str, Any],
     claude_user_dir: Path,
     command_name: str,
@@ -6300,7 +6300,7 @@ def create_additional_settings(
     status_line: dict[str, Any] | None = None,
     effort_level: str | None = None,
 ) -> bool:
-    """Create {command_name}-additional-settings.json with environment-specific settings.
+    """Create {command_name}-settings.json with environment-specific settings.
 
     This file is always overwritten to avoid duplicate hooks when re-running the installer.
     It's loaded via --settings flag when launching Claude.
@@ -6327,7 +6327,7 @@ def create_additional_settings(
     Returns:
         bool: True if successful, False otherwise.
     """
-    info(f'Creating {command_name}-additional-settings.json...')
+    info(f'Creating {command_name}-settings.json...')
 
     # Create fresh settings structure for this environment
     settings: dict[str, Any] = {}
@@ -6585,15 +6585,15 @@ def create_additional_settings(
                 matcher_hooks_list = cast(list[object], matcher_hooks_raw)
                 matcher_hooks_list.append(hook_config)
 
-    # Save additional settings (always overwrite)
-    additional_settings_path = claude_user_dir / f'{command_name}-additional-settings.json'
+    # Save settings (always overwrite)
+    settings_path = claude_user_dir / f'{command_name}-settings.json'
     try:
-        with open(additional_settings_path, 'w') as f:
+        with open(settings_path, 'w') as f:
             json.dump(settings, f, indent=2)
-        success(f'Created {command_name}-additional-settings.json')
+        success(f'Created {command_name}-settings.json')
         return True
     except Exception as e:
-        error(f'Failed to save {command_name}-additional-settings.json: {e}')
+        error(f'Failed to save {command_name}-settings.json: {e}')
         return False
 
 
@@ -6781,8 +6781,8 @@ if "%~1"=="" (
 set -euo pipefail
 
 # Get Windows path for settings
-SETTINGS_WIN="$(cygpath -m "$HOME/.claude/{command_name}-additional-settings.json" 2>/dev/null ||
-  echo "$HOME/.claude/{command_name}-additional-settings.json")"
+SETTINGS_WIN="$(cygpath -m "$HOME/.claude/{command_name}-settings.json" 2>/dev/null ||
+  echo "$HOME/.claude/{command_name}-settings.json")"
 
 # MCP configuration for profile-scoped servers
 MCP_CONFIG_PATH="$HOME/.claude/{command_name}-mcp.json"
@@ -6937,8 +6937,8 @@ fi
 set -euo pipefail
 
 # Get Windows path for settings
-SETTINGS_WIN="$(cygpath -m "$HOME/.claude/{command_name}-additional-settings.json" 2>/dev/null ||
-  echo "$HOME/.claude/{command_name}-additional-settings.json")"
+SETTINGS_WIN="$(cygpath -m "$HOME/.claude/{command_name}-settings.json" 2>/dev/null ||
+  echo "$HOME/.claude/{command_name}-settings.json")"
 
 # MCP configuration for profile-scoped servers
 MCP_CONFIG_PATH="$HOME/.claude/{command_name}-mcp.json"
@@ -6966,7 +6966,7 @@ fi
 # This script starts Claude Code with the configured environment
 
 CLAUDE_USER_DIR="$HOME/.claude"
-SETTINGS_PATH="$CLAUDE_USER_DIR/{command_name}-additional-settings.json"
+SETTINGS_PATH="$CLAUDE_USER_DIR/{command_name}-settings.json"
 PROMPT_PATH="$CLAUDE_USER_DIR/prompts/{system_prompt_file}"
 
 # MCP configuration for profile-scoped servers
@@ -7129,7 +7129,7 @@ fi
 # This script starts Claude Code with the configured environment
 
 CLAUDE_USER_DIR="$HOME/.claude"
-SETTINGS_PATH="$CLAUDE_USER_DIR/{command_name}-additional-settings.json"
+SETTINGS_PATH="$CLAUDE_USER_DIR/{command_name}-settings.json"
 
 # MCP configuration for profile-scoped servers
 MCP_CONFIG_PATH="$CLAUDE_USER_DIR/{command_name}-mcp.json"
@@ -7922,7 +7922,7 @@ def main() -> None:
             if status_line is not None and isinstance(status_line, dict):
                 status_line_arg = cast(dict[str, Any], status_line)
 
-            create_additional_settings(
+            create_settings(
                 hooks,
                 claude_user_dir,
                 primary_command_name,

--- a/tests/e2e/expected/common.py
+++ b/tests/e2e/expected/common.py
@@ -3,9 +3,9 @@
 These values represent files and JSON keys that are identical regardless
 of the operating system.
 
-Note: The actual additional-settings.json location differs by platform:
-- Linux/macOS: {config_claude}/{cmd}-additional-settings.json
-- Windows: {localappdata_claude}/{cmd}-additional-settings.json
+Note: The actual settings.json location differs by platform:
+- Linux/macOS: {config_claude}/{cmd}-settings.json
+- Windows: {localappdata_claude}/{cmd}-settings.json
 
 The MCP config file is always in {claude_dir}/{cmd}-mcp.json.
 """
@@ -23,7 +23,7 @@ COMMON_FILES: Final[list[str]] = [
 
 # Expected keys in generated JSON files
 EXPECTED_JSON_KEYS: Final[dict[str, list[str]]] = {
-    'additional-settings': [
+    'settings': [
         'permissions',
         'env',
         'hooks',

--- a/tests/e2e/expected/linux.py
+++ b/tests/e2e/expected/linux.py
@@ -17,8 +17,8 @@ from typing import Final
 EXPECTED_FILES: Final[list[str]] = [
     # Launcher script in claude_dir
     '{claude_dir}/start-{cmd}.sh',
-    # Additional settings in claude_dir (written to claude_user_dir by create_additional_settings)
-    '{claude_dir}/{cmd}-additional-settings.json',
+    # Settings in claude_dir (written to claude_user_dir by create_settings)
+    '{claude_dir}/{cmd}-settings.json',
     # MCP config in claude_dir
     '{claude_dir}/{cmd}-mcp.json',
     # Symlink in local_bin
@@ -29,7 +29,7 @@ EXPECTED_FILES: Final[list[str]] = [
 # Uses fixture keys that will be resolved at test runtime
 EXPECTED_PATHS: Final[dict[str, str]] = {
     'launcher_script': '{claude_dir}/start-{cmd}.sh',
-    'additional_settings': '{claude_dir}/{cmd}-additional-settings.json',
+    'settings': '{claude_dir}/{cmd}-settings.json',
     'mcp_config': '{claude_dir}/{cmd}-mcp.json',
     'command_symlink': '{local_bin}/{cmd}',
     'hooks_dir': '{claude_dir}/hooks',

--- a/tests/e2e/expected/macos.py
+++ b/tests/e2e/expected/macos.py
@@ -19,8 +19,8 @@ from typing import Final
 EXPECTED_FILES: Final[list[str]] = [
     # Launcher script in claude_dir
     '{claude_dir}/start-{cmd}.sh',
-    # Additional settings in claude_dir (written to claude_user_dir by create_additional_settings)
-    '{claude_dir}/{cmd}-additional-settings.json',
+    # Settings in claude_dir (written to claude_user_dir by create_settings)
+    '{claude_dir}/{cmd}-settings.json',
     # MCP config in claude_dir
     '{claude_dir}/{cmd}-mcp.json',
     # Symlink in local_bin
@@ -31,7 +31,7 @@ EXPECTED_FILES: Final[list[str]] = [
 # Uses fixture keys that will be resolved at test runtime
 EXPECTED_PATHS: Final[dict[str, str]] = {
     'launcher_script': '{claude_dir}/start-{cmd}.sh',
-    'additional_settings': '{claude_dir}/{cmd}-additional-settings.json',
+    'settings': '{claude_dir}/{cmd}-settings.json',
     'mcp_config': '{claude_dir}/{cmd}-mcp.json',
     'command_symlink': '{local_bin}/{cmd}',
     'hooks_dir': '{claude_dir}/hooks',

--- a/tests/e2e/expected/windows.py
+++ b/tests/e2e/expected/windows.py
@@ -29,8 +29,8 @@ EXPECTED_FILES: Final[list[str]] = [
     '{claude_dir}/start-{cmd}.ps1',
     # CMD launcher script
     '{claude_dir}/start-{cmd}.cmd',
-    # Additional settings in claude_dir (written to claude_user_dir by create_additional_settings)
-    '{claude_dir}/{cmd}-additional-settings.json',
+    # Settings in claude_dir (written to claude_user_dir by create_settings)
+    '{claude_dir}/{cmd}-settings.json',
     # MCP config in claude_dir
     '{claude_dir}/{cmd}-mcp.json',
     # Wrapper scripts in local_bin for PATH accessibility
@@ -45,7 +45,7 @@ EXPECTED_PATHS: Final[dict[str, str]] = {
     'launcher_script_posix': '{claude_dir}/launch-{cmd}.sh',
     'launcher_script_ps1': '{claude_dir}/start-{cmd}.ps1',
     'launcher_script_cmd': '{claude_dir}/start-{cmd}.cmd',
-    'additional_settings': '{claude_dir}/{cmd}-additional-settings.json',
+    'settings': '{claude_dir}/{cmd}-settings.json',
     'mcp_config': '{claude_dir}/{cmd}-mcp.json',
     'command_wrapper_cmd': '{local_bin}/{cmd}.cmd',
     'command_wrapper_ps1': '{local_bin}/{cmd}.ps1',

--- a/tests/e2e/test_full_setup.py
+++ b/tests/e2e/test_full_setup.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from scripts.setup_environment import create_additional_settings
 from scripts.setup_environment import create_launcher_script
 from scripts.setup_environment import create_mcp_config_file
+from scripts.setup_environment import create_settings
 from scripts.setup_environment import register_global_command
 from tests.e2e.expected import EXPECTED_FILES
 
@@ -84,8 +84,8 @@ class TestE2EFullSetup:
         # This test verifies file creation logic
         claude_dir = paths['claude_dir']
 
-        # Create additional-settings.json
-        create_additional_settings(
+        # Create settings.json
+        create_settings(
             hooks=golden_config.get('hooks', {}),
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -147,7 +147,7 @@ class TestE2EFullSetup:
         """Verify ALL config keys from golden_config are processed.
 
         This test validates that:
-        - model, permissions, env-variables are in additional-settings.json
+        - model, permissions, env-variables are in settings.json
         - mcp-servers are in {cmd}-mcp.json
         - hooks events are configured
         - always-thinking-enabled, company-announcements, attribution, status-line are present
@@ -156,8 +156,8 @@ class TestE2EFullSetup:
         cmd = golden_config['command-names'][0]
         claude_dir = paths['claude_dir']
 
-        # Create additional settings with ALL config keys
-        create_additional_settings(
+        # Create settings with ALL config keys
+        create_settings(
             hooks=golden_config.get('hooks', {}),
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -172,9 +172,9 @@ class TestE2EFullSetup:
             effort_level=golden_config.get('effort-level'),
         )
 
-        # Verify additional-settings file exists (written to claude_user_dir)
-        settings_path = claude_dir / f'{cmd}-additional-settings.json'
+        # Verify settings file exists (written to claude_user_dir)
+        settings_path = claude_dir / f'{cmd}-settings.json'
 
-        assert settings_path.exists(), f'additional-settings.json not created: {settings_path}'
+        assert settings_path.exists(), f'settings.json not created: {settings_path}'
 
         # Content validation is done in test_output_files.py

--- a/tests/e2e/test_javascript_hooks.py
+++ b/tests/e2e/test_javascript_hooks.py
@@ -10,7 +10,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from scripts.setup_environment import create_additional_settings
+from scripts.setup_environment import create_settings
 
 
 class TestJavaScriptHooks:
@@ -30,7 +30,7 @@ class TestJavaScriptHooks:
         hooks_dir = claude_dir / 'hooks'
         hooks_dir.mkdir(parents=True, exist_ok=True)
 
-        create_additional_settings(
+        create_settings(
             hooks=golden_config.get('hooks', {}),
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -45,7 +45,7 @@ class TestJavaScriptHooks:
             effort_level=None,
         )
 
-        settings_path = claude_dir / f'{cmd}-additional-settings.json'
+        settings_path = claude_dir / f'{cmd}-settings.json'
         data = json.loads(settings_path.read_text())
 
         # Find .js hook and verify node prefix
@@ -78,7 +78,7 @@ class TestJavaScriptHooks:
         hooks_dir = claude_dir / 'hooks'
         hooks_dir.mkdir(parents=True, exist_ok=True)
 
-        create_additional_settings(
+        create_settings(
             hooks=golden_config.get('hooks', {}),
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -93,7 +93,7 @@ class TestJavaScriptHooks:
             effort_level=None,
         )
 
-        settings_path = claude_dir / f'{cmd}-additional-settings.json'
+        settings_path = claude_dir / f'{cmd}-settings.json'
         data = json.loads(settings_path.read_text())
 
         errors: list[str] = []
@@ -121,7 +121,7 @@ class TestJavaScriptHooks:
         hooks_dir = claude_dir / 'hooks'
         hooks_dir.mkdir(parents=True, exist_ok=True)
 
-        create_additional_settings(
+        create_settings(
             hooks=golden_config.get('hooks', {}),
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -136,7 +136,7 @@ class TestJavaScriptHooks:
             effort_level=None,
         )
 
-        settings_path = claude_dir / f'{cmd}-additional-settings.json'
+        settings_path = claude_dir / f'{cmd}-settings.json'
         data = json.loads(settings_path.read_text())
 
         errors: list[str] = []
@@ -164,7 +164,7 @@ class TestJavaScriptHooks:
         hooks_dir = claude_dir / 'hooks'
         hooks_dir.mkdir(parents=True, exist_ok=True)
 
-        create_additional_settings(
+        create_settings(
             hooks=golden_config.get('hooks', {}),
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -179,7 +179,7 @@ class TestJavaScriptHooks:
             effort_level=None,
         )
 
-        settings_path = claude_dir / f'{cmd}-additional-settings.json'
+        settings_path = claude_dir / f'{cmd}-settings.json'
         data = json.loads(settings_path.read_text())
 
         errors: list[str] = []
@@ -219,7 +219,7 @@ class TestJavaScriptHooks:
         hooks_dir = claude_dir / 'hooks'
         hooks_dir.mkdir(parents=True, exist_ok=True)
 
-        create_additional_settings(
+        create_settings(
             hooks=golden_config.get('hooks', {}),
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -234,7 +234,7 @@ class TestJavaScriptHooks:
             effort_level=None,
         )
 
-        settings_path = claude_dir / f'{cmd}-additional-settings.json'
+        settings_path = claude_dir / f'{cmd}-settings.json'
         data = json.loads(settings_path.read_text())
 
         python_hooks_found = 0
@@ -275,7 +275,7 @@ class TestJavaScriptHooks:
         hooks_dir = claude_dir / 'hooks'
         hooks_dir.mkdir(parents=True, exist_ok=True)
 
-        create_additional_settings(
+        create_settings(
             hooks=golden_config.get('hooks', {}),
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -290,7 +290,7 @@ class TestJavaScriptHooks:
             effort_level=None,
         )
 
-        settings_path = claude_dir / f'{cmd}-additional-settings.json'
+        settings_path = claude_dir / f'{cmd}-settings.json'
         data = json.loads(settings_path.read_text())
 
         errors: list[str] = []

--- a/tests/e2e/test_launcher_scripts.py
+++ b/tests/e2e/test_launcher_scripts.py
@@ -237,7 +237,7 @@ class TestLauncherScriptsPlatformAgnostic:
     ) -> None:
         """Verify launcher script references the settings file.
 
-        The launcher should reference {cmd}-additional-settings.json
+        The launcher should reference {cmd}-settings.json
         to load environment-specific configuration.
         """
         paths = e2e_isolated_home
@@ -257,10 +257,10 @@ class TestLauncherScriptsPlatformAgnostic:
         assert launcher_path.exists(), f'Launcher script not created: {launcher_path}'
 
         content = launcher_path.read_text(encoding='utf-8')
-        settings_pattern = f'{cmd}-additional-settings.json'
+        settings_pattern = f'{cmd}-settings.json'
 
         # Note: On Windows, the launcher .sh file may not directly reference
-        # additional-settings if it's using a different invocation path
+        # settings if it's using a different invocation path
         if sys.platform == 'win32':
             # On Windows, check for settings reference OR claude invocation
             has_settings_ref = settings_pattern in content or '--settings' in content

--- a/tests/e2e/test_output_files.py
+++ b/tests/e2e/test_output_files.py
@@ -13,26 +13,26 @@ from typing import Any
 import pytest
 
 from scripts.setup_environment import configure_all_mcp_servers
-from scripts.setup_environment import create_additional_settings
 from scripts.setup_environment import create_mcp_config_file
+from scripts.setup_environment import create_settings
 from scripts.setup_environment import write_user_settings
 from tests.e2e.expected.common import EXPECTED_JSON_KEYS
-from tests.e2e.validators import validate_additional_settings
 from tests.e2e.validators import validate_mcp_json
+from tests.e2e.validators import validate_settings
 from tests.e2e.validators import validate_settings_json
 
 
 class TestOutputFiles:
     """Test output file content and structure."""
 
-    def test_additional_settings_json_structure(
+    def test_settings_json_structure(
         self,
         e2e_isolated_home: dict[str, Path],
         golden_config: dict[str, Any],
     ) -> None:
-        """Verify additional-settings.json has correct structure and content.
+        """Verify settings.json has correct structure and content.
 
-        Uses validate_additional_settings from validators.py.
+        Uses validate_settings from validators.py.
         Checks: model, permissions, env, hooks, alwaysThinkingEnabled,
         companyAnnouncements, attribution, statusLine.
         """
@@ -40,8 +40,8 @@ class TestOutputFiles:
         cmd = golden_config['command-names'][0]
         claude_dir = paths['claude_dir']
 
-        # Create additional settings
-        create_additional_settings(
+        # Create settings
+        create_settings(
             hooks=golden_config.get('hooks', {}),
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -57,27 +57,27 @@ class TestOutputFiles:
         )
 
         # File is written to claude_user_dir (= claude_dir)
-        settings_path = claude_dir / f'{cmd}-additional-settings.json'
+        settings_path = claude_dir / f'{cmd}-settings.json'
 
         # Validate using validators.py
-        errors = validate_additional_settings(settings_path, golden_config)
-        assert not errors, 'additional-settings.json validation failed:\n' + '\n'.join(errors)
+        errors = validate_settings(settings_path, golden_config)
+        assert not errors, 'settings.json validation failed:\n' + '\n'.join(errors)
 
-    def test_additional_settings_has_expected_keys(
+    def test_settings_has_expected_keys(
         self,
         e2e_isolated_home: dict[str, Path],
         golden_config: dict[str, Any],
     ) -> None:
-        """Verify additional-settings.json contains all expected top-level keys.
+        """Verify settings.json contains all expected top-level keys.
 
-        Uses EXPECTED_JSON_KEYS['additional-settings'] for reference.
+        Uses EXPECTED_JSON_KEYS['settings'] for reference.
         """
         paths = e2e_isolated_home
         cmd = golden_config['command-names'][0]
         claude_dir = paths['claude_dir']
 
-        # Create additional settings
-        create_additional_settings(
+        # Create settings
+        create_settings(
             hooks=golden_config.get('hooks', {}),
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -93,14 +93,14 @@ class TestOutputFiles:
         )
 
         # File is written to claude_user_dir (= claude_dir)
-        settings_path = claude_dir / f'{cmd}-additional-settings.json'
+        settings_path = claude_dir / f'{cmd}-settings.json'
 
         # Load and check keys
         data = json.loads(settings_path.read_text())
-        expected_keys = EXPECTED_JSON_KEYS['additional-settings']
+        expected_keys = EXPECTED_JSON_KEYS['settings']
 
         missing_keys = [k for k in expected_keys if k not in data]
-        assert not missing_keys, f'Missing expected keys in additional-settings.json: {missing_keys}'
+        assert not missing_keys, f'Missing expected keys in settings.json: {missing_keys}'
 
     def test_mcp_json_structure(
         self,
@@ -193,7 +193,7 @@ class TestOutputFiles:
         e2e_isolated_home: dict[str, Path],
         golden_config: dict[str, Any],
     ) -> None:
-        """Verify permissions in additional-settings has all required arrays.
+        """Verify permissions in settings has all required arrays.
 
         Checks: defaultMode, allow, deny, ask arrays present with expected values.
         """
@@ -201,7 +201,7 @@ class TestOutputFiles:
         cmd = golden_config['command-names'][0]
         claude_dir = paths['claude_dir']
 
-        create_additional_settings(
+        create_settings(
             hooks={},
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -217,7 +217,7 @@ class TestOutputFiles:
         )
 
         # File is written to claude_user_dir (= claude_dir)
-        settings_path = claude_dir / f'{cmd}-additional-settings.json'
+        settings_path = claude_dir / f'{cmd}-settings.json'
 
         data = json.loads(settings_path.read_text())
 

--- a/tests/e2e/test_path_handling.py
+++ b/tests/e2e/test_path_handling.py
@@ -18,8 +18,8 @@ import pytest
 
 from scripts import setup_environment
 from scripts.setup_environment import configure_all_mcp_servers
-from scripts.setup_environment import create_additional_settings
 from scripts.setup_environment import create_mcp_config_file
+from scripts.setup_environment import create_settings
 from scripts.setup_environment import write_user_settings
 from tests.e2e.validators import validate_all_paths_expanded
 from tests.e2e.validators import validate_path_expanded
@@ -85,22 +85,22 @@ class TestTildeExpansion:
 
         assert not errors, 'MCP server paths contain unexpanded tildes:\n' + '\n'.join(errors)
 
-    def test_additional_settings_paths_expanded(
+    def test_settings_paths_expanded(
         self,
         e2e_isolated_home: dict[str, Path],
         golden_config: dict[str, Any],
     ) -> None:
-        """Verify additional-settings.json paths have no unexpanded tildes.
+        """Verify settings.json paths have no unexpanded tildes.
 
-        Checks that any path-like values in additional-settings.json
+        Checks that any path-like values in settings.json
         are properly expanded.
         """
         paths = e2e_isolated_home
         cmd = golden_config['command-names'][0]
         claude_dir = paths['claude_dir']
 
-        # Create additional settings
-        create_additional_settings(
+        # Create settings
+        create_settings(
             hooks=golden_config.get('hooks', {}),
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -116,7 +116,7 @@ class TestTildeExpansion:
         )
 
         # File is written to claude_user_dir (= claude_dir)
-        settings_path = claude_dir / f'{cmd}-additional-settings.json'
+        settings_path = claude_dir / f'{cmd}-settings.json'
 
         data = json.loads(settings_path.read_text())
 
@@ -126,7 +126,7 @@ class TestTildeExpansion:
         path_keys = ['statusLine', 'hooks']
         errors = validate_all_paths_expanded(data, path_keys)
 
-        assert not errors, 'additional-settings.json paths contain unexpanded tildes:\n' + '\n'.join(
+        assert not errors, 'settings.json paths contain unexpanded tildes:\n' + '\n'.join(
             errors,
         )
 
@@ -213,7 +213,7 @@ class TestTildeExpansion:
     ) -> None:
         """Verify hook command paths have no unexpanded tildes.
 
-        Checks that hooks.events[].command paths in additional-settings
+        Checks that hooks.events[].command paths in settings
         are properly expanded.
         """
         paths = e2e_isolated_home
@@ -225,8 +225,8 @@ class TestTildeExpansion:
             # No hooks to test
             return
 
-        # Create additional settings with hooks
-        create_additional_settings(
+        # Create settings with hooks
+        create_settings(
             hooks=hooks_config,
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -242,7 +242,7 @@ class TestTildeExpansion:
         )
 
         # File is written to claude_user_dir (= claude_dir)
-        settings_path = claude_dir / f'{cmd}-additional-settings.json'
+        settings_path = claude_dir / f'{cmd}-settings.json'
 
         data = json.loads(settings_path.read_text())
         hooks = data.get('hooks', {})
@@ -282,8 +282,8 @@ class TestTildeExpansion:
             # No status line to test
             return
 
-        # Create additional settings with status line
-        create_additional_settings(
+        # Create settings with status line
+        create_settings(
             hooks={},
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -299,7 +299,7 @@ class TestTildeExpansion:
         )
 
         # File is written to claude_user_dir (= claude_dir)
-        settings_path = claude_dir / f'{cmd}-additional-settings.json'
+        settings_path = claude_dir / f'{cmd}-settings.json'
 
         data = json.loads(settings_path.read_text())
         status_line = data.get('statusLine', {})

--- a/tests/e2e/test_path_normalization.py
+++ b/tests/e2e/test_path_normalization.py
@@ -6,7 +6,7 @@ These tests verify that paths written to output files have correct format:
    settings.json) should have platform-consistent separators after the
    os.path.normpath fix (backslashes on Windows, forward slashes on Unix).
 
-2. Hook and status-line command strings in additional-settings.json use
+2. Hook and status-line command strings in settings.json use
    POSIX-style paths (forward slashes) by design via Path.as_posix(),
    which avoids JSON backslash escaping issues. These tests verify that
    POSIX consistency is maintained.
@@ -24,8 +24,8 @@ from typing import Any
 import pytest
 
 from scripts.setup_environment import configure_all_mcp_servers
-from scripts.setup_environment import create_additional_settings
 from scripts.setup_environment import create_mcp_config_file
+from scripts.setup_environment import create_settings
 from scripts.setup_environment import write_user_settings
 from tests.e2e.validators import validate_path_separator_consistency
 
@@ -271,7 +271,7 @@ class TestPathSeparatorConsistency:
     ) -> None:
         """Verify hook command paths use POSIX-style forward slashes.
 
-        Hook commands in additional-settings.json are built using
+        Hook commands in settings.json are built using
         Path.as_posix() by design to avoid JSON backslash escaping issues.
         All path tokens within hook commands should use forward slashes
         consistently, even on Windows.
@@ -284,8 +284,8 @@ class TestPathSeparatorConsistency:
         if not hooks_config.get('events'):
             return
 
-        # Create additional settings with hooks
-        create_additional_settings(
+        # Create settings with hooks
+        create_settings(
             hooks=hooks_config,
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -300,7 +300,7 @@ class TestPathSeparatorConsistency:
             effort_level=None,
         )
 
-        settings_path = claude_dir / f'{cmd}-additional-settings.json'
+        settings_path = claude_dir / f'{cmd}-settings.json'
         data = json.loads(settings_path.read_text())
         hooks = data.get('hooks', {})
 
@@ -318,7 +318,7 @@ class TestPathSeparatorConsistency:
                     # Extract path tokens from the compound command
                     path_tokens = _extract_paths_from_command(command_str)
                     # Hook paths should use POSIX-style (forward slashes)
-                    # because create_additional_settings uses .as_posix()
+                    # because create_settings uses .as_posix()
                     errors.extend(
                         f'hooks[{event_name}][{idx}].hooks[{hook_idx}].command '
                         f'contains backslash in path token: {path_token}'
@@ -338,7 +338,7 @@ class TestPathSeparatorConsistency:
     ) -> None:
         """Verify statusLine command path uses POSIX-style forward slashes.
 
-        Status line commands in additional-settings.json are built using
+        Status line commands in settings.json are built using
         Path.as_posix() by design, same as hooks.
         """
         paths = e2e_isolated_home
@@ -349,8 +349,8 @@ class TestPathSeparatorConsistency:
         if not status_line_config:
             return
 
-        # Create additional settings with status line
-        create_additional_settings(
+        # Create settings with status line
+        create_settings(
             hooks={},
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -365,7 +365,7 @@ class TestPathSeparatorConsistency:
             effort_level=None,
         )
 
-        settings_path = claude_dir / f'{cmd}-additional-settings.json'
+        settings_path = claude_dir / f'{cmd}-settings.json'
         data = json.loads(settings_path.read_text())
         status_line = data.get('statusLine', {})
 
@@ -385,23 +385,23 @@ class TestPathSeparatorConsistency:
             + '\n'.join(errors)
         )
 
-    def test_additional_settings_all_paths_consistent(
+    def test_settings_all_paths_consistent(
         self,
         e2e_isolated_home: dict[str, Path],
         golden_config: dict[str, Any],
     ) -> None:
-        """Comprehensive check: all path tokens in additional-settings are consistent.
+        """Comprehensive check: all path tokens in settings are consistent.
 
         Hook/status-line paths use POSIX-style (forward slashes) by design.
-        This test creates full additional settings and verifies each path token
+        This test creates full settings and verifies each path token
         within compound command strings uses forward slashes consistently.
         """
         paths = e2e_isolated_home
         cmd = golden_config['command-names'][0]
         claude_dir = paths['claude_dir']
 
-        # Create full additional settings
-        create_additional_settings(
+        # Create full settings
+        create_settings(
             hooks=golden_config.get('hooks', {}),
             claude_user_dir=claude_dir,
             command_name=cmd,
@@ -416,7 +416,7 @@ class TestPathSeparatorConsistency:
             effort_level=golden_config.get('effort-level'),
         )
 
-        settings_path = claude_dir / f'{cmd}-additional-settings.json'
+        settings_path = claude_dir / f'{cmd}-settings.json'
         data = json.loads(settings_path.read_text())
 
         errors: list[str] = []
@@ -446,6 +446,6 @@ class TestPathSeparatorConsistency:
 
         platform_name = 'Windows' if sys.platform == 'win32' else 'Unix'
         assert not errors, (
-            f'Path consistency issues in additional-settings on {platform_name}:\n'
+            f'Path consistency issues in settings on {platform_name}:\n'
             + '\n'.join(errors)
         )

--- a/tests/e2e/validators.py
+++ b/tests/e2e/validators.py
@@ -286,8 +286,8 @@ def _validate_mcp_server_config(name: str, server: dict[str, Any]) -> list[str]:
     return errors
 
 
-def validate_additional_settings(path: Path, config: dict[str, Any]) -> list[str]:
-    """Validate {cmd}-additional-settings.json.
+def validate_settings(path: Path, config: dict[str, Any]) -> list[str]:
+    """Validate {cmd}-settings.json.
 
     Validates the environment-specific settings file that is loaded via --settings flag.
     Contains: model, permissions, env, hooks, attribution, statusLine, etc.
@@ -305,7 +305,7 @@ def validate_additional_settings(path: Path, config: dict[str, Any]) -> list[str
     - statusLine structure is correct if specified
 
     Args:
-        path: Path to the additional-settings.json file
+        path: Path to the settings.json file
         config: Golden configuration dictionary
 
     Returns:
@@ -328,7 +328,7 @@ def validate_additional_settings(path: Path, config: dict[str, Any]) -> list[str
     # Permissions validation
     if 'permissions' in config:
         if 'permissions' not in data:
-            errors.append("Missing 'permissions' block in additional-settings.json")
+            errors.append("Missing 'permissions' block in settings.json")
         else:
             perm_errors = _validate_permissions(data['permissions'], config['permissions'])
             errors.extend(perm_errors)
@@ -454,7 +454,7 @@ def _validate_permissions(actual: dict[str, Any], expected: dict[str, Any]) -> l
 
 
 def _validate_hooks_structure(actual: dict[str, Any], config: dict[str, Any]) -> list[str]:
-    """Validate hooks structure in additional-settings.json.
+    """Validate hooks structure in settings.json.
 
     The hooks structure in the generated file is:
     {
@@ -716,8 +716,8 @@ def _validate_unix_launcher(path: Path, content: str, command_name: str) -> list
     if 'claude' not in content.lower():
         errors.append(f'Unix launcher {path.name} missing claude invocation')
 
-    # Should reference the additional-settings file
-    settings_pattern = f'{command_name}-additional-settings.json'
+    # Should reference the settings file
+    settings_pattern = f'{command_name}-settings.json'
     if settings_pattern not in content:
         errors.append(f'Unix launcher {path.name} missing reference to {settings_pattern}')
 

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -2898,15 +2898,15 @@ class TestMCPTildeExpansionUnix:
         assert any('/Users/test/.claude' in str(arg) for arg in cmd_list)
 
 
-class TestCreateAdditionalSettings:
-    """Test additional settings creation."""
+class TestCreateSettings:
+    """Test settings creation."""
 
-    def test_create_additional_settings_basic(self):
-        """Test creating basic additional settings."""
+    def test_create_settings_basic(self):
+        """Test creating basic settings."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -2914,25 +2914,25 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             assert settings_file.exists()
 
             settings = json.loads(settings_file.read_text())
             assert settings['model'] == 'claude-3-opus'
 
-    def test_create_additional_settings_with_mcp_permissions(self):
+    def test_create_settings_with_mcp_permissions(self):
         """Test creating settings without automatic MCP server permissions."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             # MCP servers should NOT be automatically added to permissions
@@ -2941,7 +2941,7 @@ class TestCreateAdditionalSettings:
                 and 'mcp__server2' not in settings.get('permissions', {}).get('allow', [])
             )
 
-    def test_create_additional_settings_with_explicit_permissions(self):
+    def test_create_settings_with_explicit_permissions(self):
         """Test that explicit permissions are still preserved."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -2951,7 +2951,7 @@ class TestCreateAdditionalSettings:
                 'deny': ['mcp__server3'],
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -2959,7 +2959,7 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             # Explicit permissions should be preserved exactly as provided
@@ -2971,7 +2971,7 @@ class TestCreateAdditionalSettings:
             assert 'mcp__server3' in settings['permissions']['deny']
 
     @patch('setup_environment.handle_resource')
-    def test_create_additional_settings_with_hooks(self, mock_download):
+    def test_create_settings_with_hooks(self, mock_download):
         """Test creating settings with hooks."""
         mock_download.return_value = True
 
@@ -2997,22 +2997,22 @@ class TestCreateAdditionalSettings:
                 config_source='https://example.com/config.yaml',
             )
 
-            # Then create additional settings
-            result = setup_environment.create_additional_settings(
+            # Then create settings
+            result = setup_environment.create_settings(
                 hooks,
                 claude_dir,
                 'test-env',
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'hooks' in settings
             assert 'PostToolUse' in settings['hooks']
 
     @patch('setup_environment.handle_resource')
-    def test_create_additional_settings_with_javascript_hooks(self, mock_download):
+    def test_create_settings_with_javascript_hooks(self, mock_download):
         """Test creating settings with JavaScript hooks includes node prefix."""
         mock_download.return_value = True
 
@@ -3033,14 +3033,14 @@ class TestCreateAdditionalSettings:
                 ],
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 hooks,
                 claude_dir,
                 'test-env',
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'hooks' in settings
@@ -3052,7 +3052,7 @@ class TestCreateAdditionalSettings:
             assert 'quality-check.js' in hook_command
 
     @patch('setup_environment.handle_resource')
-    def test_create_additional_settings_with_mjs_hooks(self, mock_download):
+    def test_create_settings_with_mjs_hooks(self, mock_download):
         """Test creating settings with .mjs ES module hooks includes node prefix."""
         mock_download.return_value = True
 
@@ -3073,14 +3073,14 @@ class TestCreateAdditionalSettings:
                 ],
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 hooks,
                 claude_dir,
                 'test-env',
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             hook_command = settings['hooks']['PreToolUse'][0]['hooks'][0]['command']
@@ -3088,7 +3088,7 @@ class TestCreateAdditionalSettings:
             assert 'validator.mjs' in hook_command
 
     @patch('setup_environment.handle_resource')
-    def test_create_additional_settings_with_cjs_hooks(self, mock_download):
+    def test_create_settings_with_cjs_hooks(self, mock_download):
         """Test creating settings with .cjs CommonJS hooks includes node prefix."""
         mock_download.return_value = True
 
@@ -3109,14 +3109,14 @@ class TestCreateAdditionalSettings:
                 ],
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 hooks,
                 claude_dir,
                 'test-env',
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             hook_command = settings['hooks']['PostToolUse'][0]['hooks'][0]['command']
@@ -3124,7 +3124,7 @@ class TestCreateAdditionalSettings:
             assert 'legacy-hook.cjs' in hook_command
 
     @patch('setup_environment.handle_resource')
-    def test_create_additional_settings_javascript_hook_with_config(self, mock_download):
+    def test_create_settings_javascript_hook_with_config(self, mock_download):
         """Test JavaScript hooks with config file path appended correctly."""
         mock_download.return_value = True
 
@@ -3146,14 +3146,14 @@ class TestCreateAdditionalSettings:
                 ],
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 hooks,
                 claude_dir,
                 'test-env',
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             hook_command = settings['hooks']['PostToolUse'][0]['hooks'][0]['command']
@@ -3162,7 +3162,7 @@ class TestCreateAdditionalSettings:
             assert 'js-hook-config.yaml' in hook_command
 
     @patch('setup_environment.handle_resource')
-    def test_create_additional_settings_mixed_python_javascript_hooks(self, mock_download):
+    def test_create_settings_mixed_python_javascript_hooks(self, mock_download):
         """Test mixed Python and JavaScript hooks get correct prefixes."""
         mock_download.return_value = True
 
@@ -3189,14 +3189,14 @@ class TestCreateAdditionalSettings:
                 ],
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 hooks,
                 claude_dir,
                 'test-env',
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             # Find Python and JavaScript hooks
@@ -3210,7 +3210,7 @@ class TestCreateAdditionalSettings:
                         assert hook['command'].startswith('node ')
 
     @patch('setup_environment.handle_resource')
-    def test_create_additional_settings_javascript_case_insensitive(self, mock_download):
+    def test_create_settings_javascript_case_insensitive(self, mock_download):
         """Test JavaScript extension detection is case-insensitive."""
         mock_download.return_value = True
 
@@ -3231,25 +3231,25 @@ class TestCreateAdditionalSettings:
                 ],
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 hooks,
                 claude_dir,
                 'test-env',
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             hook_command = settings['hooks']['PostToolUse'][0]['hooks'][0]['command']
             assert hook_command.startswith('node ')
 
-    def test_create_additional_settings_always_thinking_enabled_true(self):
+    def test_create_settings_always_thinking_enabled_true(self):
         """Test alwaysThinkingEnabled set to true."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3257,18 +3257,18 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'alwaysThinkingEnabled' in settings
             assert settings['alwaysThinkingEnabled'] is True
 
-    def test_create_additional_settings_always_thinking_enabled_false(self):
+    def test_create_settings_always_thinking_enabled_false(self):
         """Test alwaysThinkingEnabled set to false."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3276,18 +3276,18 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'alwaysThinkingEnabled' in settings
             assert settings['alwaysThinkingEnabled'] is False
 
-    def test_create_additional_settings_always_thinking_enabled_none_not_included(self):
+    def test_create_settings_always_thinking_enabled_none_not_included(self):
         """Test alwaysThinkingEnabled not included when None."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3295,17 +3295,17 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'alwaysThinkingEnabled' not in settings
 
-    def test_create_additional_settings_effort_level_low(self):
+    def test_create_settings_effort_level_low(self):
         """Test effortLevel set to low."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3313,18 +3313,18 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'effortLevel' in settings
             assert settings['effortLevel'] == 'low'
 
-    def test_create_additional_settings_effort_level_medium(self):
+    def test_create_settings_effort_level_medium(self):
         """Test effortLevel set to medium."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3332,18 +3332,18 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'effortLevel' in settings
             assert settings['effortLevel'] == 'medium'
 
-    def test_create_additional_settings_effort_level_high(self):
+    def test_create_settings_effort_level_high(self):
         """Test effortLevel set to high."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3351,18 +3351,18 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'effortLevel' in settings
             assert settings['effortLevel'] == 'high'
 
-    def test_create_additional_settings_effort_level_max(self):
+    def test_create_settings_effort_level_max(self):
         """Test effortLevel set to max."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3370,18 +3370,18 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'effortLevel' in settings
             assert settings['effortLevel'] == 'max'
 
-    def test_create_additional_settings_effort_level_none_not_included(self):
+    def test_create_settings_effort_level_none_not_included(self):
         """Test effortLevel not included when None."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3389,12 +3389,12 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'effortLevel' not in settings
 
-    def test_create_additional_settings_company_announcements(self):
+    def test_create_settings_company_announcements(self):
         """Test companyAnnouncements set with multiple items."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -3403,7 +3403,7 @@ class TestCreateAdditionalSettings:
                 'Code reviews required for all PRs',
             ]
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3411,20 +3411,20 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'companyAnnouncements' in settings
             assert settings['companyAnnouncements'] == announcements
             assert len(settings['companyAnnouncements']) == 2
 
-    def test_create_additional_settings_company_announcements_single(self):
+    def test_create_settings_company_announcements_single(self):
         """Test companyAnnouncements with single announcement."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
             announcements = ['Single announcement']
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3432,18 +3432,18 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'companyAnnouncements' in settings
             assert settings['companyAnnouncements'] == announcements
 
-    def test_create_additional_settings_company_announcements_empty_list(self):
+    def test_create_settings_company_announcements_empty_list(self):
         """Test companyAnnouncements with empty list."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3451,19 +3451,19 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             # Empty list should still be included (explicit configuration)
             assert 'companyAnnouncements' in settings
             assert settings['companyAnnouncements'] == []
 
-    def test_create_additional_settings_company_announcements_none_not_included(self):
+    def test_create_settings_company_announcements_none_not_included(self):
         """Test companyAnnouncements not included when None."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3471,12 +3471,12 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'companyAnnouncements' not in settings
 
-    def test_create_additional_settings_attribution_full(self):
+    def test_create_settings_attribution_full(self):
         """Test attribution with both commit and pr values."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -3485,7 +3485,7 @@ class TestCreateAdditionalSettings:
                 'pr': 'Custom PR attribution',
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3493,20 +3493,20 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'attribution' in settings
             assert settings['attribution']['commit'] == 'Custom commit attribution'
             assert settings['attribution']['pr'] == 'Custom PR attribution'
 
-    def test_create_additional_settings_attribution_hide_all(self):
+    def test_create_settings_attribution_hide_all(self):
         """Test attribution with empty strings to hide all."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
             attribution = {'commit': '', 'pr': ''}
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3514,17 +3514,17 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert settings['attribution'] == {'commit': '', 'pr': ''}
 
-    def test_create_additional_settings_attribution_none_not_included(self):
+    def test_create_settings_attribution_none_not_included(self):
         """Test attribution not included when None."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3532,12 +3532,12 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'attribution' not in settings
 
-    def test_create_additional_settings_status_line_python(self):
+    def test_create_settings_status_line_python(self):
         """Test statusLine with Python script."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -3550,7 +3550,7 @@ class TestCreateAdditionalSettings:
                 'padding': 0,
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3558,7 +3558,7 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'statusLine' in settings
@@ -3567,7 +3567,7 @@ class TestCreateAdditionalSettings:
             assert 'statusline.py' in settings['statusLine']['command']
             assert settings['statusLine']['padding'] == 0
 
-    def test_create_additional_settings_status_line_shell(self):
+    def test_create_settings_status_line_shell(self):
         """Test statusLine with shell script."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -3578,7 +3578,7 @@ class TestCreateAdditionalSettings:
                 'file': 'statusline.sh',
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3586,7 +3586,7 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'statusLine' in settings
@@ -3595,12 +3595,12 @@ class TestCreateAdditionalSettings:
             assert 'statusline.sh' in settings['statusLine']['command']
             assert 'padding' not in settings['statusLine']
 
-    def test_create_additional_settings_status_line_none_not_included(self):
+    def test_create_settings_status_line_none_not_included(self):
         """Test statusLine not included when None."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3608,12 +3608,12 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'statusLine' not in settings
 
-    def test_create_additional_settings_status_line_with_query_params(self):
+    def test_create_settings_status_line_with_query_params(self):
         """Test statusLine file with query parameters stripped."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -3624,7 +3624,7 @@ class TestCreateAdditionalSettings:
                 'file': 'statusline.py?ref_type=heads',
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3632,14 +3632,14 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'statusLine' in settings
             assert '?' not in settings['statusLine']['command']
             assert 'statusline.py' in settings['statusLine']['command']
 
-    def test_create_additional_settings_status_line_with_config(self):
+    def test_create_settings_status_line_with_config(self):
         """Test statusLine with Python script and config file."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -3656,7 +3656,7 @@ class TestCreateAdditionalSettings:
                 'padding': 0,
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3664,7 +3664,7 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'statusLine' in settings
@@ -3675,7 +3675,7 @@ class TestCreateAdditionalSettings:
             assert settings['statusLine']['command'].endswith('config.yaml')
             assert settings['statusLine']['padding'] == 0
 
-    def test_create_additional_settings_status_line_config_with_query_params(self):
+    def test_create_settings_status_line_config_with_query_params(self):
         """Test statusLine config with query parameters stripped."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -3690,7 +3690,7 @@ class TestCreateAdditionalSettings:
                 'config': 'config.yaml?token=abc123',
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3698,7 +3698,7 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'statusLine' in settings
@@ -3706,7 +3706,7 @@ class TestCreateAdditionalSettings:
             assert 'statusline.py' in settings['statusLine']['command']
             assert 'config.yaml' in settings['statusLine']['command']
 
-    def test_create_additional_settings_status_line_shell_with_config(self):
+    def test_create_settings_status_line_shell_with_config(self):
         """Test statusLine with shell script and config file."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -3721,7 +3721,7 @@ class TestCreateAdditionalSettings:
                 'config': 'config.yaml',
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3729,7 +3729,7 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'statusLine' in settings
@@ -3737,7 +3737,7 @@ class TestCreateAdditionalSettings:
             assert 'statusline.sh' in settings['statusLine']['command']
             assert 'config.yaml' in settings['statusLine']['command']
 
-    def test_create_additional_settings_status_line_without_config_backward_compat(self):
+    def test_create_settings_status_line_without_config_backward_compat(self):
         """Test that status-line without config field still works (backward compatibility)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -3752,7 +3752,7 @@ class TestCreateAdditionalSettings:
                 # No 'config' field - backward compatibility
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test-env',
@@ -3760,7 +3760,7 @@ class TestCreateAdditionalSettings:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-env-additional-settings.json'
+            settings_file = claude_dir / 'test-env-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert 'statusLine' in settings
@@ -4014,7 +4014,7 @@ class TestMainFunction:
     @patch('setup_environment.install_dependencies')
     @patch('setup_environment.process_resources')
     @patch('setup_environment.configure_all_mcp_servers')
-    @patch('setup_environment.create_additional_settings')
+    @patch('setup_environment.create_settings')
     @patch('setup_environment.create_launcher_script')
     @patch('setup_environment.register_global_command')
     @patch('setup_environment.is_admin', return_value=True)
@@ -4107,7 +4107,7 @@ class TestMainFunction:
 
         with (
             patch('sys.argv', ['setup_environment.py', 'test', '--skip-install', '--yes']),
-            patch('setup_environment.create_additional_settings', return_value=True),
+            patch('setup_environment.create_settings', return_value=True),
             patch('setup_environment.create_launcher_script', return_value=Path('/tmp/launcher')),
             patch('setup_environment.register_global_command', return_value=True),
             patch('sys.exit') as mock_exit,
@@ -4122,7 +4122,7 @@ class TestMainFunction:
     @patch('setup_environment.process_resources')
     @patch('setup_environment.process_skills')
     @patch('setup_environment.configure_all_mcp_servers')
-    @patch('setup_environment.create_additional_settings')
+    @patch('setup_environment.create_settings')
     @patch('setup_environment.create_launcher_script')
     @patch('setup_environment.register_global_command')
     @patch('setup_environment.is_admin', return_value=True)
@@ -4169,7 +4169,7 @@ class TestMainFunction:
         assert 'Invalid effort-level value' in captured.out
         assert "'extreme'" in captured.out
 
-        # Verify create_additional_settings was called with effort_level=None
+        # Verify create_settings was called with effort_level=None
         # (the invalid value should have been reset to None)
         mock_settings.assert_called_once()
         call_args = mock_settings.call_args
@@ -4190,7 +4190,7 @@ class TestDownloadFailureTracking:
     @patch('setup_environment.download_hook_files')
     @patch('setup_environment.handle_resource')
     @patch('setup_environment.configure_all_mcp_servers')
-    @patch('setup_environment.create_additional_settings')
+    @patch('setup_environment.create_settings')
     @patch('setup_environment.create_launcher_script')
     @patch('setup_environment.register_global_command')
     @patch('setup_environment.is_admin', return_value=True)
@@ -4253,7 +4253,7 @@ class TestDownloadFailureTracking:
     @patch('setup_environment.download_hook_files')
     @patch('setup_environment.handle_resource')
     @patch('setup_environment.configure_all_mcp_servers')
-    @patch('setup_environment.create_additional_settings')
+    @patch('setup_environment.create_settings')
     @patch('setup_environment.create_launcher_script')
     @patch('setup_environment.register_global_command')
     @patch('setup_environment.is_admin', return_value=True)
@@ -4316,7 +4316,7 @@ class TestDownloadFailureTracking:
     @patch('setup_environment.download_hook_files')
     @patch('setup_environment.handle_resource')
     @patch('setup_environment.configure_all_mcp_servers')
-    @patch('setup_environment.create_additional_settings')
+    @patch('setup_environment.create_settings')
     @patch('setup_environment.create_launcher_script')
     @patch('setup_environment.register_global_command')
     @patch('setup_environment.is_admin', return_value=True)
@@ -4389,7 +4389,7 @@ class TestDownloadFailureTracking:
     @patch('setup_environment.download_hook_files')
     @patch('setup_environment.handle_resource')
     @patch('setup_environment.configure_all_mcp_servers')
-    @patch('setup_environment.create_additional_settings')
+    @patch('setup_environment.create_settings')
     @patch('setup_environment.create_launcher_script')
     @patch('setup_environment.register_global_command')
     @patch('setup_environment.is_admin', return_value=True)
@@ -6296,7 +6296,7 @@ class TestCommandNames:
     @patch('setup_environment.install_dependencies')
     @patch('setup_environment.process_resources')
     @patch('setup_environment.configure_all_mcp_servers')
-    @patch('setup_environment.create_additional_settings')
+    @patch('setup_environment.create_settings')
     @patch('setup_environment.create_launcher_script')
     @patch('setup_environment.register_global_command')
     @patch('setup_environment.is_admin', return_value=True)
@@ -6355,7 +6355,7 @@ class TestCommandNames:
     @patch('setup_environment.install_dependencies')
     @patch('setup_environment.process_resources')
     @patch('setup_environment.configure_all_mcp_servers')
-    @patch('setup_environment.create_additional_settings')
+    @patch('setup_environment.create_settings')
     @patch('setup_environment.create_launcher_script')
     @patch('setup_environment.register_global_command')
     @patch('setup_environment.is_admin', return_value=True)
@@ -7746,7 +7746,7 @@ class TestMainFunctionUserSettings:
     @patch('setup_environment.process_skills')
     @patch('setup_environment.configure_all_mcp_servers')
     @patch('setup_environment.write_user_settings')
-    @patch('setup_environment.create_additional_settings')
+    @patch('setup_environment.create_settings')
     @patch('setup_environment.create_launcher_script')
     @patch('setup_environment.register_global_command')
     @patch('setup_environment.is_admin', return_value=True)
@@ -7842,7 +7842,7 @@ class TestMainFunctionUserSettings:
     @patch('setup_environment.process_skills')
     @patch('setup_environment.configure_all_mcp_servers')
     @patch('setup_environment.write_user_settings')
-    @patch('setup_environment.create_additional_settings')
+    @patch('setup_environment.create_settings')
     @patch('setup_environment.create_launcher_script')
     @patch('setup_environment.register_global_command')
     @patch('setup_environment.is_admin', return_value=True)
@@ -7903,7 +7903,7 @@ class TestMainFunctionUserSettings:
     @patch('setup_environment.process_skills')
     @patch('setup_environment.configure_all_mcp_servers')
     @patch('setup_environment.write_user_settings')
-    @patch('setup_environment.create_additional_settings')
+    @patch('setup_environment.create_settings')
     @patch('setup_environment.create_launcher_script')
     @patch('setup_environment.register_global_command')
     @patch('setup_environment.is_admin', return_value=True)
@@ -8189,7 +8189,7 @@ class TestUserSettingsIntegration:
     def test_integration_combined_mode_writes_both_files(
         self, tmp_path: Path,
     ) -> None:
-        """Verify combined mode writes to both settings.json AND additional-settings.json."""
+        """Verify combined mode writes to both settings.json AND settings.json."""
         claude_dir = tmp_path / '.claude'
         claude_dir.mkdir(parents=True)
 
@@ -8207,8 +8207,8 @@ class TestUserSettingsIntegration:
         result1 = setup_environment.write_user_settings(user_settings, claude_dir)
         assert result1 is True
 
-        # Write profile settings (simulating additional-settings behavior)
-        result2 = setup_environment.create_additional_settings(
+        # Write profile settings (simulating settings file behavior)
+        result2 = setup_environment.create_settings(
             hooks={},  # Empty hooks
             claude_user_dir=claude_dir,
             command_name='mydev',
@@ -8219,7 +8219,7 @@ class TestUserSettingsIntegration:
 
         # Verify both files exist
         assert (claude_dir / 'settings.json').exists()
-        assert (claude_dir / 'mydev-additional-settings.json').exists()
+        assert (claude_dir / 'mydev-settings.json').exists()
 
     def test_integration_existing_settings_preserved_during_merge(
         self, tmp_path: Path,

--- a/tests/test_setup_environment_additional.py
+++ b/tests/test_setup_environment_additional.py
@@ -922,10 +922,10 @@ class TestMCPServerConfigurationEdgeCases:
         assert '--env "REGION=us-west"' in bash_cmd
 
 
-class TestCreateAdditionalSettingsComplex:
-    """Test complex additional settings creation scenarios."""
+class TestCreateSettingsComplex:
+    """Test complex settings creation scenarios."""
 
-    def test_create_additional_settings_with_permissions_merge(self):
+    def test_create_settings_with_permissions_merge(self):
         """Test that only explicit permissions are included, no auto-adding."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -936,7 +936,7 @@ class TestCreateAdditionalSettingsComplex:
                 'ask': ['mcp__server4'],
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test',
@@ -944,7 +944,7 @@ class TestCreateAdditionalSettingsComplex:
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-additional-settings.json'
+            settings_file = claude_dir / 'test-settings.json'
             settings = json.loads(settings_file.read_text())
 
             # Only explicitly listed permissions should be present
@@ -954,21 +954,21 @@ class TestCreateAdditionalSettingsComplex:
             assert 'mcp__server2' not in settings['permissions']['allow']
             assert settings['permissions']['allow'].count('mcp__server1') == 1
 
-    def test_create_additional_settings_mcp_in_deny_list(self):
+    def test_create_settings_mcp_in_deny_list(self):
         """Test MCP server in deny list is not auto-allowed."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
             permissions = {'deny': ['mcp__blocked_server']}
 
-            setup_environment.create_additional_settings(
+            setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test',
                 permissions=permissions,
             )
 
-            settings_file = claude_dir / 'test-additional-settings.json'
+            settings_file = claude_dir / 'test-settings.json'
             settings = json.loads(settings_file.read_text())
 
             # Should not be in allow list
@@ -977,27 +977,27 @@ class TestCreateAdditionalSettingsComplex:
                 [],
             )
 
-    def test_create_additional_settings_mcp_in_ask_list(self):
+    def test_create_settings_mcp_in_ask_list(self):
         """Test MCP server in ask list is not auto-allowed."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
             permissions = {'ask': ['mcp__ask_server']}
 
-            setup_environment.create_additional_settings(
+            setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test',
                 permissions=permissions,
             )
 
-            settings_file = claude_dir / 'test-additional-settings.json'
+            settings_file = claude_dir / 'test-settings.json'
             settings = json.loads(settings_file.read_text())
 
             # Should not be in allow list
             assert 'allow' not in settings['permissions'] or 'mcp__ask_server' not in settings['permissions'].get('allow', [])
 
-    def test_create_additional_settings_with_env_variables(self):
+    def test_create_settings_with_env_variables(self):
         """Test creating settings with environment variables."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -1007,14 +1007,14 @@ class TestCreateAdditionalSettingsComplex:
                 'DEBUG': 'true',
             }
 
-            setup_environment.create_additional_settings(
+            setup_environment.create_settings(
                 {},
                 claude_dir,
                 'test',
                 env=env_vars,
             )
 
-            settings_file = claude_dir / 'test-additional-settings.json'
+            settings_file = claude_dir / 'test-settings.json'
             settings = json.loads(settings_file.read_text())
 
             assert settings['env'] == env_vars
@@ -1022,7 +1022,7 @@ class TestCreateAdditionalSettingsComplex:
     @patch('setup_environment.download_file')
     @patch('platform.system', return_value='Windows')
     @patch('shutil.which', return_value='py')
-    def test_create_additional_settings_hooks_windows_python(self, mock_which, _mock_system, mock_download):
+    def test_create_settings_hooks_windows_python(self, mock_which, _mock_system, mock_download):
         """Test hook configuration with Python scripts on Windows."""
         del mock_which  # Unused but required for patch
         del _mock_system  # Unused but required for patch
@@ -1049,13 +1049,13 @@ class TestCreateAdditionalSettingsComplex:
                 ],
             }
 
-            setup_environment.create_additional_settings(
+            setup_environment.create_settings(
                 hooks,
                 claude_dir,
                 'test',
             )
 
-            settings_file = claude_dir / 'test-additional-settings.json'
+            settings_file = claude_dir / 'test-settings.json'
             settings = json.loads(settings_file.read_text())
 
             # Should use py command on Windows
@@ -1065,7 +1065,7 @@ class TestCreateAdditionalSettingsComplex:
 
     @patch('setup_environment.handle_resource')
     @patch('platform.system', return_value='Linux')
-    def test_create_additional_settings_hooks_linux(self, _mock_system, mock_download):
+    def test_create_settings_hooks_linux(self, _mock_system, mock_download):
         """Test hook configuration on Linux."""
         mock_download.return_value = True
 
@@ -1096,8 +1096,8 @@ class TestCreateAdditionalSettingsComplex:
                 config_source='https://example.com/config.yaml',
             )
 
-            # Then create additional settings
-            result = setup_environment.create_additional_settings(
+            # Then create settings
+            result = setup_environment.create_settings(
                 hooks,
                 claude_dir,
                 'test',
@@ -1107,7 +1107,7 @@ class TestCreateAdditionalSettingsComplex:
             # Note: With uv run, executable permissions are no longer needed
             # The script is executed via: uv run --python 3.12 script.py
 
-    def test_create_additional_settings_hooks_invalid(self):
+    def test_create_settings_hooks_invalid(self):
         """Test handling invalid hook configuration."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -1121,7 +1121,7 @@ class TestCreateAdditionalSettingsComplex:
                 ],
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 hooks,
                 claude_dir,
                 'test',
@@ -1130,7 +1130,7 @@ class TestCreateAdditionalSettingsComplex:
             # Should still succeed but skip invalid hook
             assert result is True
 
-    def test_create_additional_settings_non_python_hook(self):
+    def test_create_settings_non_python_hook(self):
         """Test hook configuration with non-Python script."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -1146,30 +1146,30 @@ class TestCreateAdditionalSettingsComplex:
                 ],
             }
 
-            setup_environment.create_additional_settings(
+            setup_environment.create_settings(
                 hooks,
                 claude_dir,
                 'test',
             )
 
-            settings_file = claude_dir / 'test-additional-settings.json'
+            settings_file = claude_dir / 'test-settings.json'
             settings = json.loads(settings_file.read_text())
 
             # Command should be used as-is
             hook_cmd = settings['hooks']['PreToolUse'][0]['hooks'][0]['command']
             assert hook_cmd == 'echo "test"'
 
-    def test_create_additional_settings_save_failure(self):
+    def test_create_settings_save_failure(self):
         """Test handling save failure."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
             # Make directory read-only to cause save failure
-            settings_file = claude_dir / 'test-additional-settings.json'
+            settings_file = claude_dir / 'test-settings.json'
             settings_file.write_text('dummy')
 
             with patch('builtins.open', side_effect=PermissionError('Cannot write')):
-                result = setup_environment.create_additional_settings(
+                result = setup_environment.create_settings(
                     {},
                     claude_dir,
                     'test',
@@ -1419,7 +1419,7 @@ class TestMainFunctionErrorPaths:
         'setup_environment.configure_all_mcp_servers',
         return_value=(True, [], {'global_count': 0, 'profile_count': 0, 'combined_count': 0}),
     )
-    @patch('setup_environment.create_additional_settings', return_value=True)
+    @patch('setup_environment.create_settings', return_value=True)
     @patch('setup_environment.create_launcher_script', return_value=None)
     @patch('pathlib.Path.mkdir')
     def test_main_no_launcher_created(
@@ -1471,7 +1471,7 @@ class TestMainFunctionErrorPaths:
         'setup_environment.configure_all_mcp_servers',
         return_value=(True, [], {'global_count': 0, 'profile_count': 0, 'combined_count': 0}),
     )
-    @patch('setup_environment.create_additional_settings', return_value=True)
+    @patch('setup_environment.create_settings', return_value=True)
     @patch('setup_environment.create_launcher_script')
     @patch('setup_environment.register_global_command', return_value=True)
     @patch('pathlib.Path.mkdir')
@@ -1519,7 +1519,7 @@ class TestMainFunctionErrorPaths:
         'setup_environment.configure_all_mcp_servers',
         return_value=(True, [], {'global_count': 0, 'profile_count': 0, 'combined_count': 0}),
     )
-    @patch('setup_environment.create_additional_settings', return_value=True)
+    @patch('setup_environment.create_settings', return_value=True)
     @patch('setup_environment.create_launcher_script')
     @patch('setup_environment.register_global_command', return_value=True)
     @patch('pathlib.Path.mkdir')
@@ -2528,9 +2528,9 @@ class TestAddDirectoryToWindowsPathLength:
 
 
 class TestHookConfigFileSupport:
-    """Test hook configuration file support in create_additional_settings."""
+    """Test hook configuration file support in create_settings."""
 
-    def test_create_additional_settings_hook_with_config(self) -> None:
+    def test_create_settings_hook_with_config(self) -> None:
         """Test hook configuration with config file reference."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -2559,14 +2559,14 @@ class TestHookConfigFileSupport:
                 ],
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 hooks,
                 claude_dir,
                 'test',
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-additional-settings.json'
+            settings_file = claude_dir / 'test-settings.json'
             settings = json.loads(settings_file.read_text())
 
             # Verify command includes config path
@@ -2575,7 +2575,7 @@ class TestHookConfigFileSupport:
             assert 'protect_config.yaml' in hook_cmd
             assert hook_cmd.endswith('protect_config.yaml')
 
-    def test_create_additional_settings_hook_without_config_backward_compat(self) -> None:
+    def test_create_settings_hook_without_config_backward_compat(self) -> None:
         """Test that hooks without config field still work (backward compatibility)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -2598,14 +2598,14 @@ class TestHookConfigFileSupport:
                 ],
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 hooks,
                 claude_dir,
                 'test',
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-additional-settings.json'
+            settings_file = claude_dir / 'test-settings.json'
             settings = json.loads(settings_file.read_text())
 
             # Verify command does NOT include config path
@@ -2614,7 +2614,7 @@ class TestHookConfigFileSupport:
             # Command should end with the Python file, not a config
             assert hook_cmd.endswith('test.py')
 
-    def test_create_additional_settings_hook_config_with_query_params(self) -> None:
+    def test_create_settings_hook_config_with_query_params(self) -> None:
         """Test hook config with query parameters in filename."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -2642,14 +2642,14 @@ class TestHookConfigFileSupport:
                 ],
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 hooks,
                 claude_dir,
                 'test',
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-additional-settings.json'
+            settings_file = claude_dir / 'test-settings.json'
             settings = json.loads(settings_file.read_text())
 
             # Verify query params are stripped from config path
@@ -2657,7 +2657,7 @@ class TestHookConfigFileSupport:
             assert 'config.yaml' in hook_cmd
             assert '?token=' not in hook_cmd
 
-    def test_create_additional_settings_non_python_hook_with_config(self) -> None:
+    def test_create_settings_non_python_hook_with_config(self) -> None:
         """Test non-Python hook with config file."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
@@ -2682,14 +2682,14 @@ class TestHookConfigFileSupport:
                 ],
             }
 
-            result = setup_environment.create_additional_settings(
+            result = setup_environment.create_settings(
                 hooks,
                 claude_dir,
                 'test',
             )
 
             assert result is True
-            settings_file = claude_dir / 'test-additional-settings.json'
+            settings_file = claude_dir / 'test-settings.json'
             settings = json.loads(settings_file.read_text())
 
             # Non-Python scripts should also get config appended


### PR DESCRIPTION
The word "additional" is misleading since these are the primary settings for custom command environments, not supplementary ones. This rename produces cleaner, more consistent filenames alongside other generated files like {command}-mcp.json.