### PR TITLE
Add merge-keys directive for selective config inheritance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,7 @@ YAML configurations define complete development environments including:
 - System prompts (with configurable mode: append or replace)
 - Hooks (event-driven scripts)
 - Global config (`~/.claude.json` settings via deep merge)
+- Selective merge during inheritance (`merge-keys` directive)
 
 ### Global Config (`global-config`)
 

--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -129,7 +129,7 @@ Browse the [repository](https://github.com/alex-feel/claude-code-artifacts-publi
 
 ## Configuration Reference
 
-Quick-reference table of all 29 configuration keys. Each key links to its detailed documentation in the [Configuration Keys](#configuration-keys) section below.
+Quick-reference table of all configuration keys. Each key links to its detailed documentation in the [Configuration Keys](#configuration-keys) section below.
 
 | YAML Key                                              | Type                   | Required | Default | Brief Description                          |
 |-------------------------------------------------------|------------------------|----------|---------|--------------------------------------------|
@@ -138,6 +138,7 @@ Quick-reference table of all 29 configuration keys. Each key links to its detail
 | [`post-install-notes`](#post-install-notes)           | `str`                  | No       | `None`  | Notes shown after successful installation  |
 | [`version`](#version)                                 | `str`                  | No       | `None`  | Config version (semver)                    |
 | [`inherit`](#inherit)                                 | `str`                  | No       | `None`  | Parent config URL/path/name                |
+| [`merge-keys`](#merge-keys)                           | `list[str]`            | No       | `None`  | Keys to merge instead of replace           |
 | [`command-names`](#command-names)                     | `list[str]`            | No*      | `[]`    | Command names and aliases                  |
 | [`base-url`](#base-url)                               | `str`                  | No       | `None`  | Base URL for relative resource paths       |
 | [`claude-code-version`](#claude-code-version)         | `str`                  | No       | `None`  | Specific Claude Code version or `"latest"` |
@@ -180,6 +181,7 @@ All configuration keys use **kebab-case** (hyphenated lowercase), for example `m
 Display name for the environment, shown in the setup header and summary.
 
 - **Type:** `str` (required)
+- **Inheritance:** Standard override (child replaces parent)
 - **Example:** `name: "Python Development"`
 
 #### `description`
@@ -227,6 +229,7 @@ Configuration version for update checking. Extracted from the root config before
 - **Type:** `str | None`
 - **Default:** `None`
 - **Validation:** Must be valid semver (`X.Y.Z` format, with optional pre-release and build metadata)
+- **Inheritance:** Not inherited. Extracted from the root config before inheritance resolution.
 - **Example:** `version: "1.0.0"` or `version: "2.1.0-beta.1"`
 
 #### `command-names`
@@ -240,6 +243,7 @@ Creates global shell commands that launch Claude Code with this environment conf
   - Cannot contain spaces
   - Must be alphanumeric, hyphens, and underscores only
 - **Co-dependency:** If specified, `command-defaults` must also be specified (and vice versa)
+- **Inheritance:** Standard override (child replaces parent)
 - **Note:** If empty or not specified, setup steps for hooks download, settings, manifest, launcher, and command registration are skipped. The setup still processes other resources (agents, MCP servers, dependencies, and so on) but does not create a launchable command.
 - **Example:**
 
@@ -256,17 +260,19 @@ Base URL for resolving relative resource paths (agents, commands, skills, hooks,
 - **Type:** `str | None`
 - **Default:** `None`
 - **Validation:** Must start with `http://` or `https://`
+- **Inheritance:** Standard override (child replaces parent). Each level's `base-url` applies to that level's own resource paths.
 - **Example:** `base-url: "https://raw.githubusercontent.com/org/repo/main"`
 
 #### `inherit`
 
-URL, local path, or repository config name to inherit from. The child configuration overrides parent values at the top level (no deep merge).
+URL, local path, or repository config name to inherit from. The child configuration overrides parent values at the top level by default. Use `merge-keys` to selectively merge specific keys instead of replacing them.
 
 - **Type:** `str | None`
 - **Default:** `None`
 - **Validation:** Cannot be empty, no null bytes
 - **Max depth:** 10 levels
 - **Circular dependency detection:** Automatic
+- **Inheritance:** Not applicable (structural meta-key consumed during resolution)
 - **Example:**
 
 ```yaml
@@ -279,6 +285,29 @@ inherit: "base-config"  # fetched from artifacts-public repo
 
 See [Configuration Inheritance](#configuration-inheritance) for details.
 
+#### `merge-keys`
+
+List of top-level keys that should be merged (extended from parent) rather than replaced during inheritance resolution. Only effective when `inherit` is also specified.
+
+- **Type:** `list[str] | None`
+- **Default:** `None`
+- **Valid values:** `dependencies`, `agents`, `slash-commands`, `rules`, `skills`, `files-to-download`, `hooks`, `mcp-servers`, `global-config`, `user-settings`, `env-variables`, `os-env-variables`
+- **Validation:** Non-eligible keys produce an error. Presence without `inherit` produces a warning.
+- **Stripped from output:** Yes (like `inherit`)
+- **Inheritance:** Not applicable. Evaluated at each inheritance level independently; not inherited or accumulated across levels.
+- **Example:**
+
+```yaml
+inherit: base.yaml
+merge-keys:
+  - agents
+  - mcp-servers
+  - dependencies
+  - hooks
+```
+
+See [Selective Merge (merge-keys)](#selective-merge-merge-keys) for details.
+
 ### Installation Control
 
 #### `claude-code-version`
@@ -290,6 +319,7 @@ Specific Claude Code version to install.
 - **Special value:** `"latest"` (case-insensitive) installs the latest available version (same as the default behavior)
 - **Validation:** Must be `"latest"` or valid semver (`X.Y.Z` with optional pre-release and build metadata)
 - **Note:** Works with both native (via direct binary download from Google Cloud Storage) and npm installation methods. If the requested version is not found via GCS, the installer falls back to the native installer with the latest version
+- **Inheritance:** Standard override (child replaces parent)
 - **Example:** `claude-code-version: "1.0.128"` or `claude-code-version: "latest"`
 
 #### `install-nodejs`
@@ -299,6 +329,7 @@ Install Node.js LTS before processing dependencies. Used when MCP servers or too
 - **Type:** `bool | None`
 - **Default:** `None`
 - **Note:** When `true`, only checks the minimum Node.js version (>= 18.0.0), not Claude Code npm compatibility
+- **Inheritance:** Standard override (child replaces parent)
 - **Example:** `install-nodejs: true`
 
 #### `dependencies`
@@ -312,6 +343,7 @@ Platform-specific shell commands to execute during setup.
   - `common` runs on all platforms
   - Platform-specific keys run only on the matching platform
   - Invalid keys raise a `ValueError`
+- **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: per-platform sub-key list concatenation with deduplication. Parent platform commands appear first; child commands are appended. Duplicates are removed by string equality.
 - **Example:**
 
 ```yaml
@@ -335,6 +367,7 @@ Markdown files placed in `~/.claude/agents/` during setup. Values are URLs or re
 
 - **Type:** `list[str] | None`
 - **Default:** `[]`
+- **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: parent and child lists are concatenated with deduplication by string equality. Parent items appear first; new child items are appended.
 - **Example:**
 
 ```yaml
@@ -349,6 +382,7 @@ Command files placed in `~/.claude/commands/` during setup. Uses the same path r
 
 - **Type:** `list[str] | None`
 - **Default:** `[]`
+- **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: parent and child lists are concatenated with deduplication by string equality. Parent items appear first; new child items are appended.
 - **Example:**
 
 ```yaml
@@ -365,6 +399,7 @@ Rule files placed in `~/.claude/rules/` during setup. Claude Code loads `.md` fi
 - **Default:** `[]`
 - **Scope:** User-scope only (`~/.claude/rules/`). Project-scope rules (`.claude/rules/` in the repository) should be committed directly to version control.
 - **Note:** Only `.md` files are recognized by Claude Code. Rules support optional YAML frontmatter with `description:` and `paths:` for path-scoped rules (glob patterns).
+- **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: parent and child lists are concatenated with deduplication by string equality. Parent items appear first; new child items are appended.
 - **Example:**
 
 ```yaml
@@ -379,6 +414,7 @@ Skill configurations. Each skill is a set of files placed in `~/.claude/skills/{
 
 - **Type:** `list[Skill] | None`
 - **Default:** `[]`
+- **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: identity-based merge by `name` field. Child skills with the same name replace the parent skill in-position (at the parent's original index). New child skills are appended at the end.
 - **Skill fields:**
   - `name` (str, required): Skill identifier
   - `base` (str, required): Base URL or local path for skill files
@@ -405,6 +441,7 @@ Arbitrary files to download during setup. Each entry specifies a source and a de
   - `dest` (str, required): Destination path (supports `~` expansion)
 - **Validation:** Paths cannot be empty or contain null bytes
 - **Security:** Destinations matching sensitive path prefixes (for example, `~/.ssh/`, `~/.bashrc`) are flagged with `[!]` in the installation summary
+- **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: identity-based merge by `dest` field. Child entries with the same destination replace the parent entry in-position. New child entries are appended at the end.
 - **Example:**
 
 ```yaml
@@ -420,6 +457,7 @@ MCP (Model Context Protocol) servers extend Claude Code with additional capabili
 - **Type:** `list[dict] | None`
 - **Default:** `[]`
 - **Note:** Each server must have a `name` field
+- **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: identity-based merge by `name` field. Child servers with the same name replace the parent server in-position (at the parent's original index). New child servers are appended at the end.
 
 #### HTTP Transport
 
@@ -517,6 +555,7 @@ Model alias or custom model name for Claude Code.
 - **Default:** `None`
 - **Valid aliases:** `default`, `sonnet`, `opus`, `haiku`, `opus[1m]`, `sonnet[1m]`, `opusplan`
 - **Custom names:** Any model name starting with `claude-` (for example, `claude-3-5-sonnet-20241022`)
+- **Inheritance:** Standard override (child replaces parent)
 - **Example:** `model: "opus"` or `model: "claude-3-5-sonnet-20241022"`
 
 #### `always-thinking-enabled`
@@ -525,6 +564,7 @@ Enable always-on extended thinking mode.
 
 - **Type:** `bool | None`
 - **Default:** `None`
+- **Inheritance:** Standard override (child replaces parent)
 - **Example:** `always-thinking-enabled: true`
 
 #### `effort-level`
@@ -533,6 +573,7 @@ Controls adaptive reasoning effort.
 
 - **Type:** `str | None` (one of `low`, `medium`, `high`, `max`)
 - **Default:** `None`
+- **Inheritance:** Standard override (child replaces parent)
 - **Values:**
   - `low` -- Minimal reasoning, fastest responses
   - `medium` -- Balanced reasoning and speed
@@ -557,6 +598,7 @@ Permission rules controlling which tools and actions are allowed, denied, or req
 
 - **Type:** `Permissions | None`
 - **Default:** `None`
+- **Inheritance:** Standard override (child replaces parent). Note: MCP server permissions are automatically added during setup regardless of inheritance.
 - **Fields:**
   - `defaultMode` -- One of `default`, `acceptEdits`, `plan`, `bypassPermissions`
   - `allow` -- List of explicitly allowed actions
@@ -590,6 +632,7 @@ Claude-level environment variables set in the settings file. These are available
 
 - **Type:** `dict[str, str] | None`
 - **Default:** `None`
+- **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: shallow dictionary merge. Child keys override matching parent keys. Set a value to `null` to delete a parent key (RFC 7396 semantics).
 - **Example:**
 
 ```yaml
@@ -606,6 +649,7 @@ OS-level persistent environment variables written to the shell profile (Linux/ma
 - **Default:** `None`
 - **Special value:** Set a value to `null` to delete an existing variable
 - **Validation:** Variable names must match `^[A-Za-z_][A-Za-z0-9_]*$`
+- **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: shallow dictionary merge. Child keys override matching parent keys. Set a value to `null` to delete a parent key (RFC 7396 semantics).
 - **Example:**
 
 ```yaml
@@ -628,6 +672,7 @@ System prompt configuration for the environment command.
     - `replace` -- Completely replaces the default system prompt (`--system-prompt` flag, added in Claude Code v2.0.14)
     - `append` -- Appends to Claude's default development prompt (`--append-system-prompt` flag, added in Claude Code v1.0.55)
 - **Co-dependency:** If specified, `command-names` must also be specified (and vice versa)
+- **Inheritance:** Standard override (child replaces parent)
 - **Example:**
 
 ```yaml
@@ -645,6 +690,7 @@ Free-form settings merged into `~/.claude/settings.json`. Uses deep merge with a
 - **Type:** `UserSettings | None`
 - **Default:** `None`
 - **Excluded keys:** `hooks` and `statusLine` (these are profile-specific and must be configured at the root level of the YAML configuration)
+- **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: deep recursive merge using `deep_merge_settings()` with `DEFAULT_ARRAY_UNION_KEYS` (`permissions.allow`, `permissions.deny`, `permissions.ask` arrays are unioned with deduplication). Child keys override matching parent keys; `null` values delete keys.
 - **Example:**
 
 ```yaml
@@ -661,6 +707,7 @@ Settings merged into `~/.claude.json` (the Claude Code global configuration file
 - **Type:** `GlobalConfig | None`
 - **Default:** `None`
 - **Excluded keys:** `oauthAccount` cannot be set to non-null values (OAuth credentials must not appear in YAML configuration files). Set `oauthAccount: null` to clear authentication state.
+- **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: deep recursive merge using `deep_merge_settings()` with `array_union_keys=set()` (arrays are replaced, not unioned). Child keys override matching parent keys; `null` values delete keys (RFC 7396).
 - **Example:**
 
 ```yaml
@@ -702,6 +749,7 @@ Announcement strings displayed to users during setup.
 
 - **Type:** `list[str] | None`
 - **Default:** `None`
+- **Inheritance:** Standard override (child replaces parent)
 - **Example:**
 
 ```yaml
@@ -716,6 +764,7 @@ Attribution strings for commits and pull requests. Set a field to an empty strin
 
 - **Type:** `Attribution | None`
 - **Default:** `None`
+- **Inheritance:** Standard override (child replaces parent)
 - **Fields:**
   - `commit` (str) -- Attribution string for commits
   - `pr` (str) -- Attribution string for pull requests
@@ -733,6 +782,7 @@ Status line script configuration. The script file and optional config file are d
 
 - **Type:** `StatusLine | None`
 - **Default:** `None`
+- **Inheritance:** Standard override (child replaces parent)
 - **Fields:**
   - `file` (str, required) -- Script file path
   - `padding` (int, optional) -- Padding value
@@ -753,6 +803,7 @@ Event-driven scripts that run automatically during Claude Code sessions.
 
 - **Type:** `Hooks | None`
 - **Default:** `None`
+- **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: composite merge. `files` lists are concatenated with deduplication by full file path string equality. `events` lists are concatenated without deduplication (each event is unique by its field combination).
 - **Fields:**
   - `files` (list[str]) -- Script files to download to `~/.claude/hooks/`
   - `events` (list[HookEvent]) -- Event configurations
@@ -846,11 +897,12 @@ The `inherit` key allows a configuration to extend a parent configuration.
 
 #### How Inheritance Works
 
-- Child values completely **replace** parent values for the same top-level key (no deep merge)
+- Child values completely **replace** parent values for the same top-level key by default
+- Use `merge-keys` to selectively **merge** (extend) specific keys instead of replacing them -- see [Selective Merge (merge-keys)](#selective-merge-merge-keys)
 - Maximum inheritance depth is 10 levels
 - Circular dependencies are detected automatically
 - The `version` key is extracted from the root config **before** inheritance resolution
-- The `inherit` key is stripped from the final merged configuration
+- Both `inherit` and `merge-keys` are stripped from the final merged configuration
 
 #### Inheritance Path Resolution
 
@@ -880,6 +932,99 @@ agents:                       # Completely REPLACES parent's agents list
 effort-level: "high"          # Added (not in parent)
 # model: "sonnet" is inherited from parent (not overridden)
 ```
+
+### Selective Merge (`merge-keys`)
+
+By default, child configurations completely replace parent values at the top level. The `merge-keys` directive enables selective extension: child values are merged with parent values for specified keys instead of replacing them.
+
+#### Syntax
+
+```yaml
+inherit: base-config.yaml
+merge-keys:
+  - agents
+  - mcp-servers
+  - dependencies
+```
+
+#### Per-Level Evaluation
+
+`merge-keys` is evaluated at each inheritance level independently. It is NOT inherited or accumulated across levels. A replace at level N resets the accumulated value; a merge at level N+1 extends from level N's resolved value only.
+
+Example -- 4-level chain:
+
+```text
+Level 1 (source):  agents: [A, B]
+Level 2 (merge):   merge-keys: [agents], agents: [C]     => [A, B, C]
+Level 3 (replace): agents: [D]                            => [D]
+Level 4 (merge):   merge-keys: [agents], agents: [E]     => [D, E]
+```
+
+If all levels 2-4 use merge: `[A, B, C, D, E]`.
+
+#### Merge Strategies by Key Type
+
+| Type                   | Keys                                | Strategy                                                                             |
+|------------------------|-------------------------------------|--------------------------------------------------------------------------------------|
+| String list            | `agents`, `slash-commands`, `rules` | Concatenate parent + child; deduplicate by string equality; parent items first       |
+| Named list (by `name`) | `mcp-servers`, `skills`             | Identity-based: child overrides parent in-position; new items appended               |
+| Named list (by `dest`) | `files-to-download`                 | Identity-based: child overrides parent in-position; new items appended               |
+| Per-platform dict      | `dependencies`                      | Per-platform sub-key list concatenation with deduplication                           |
+| Composite              | `hooks`                             | `files`: concat + dedup by full path; `events`: concat (no dedup)                    |
+| Deep dict              | `global-config`                     | `deep_merge_settings()` with no array union                                          |
+| Deep dict              | `user-settings`                     | `deep_merge_settings()` with `permissions.*` array union                             |
+| Shallow dict           | `env-variables`, `os-env-variables` | Shallow merge; child overrides; `null` deletes (RFC 7396)                            |
+
+#### Non-Mergeable Keys
+
+Keys not listed in the 12 mergeable keys (such as `name`, `model`, `permissions`, `command-defaults`) always use replace semantics, regardless of `merge-keys`.
+
+#### Complete Merge Example
+
+```yaml
+# base.yaml
+name: "Base Environment"
+agents:
+  - "agents/core-agent.md"
+mcp-servers:
+  - name: "context-server"
+    transport: "http"
+    url: "http://localhost:8000/mcp"
+dependencies:
+  common:
+    - "uv tool install ruff"
+```
+
+```yaml
+# child.yaml
+inherit: "base.yaml"
+merge-keys:
+  - agents
+  - mcp-servers
+  - dependencies
+name: "Extended Environment"  # Replaces (not in merge-keys)
+agents:
+  - "agents/extra-agent.md"  # Appended to parent's list
+mcp-servers:
+  - name: "context-server"   # Replaces parent's context-server in-position
+    transport: "http"
+    url: "http://localhost:9000/mcp"
+  - name: "new-server"       # Appended (new identity)
+    command: "npx @example/new-mcp"
+dependencies:
+  common:
+    - "uv tool install mypy"  # Appended to parent's common list
+  linux:
+    - "sudo apt-get install -y shellcheck"  # New platform
+```
+
+Result after merge:
+
+- `name`: `"Extended Environment"` (replaced)
+- `agents`: `["agents/core-agent.md", "agents/extra-agent.md"]` (merged)
+- `mcp-servers`: context-server with updated URL at index 0, new-server appended (merged)
+- `dependencies.common`: `["uv tool install ruff", "uv tool install mypy"]` (merged)
+- `dependencies.linux`: `["sudo apt-get install -y shellcheck"]` (new platform from child)
 
 ### Authentication for Private Repositories
 

--- a/scripts/models/environment_config.py
+++ b/scripts/models/environment_config.py
@@ -620,6 +620,12 @@ class EnvironmentConfig(BaseModel):
         description='URL or path to parent configuration to inherit from. '
         'Supports full URLs, local paths, or repository config names.',
     )
+    merge_keys: list[str] | None = Field(
+        None,
+        alias='merge-keys',
+        description='List of top-level keys to merge (extend) from parent during inheritance. '
+        'Only applicable with inherit. Keys not listed here use replace semantics.',
+    )
     os_env_variables: dict[str, str | None] | None = Field(
         None,
         alias='os-env-variables',
@@ -807,6 +813,37 @@ class EnvironmentConfig(BaseModel):
         if '\x00' in v:
             raise ValueError('inherit cannot contain null bytes')
 
+        return v
+
+    @field_validator('merge_keys')
+    @classmethod
+    def validate_merge_keys(cls, v: list[str] | None) -> list[str] | None:
+        """Validate merge-keys entries against the set of mergeable configuration keys.
+
+        Args:
+            v: List of key names to validate.
+
+        Returns:
+            The validated list, or None.
+
+        Raises:
+            ValueError: If any key is not in the set of mergeable keys.
+        """
+        if v is None:
+            return v
+
+        # Inline definition avoids circular import from setup_environment.py
+        mergeable: frozenset[str] = frozenset({
+            'dependencies', 'agents', 'slash-commands', 'rules', 'skills',
+            'files-to-download', 'hooks', 'mcp-servers',
+            'global-config', 'user-settings', 'env-variables', 'os-env-variables',
+        })
+        invalid = [k for k in v if k not in mergeable]
+        if invalid:
+            raise ValueError(
+                f'Invalid merge-keys: {invalid}. '
+                f'Valid mergeable keys: {sorted(mergeable)}',
+            )
         return v
 
     @field_validator('os_env_variables')

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -55,6 +55,24 @@ if sys.platform != 'win32':
 # Configuration inheritance constants
 MAX_INHERITANCE_DEPTH = 10
 INHERIT_KEY = 'inherit'
+MERGE_KEYS_KEY = 'merge-keys'
+
+# Keys eligible for selective merge during configuration inheritance.
+# Only these top-level keys can be listed in the `merge-keys` directive.
+MERGEABLE_CONFIG_KEYS: frozenset[str] = frozenset({
+    'dependencies',
+    'agents',
+    'slash-commands',
+    'rules',
+    'skills',
+    'files-to-download',
+    'hooks',
+    'mcp-servers',
+    'global-config',
+    'user-settings',
+    'env-variables',
+    'os-env-variables',
+})
 
 # Node.js installation constants (standalone -- no imports from install_claude.py)
 MIN_NODE_VERSION = '18.0.0'
@@ -65,6 +83,7 @@ KNOWN_CONFIG_KEYS: frozenset[str] = frozenset({
     'name',
     'version',
     'inherit',
+    'merge-keys',
     'command-names',
     'base-url',
     'claude-code-version',
@@ -3144,26 +3163,239 @@ def _resolve_inherit_path(inherit_value: str, current_source: str) -> str:
     return inherit_value
 
 
-def _merge_configs(parent: dict[str, Any], child: dict[str, Any]) -> dict[str, Any]:
-    """Merge parent and child configs with top-level key override semantics.
+def _merge_string_list(
+    parent_list: list[str],
+    child_list: list[str],
+) -> list[str]:
+    """Merge two string lists with deduplication, parent items first.
 
-    Child values completely replace parent values for the same key.
-    No deep merging is performed.
+    Args:
+        parent_list: Base list of strings.
+        child_list: Override list of strings to append.
+
+    Returns:
+        Merged list with parent order preserved and new child items appended.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in parent_list:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    for item in child_list:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def _merge_named_list(
+    parent_list: list[dict[str, Any]],
+    child_list: list[dict[str, Any]],
+    identity_key: str,
+) -> list[dict[str, Any]]:
+    """Merge named lists with in-position replacement for matching identities.
+
+    Child items sharing a parent item's identity replace it at the parent's
+    original position. New child items (no matching parent) are appended.
+
+    Args:
+        parent_list: Base list of dicts.
+        child_list: Override list of dicts.
+        identity_key: Dict key used as the identity for matching.
+
+    Returns:
+        Merged list preserving parent ordering with child overrides and appends.
+    """
+    child_by_id: dict[str, dict[str, Any]] = {}
+    for item in child_list:
+        key = item.get(identity_key)
+        if key is not None:
+            child_by_id[str(key)] = item
+
+    consumed: set[str] = set()
+    result: list[dict[str, Any]] = []
+
+    for parent_item in parent_list:
+        parent_key = str(parent_item.get(identity_key, ''))
+        if parent_key in child_by_id:
+            result.append(child_by_id[parent_key])
+            consumed.add(parent_key)
+        else:
+            result.append(parent_item)
+
+    for item in child_list:
+        key = str(item.get(identity_key, ''))
+        if key not in consumed:
+            result.append(item)
+
+    return result
+
+
+def _merge_hooks(
+    parent_hooks: dict[str, Any],
+    child_hooks: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge hooks: files with dedup, events concatenated.
+
+    Args:
+        parent_hooks: Parent hooks configuration.
+        child_hooks: Child hooks configuration.
+
+    Returns:
+        Merged hooks with deduplicated files and concatenated events.
+    """
+    parent_files = parent_hooks.get('files', [])
+    child_files = child_hooks.get('files', [])
+    seen_files: set[str] = set()
+    merged_files: list[str] = []
+    for f in parent_files:
+        if f not in seen_files:
+            seen_files.add(f)
+            merged_files.append(f)
+    for f in child_files:
+        if f not in seen_files:
+            seen_files.add(f)
+            merged_files.append(f)
+
+    parent_events = parent_hooks.get('events', [])
+    child_events = child_hooks.get('events', [])
+    merged_events = list(parent_events) + list(child_events)
+
+    return {'files': merged_files, 'events': merged_events}
+
+
+def _merge_dependencies(
+    parent_deps: dict[str, list[str]],
+    child_deps: dict[str, list[str]],
+) -> dict[str, list[str]]:
+    """Merge dependency dicts per platform with deduplication.
+
+    Args:
+        parent_deps: Parent per-platform dependency commands.
+        child_deps: Child per-platform dependency commands.
+
+    Returns:
+        Merged dependencies with per-platform list concatenation and dedup.
+    """
+    all_platforms = set(parent_deps.keys()) | set(child_deps.keys())
+    result: dict[str, list[str]] = {}
+    for plat in sorted(all_platforms):
+        parent_cmds = parent_deps.get(plat, [])
+        child_cmds = child_deps.get(plat, [])
+        result[plat] = _merge_string_list(parent_cmds, child_cmds)
+    return result
+
+
+def _merge_config_key(
+    key: str,
+    parent_value: object,
+    child_value: object,
+) -> object:
+    """Dispatch merge for a single key based on its type semantics.
+
+    Args:
+        key: The configuration key name.
+        parent_value: The parent's value for this key.
+        child_value: The child's value for this key.
+
+    Returns:
+        The merged value using the appropriate strategy for the key type.
+    """
+    # String list keys: concat + dedup, parent-first order
+    if key in ('agents', 'slash-commands', 'rules'):
+        p_list = cast(list[str], parent_value) if isinstance(parent_value, list) else []
+        c_list = cast(list[str], child_value) if isinstance(child_value, list) else []
+        return _merge_string_list(p_list, c_list)
+
+    # Named list keys with identity by 'name'
+    if key in ('mcp-servers', 'skills'):
+        p_named = cast(list[dict[str, object]], parent_value) if isinstance(parent_value, list) else []
+        c_named = cast(list[dict[str, object]], child_value) if isinstance(child_value, list) else []
+        return _merge_named_list(p_named, c_named, 'name')
+
+    # Named list key with identity by 'dest'
+    if key == 'files-to-download':
+        p_files = cast(list[dict[str, object]], parent_value) if isinstance(parent_value, list) else []
+        c_files = cast(list[dict[str, object]], child_value) if isinstance(child_value, list) else []
+        return _merge_named_list(p_files, c_files, 'dest')
+
+    # Dependencies: per-platform merge
+    if key == 'dependencies':
+        p_deps = cast(dict[str, list[str]], parent_value) if isinstance(parent_value, dict) else {}
+        c_deps = cast(dict[str, list[str]], child_value) if isinstance(child_value, dict) else {}
+        return _merge_dependencies(p_deps, c_deps)
+
+    # Hooks: composite merge (files dedup + events concat)
+    if key == 'hooks':
+        p_hooks = cast(dict[str, Any], parent_value) if isinstance(parent_value, dict) else {}
+        c_hooks = cast(dict[str, Any], child_value) if isinstance(child_value, dict) else {}
+        return _merge_hooks(p_hooks, c_hooks)
+
+    # Global-config: deep merge with no array union
+    if key == 'global-config':
+        p_gc = cast(dict[str, Any], parent_value) if isinstance(parent_value, dict) else {}
+        c_gc = cast(dict[str, Any], child_value) if isinstance(child_value, dict) else {}
+        return deep_merge_settings(p_gc, c_gc, array_union_keys=set())
+
+    # User-settings: deep merge with default array union keys
+    if key == 'user-settings':
+        p_us = cast(dict[str, Any], parent_value) if isinstance(parent_value, dict) else {}
+        c_us = cast(dict[str, Any], child_value) if isinstance(child_value, dict) else {}
+        return deep_merge_settings(p_us, c_us, array_union_keys=DEFAULT_ARRAY_UNION_KEYS)
+
+    # Env-variables and os-env-variables: shallow dict merge, null deletes
+    if key in ('env-variables', 'os-env-variables'):
+        p_env = cast(dict[str, str | None], parent_value) if isinstance(parent_value, dict) else {}
+        c_env = cast(dict[str, str | None], child_value) if isinstance(child_value, dict) else {}
+        merged_env: dict[str, str | None] = dict(p_env)
+        for env_k, env_v in c_env.items():
+            if env_v is None:
+                merged_env.pop(env_k, None)
+            else:
+                merged_env[env_k] = env_v
+        return merged_env
+
+    # Fallback: replace semantics
+    return child_value
+
+
+def _merge_configs(
+    parent: dict[str, Any],
+    child: dict[str, Any],
+    merge_keys: frozenset[str] | None = None,
+) -> dict[str, Any]:
+    """Merge parent and child configs with optional per-key merge semantics.
+
+    When merge_keys is None (default), child values completely replace parent
+    values (backward-compatible behavior). When merge_keys is provided, keys
+    listed in it are merged using type-aware strategies instead of replaced.
 
     Args:
         parent: The parent configuration (base).
         child: The child configuration (overrides parent).
+        merge_keys: Optional set of key names to merge instead of replace.
 
     Returns:
-        dict[str, Any]: Merged configuration.
+        Merged configuration with inherit and merge-keys stripped.
     """
-    # Start with parent's keys
     result = parent.copy()
 
-    # Override with child's keys (excluding 'inherit')
     for key, value in child.items():
-        if key != INHERIT_KEY:
+        if key in (INHERIT_KEY, MERGE_KEYS_KEY):
+            continue
+        if (
+            merge_keys is not None
+            and key in merge_keys
+            and key in result
+        ):
+            result[key] = _merge_config_key(key, result[key], value)
+        else:
             result[key] = value
+
+    # Defensive strip of meta-keys from result
+    result.pop(INHERIT_KEY, None)
+    result.pop(MERGE_KEYS_KEY, None)
 
     return result
 
@@ -3178,13 +3410,15 @@ def resolve_config_inheritance(
 ) -> tuple[dict[str, Any], list[InheritanceChainEntry]]:
     """Resolve configuration inheritance by loading and merging parent configs.
 
-    Implements top-level key override semantics: child config values completely
-    replace parent values for the same key. No deep merging is performed.
+    Implements top-level key override semantics by default: child config values
+    completely replace parent values for the same key. When 'merge-keys' is
+    specified, listed keys are merged using type-aware strategies instead.
 
     The inheritance chain is resolved recursively:
     1. If config has 'inherit' key, load the parent config
     2. If parent also has 'inherit', load its parent (recursive)
     3. Merge configs from oldest ancestor to newest child
+    4. If 'merge-keys' is present, listed keys use merge instead of replace
 
     Args:
         config: The configuration dictionary to resolve inheritance for.
@@ -3241,8 +3475,14 @@ def resolve_config_inheritance(
     # Check if this config has inheritance
     inherit_value = config.get(INHERIT_KEY)
     if inherit_value is None:
-        # No inheritance - return config as-is (without the inherit key if present)
-        return {k: v for k, v in config.items() if k != INHERIT_KEY}, chain
+        # Warn if merge-keys present without inherit
+        if config.get(MERGE_KEYS_KEY) is not None:
+            warning(
+                "Warning: 'merge-keys' has no effect without 'inherit'. "
+                "Did you mean to add an 'inherit' key?",
+            )
+        # No inheritance - return config as-is (without meta-keys)
+        return {k: v for k, v in config.items() if k not in (INHERIT_KEY, MERGE_KEYS_KEY)}, chain
 
     # Validate inherit value is a string
     if not isinstance(inherit_value, str):
@@ -3311,8 +3551,41 @@ def resolve_config_inheritance(
         name=parent_config.get('name', inherit_value),
     ))
 
-    # Merge: parent first, then child overrides (top-level key override)
-    merged = _merge_configs(resolved_parent, config)
+    # Extract and validate merge-keys from child config
+    merge_keys_value = config.get(MERGE_KEYS_KEY)
+    validated_merge_keys: frozenset[str] | None = None
+
+    if merge_keys_value is not None:
+        if not isinstance(merge_keys_value, list):
+            error(f"Invalid 'merge-keys' value: expected list, got {type(merge_keys_value).__name__}")
+            raise ValueError(
+                f"The 'merge-keys' key must be a list of strings, "
+                f"got {type(merge_keys_value).__name__}: {merge_keys_value!r}",
+            )
+
+        # Cast to list[object] for Pyright after isinstance narrowing
+        merge_keys_list = cast(list[object], merge_keys_value)
+
+        # Validate all entries are strings
+        for i, entry in enumerate(merge_keys_list):
+            if not isinstance(entry, str):
+                error(f'Invalid merge-keys[{i}]: expected string, got {type(entry).__name__}')
+                raise ValueError(f'merge-keys[{i}] must be a string, got {type(entry).__name__}')
+
+        # Validate entries against MERGEABLE_CONFIG_KEYS
+        merge_keys_str = cast(list[str], merge_keys_list)
+        invalid_keys = [k for k in merge_keys_str if k not in MERGEABLE_CONFIG_KEYS]
+        if invalid_keys:
+            error(f'Invalid merge-keys: {invalid_keys}')
+            raise ValueError(
+                f'Invalid keys in merge-keys: {invalid_keys}. '
+                f'Valid mergeable keys: {sorted(MERGEABLE_CONFIG_KEYS)}',
+            )
+
+        validated_merge_keys = frozenset(merge_keys_str)
+
+    # Merge: parent first, then child overrides
+    merged = _merge_configs(resolved_parent, config, merge_keys=validated_merge_keys)
 
     success(f'Inherited from: {inherit_value}')
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -144,6 +144,7 @@ def golden_config() -> dict[str, Any]:
 
     The golden config includes:
     - version: Configuration version for update checking
+    - merge-keys: Selective merge keys (exercises warning path without inherit)
     - command-names: Array of command names/aliases
     - base-url: Resource URL (uses local mock_repo)
     - claude-code-version: Version specification

--- a/tests/e2e/fixtures/merge_chain_l1.yaml
+++ b/tests/e2e/fixtures/merge_chain_l1.yaml
@@ -1,0 +1,14 @@
+# Level 1: Source config (no inheritance)
+name: "Chain Level 1"
+
+agents:
+  - "agents/l1-agent.md"
+
+mcp-servers:
+  - name: "l1-server"
+    scope: "user"
+    transport: "http"
+    url: "http://localhost:3000/l1"
+
+rules:
+  - "rules/l1-rule.md"

--- a/tests/e2e/fixtures/merge_chain_l2.yaml
+++ b/tests/e2e/fixtures/merge_chain_l2.yaml
@@ -1,0 +1,20 @@
+# Level 2: Merges from L1
+name: "Chain Level 2"
+
+inherit: merge_chain_l1.yaml
+merge-keys:
+  - agents
+  - mcp-servers
+  - rules
+
+agents:
+  - "agents/l2-agent.md"
+
+mcp-servers:
+  - name: "l2-server"
+    scope: "user"
+    transport: "http"
+    url: "http://localhost:3000/l2"
+
+rules:
+  - "rules/l2-rule.md"

--- a/tests/e2e/fixtures/merge_chain_l3.yaml
+++ b/tests/e2e/fixtures/merge_chain_l3.yaml
@@ -1,0 +1,16 @@
+# Level 3: Replaces from L2 (no merge-keys)
+name: "Chain Level 3"
+
+inherit: merge_chain_l2.yaml
+
+agents:
+  - "agents/l3-agent.md"
+
+mcp-servers:
+  - name: "l3-server"
+    scope: "user"
+    transport: "http"
+    url: "http://localhost:3000/l3"
+
+rules:
+  - "rules/l3-rule.md"

--- a/tests/e2e/fixtures/merge_chain_l4.yaml
+++ b/tests/e2e/fixtures/merge_chain_l4.yaml
@@ -1,0 +1,20 @@
+# Level 4: Merges from L3 (extends L3's replaced values)
+name: "Chain Level 4"
+
+inherit: merge_chain_l3.yaml
+merge-keys:
+  - agents
+  - mcp-servers
+  - rules
+
+agents:
+  - "agents/l4-agent.md"
+
+mcp-servers:
+  - name: "l4-server"
+    scope: "user"
+    transport: "http"
+    url: "http://localhost:3000/l4"
+
+rules:
+  - "rules/l4-rule.md"

--- a/tests/e2e/fixtures/merge_child.yaml
+++ b/tests/e2e/fixtures/merge_child.yaml
@@ -1,0 +1,76 @@
+# Child config that merges selected keys from parent
+name: "Merge Child"
+
+inherit: merge_parent.yaml
+merge-keys:
+  - agents
+  - mcp-servers
+  - rules
+  - dependencies
+  - hooks
+  - global-config
+  - user-settings
+  - env-variables
+  - os-env-variables
+  - skills
+  - files-to-download
+
+agents:
+  - "agents/child-agent.md"
+
+rules:
+  - "rules/child-rule.md"
+
+mcp-servers:
+  - name: "parent-server"
+    scope: "project"
+    transport: "http"
+    url: "http://localhost:3000/child-override"
+  - name: "child-server"
+    scope: "user"
+    transport: "http"
+    url: "http://localhost:3001/child"
+
+dependencies:
+  common:
+    - "echo child-common"
+  windows:
+    - "echo child-windows"
+
+hooks:
+  files:
+    - "hooks/child-hook.py"
+  events:
+    - event: "PreToolUse"
+      matcher: "Bash"
+      type: "command"
+      command: "child-hook.py"
+
+global-config:
+  childKey: "childValue"
+  sharedKey: "fromChild"
+
+user-settings:
+  theme: "dark"
+  permissions:
+    allow:
+      - "Write"
+
+env-variables:
+  CHILD_VAR: "child_val"
+  SHARED_VAR: null
+
+os-env-variables:
+  CHILD_OS: "child_os_val"
+
+skills:
+  - name: "child-skill"
+    base: "skills/"
+    files:
+      - "SKILL.md"
+
+files-to-download:
+  - source: "configs/child-file.txt"
+    dest: "~/.claude/child-file.txt"
+  - source: "configs/override-parent.txt"
+    dest: "~/.claude/parent-file.txt"

--- a/tests/e2e/fixtures/merge_parent.yaml
+++ b/tests/e2e/fixtures/merge_parent.yaml
@@ -1,0 +1,56 @@
+# Base config for merge-keys E2E testing
+name: "Merge Parent"
+
+agents:
+  - "agents/parent-agent.md"
+
+rules:
+  - "rules/parent-rule.md"
+
+mcp-servers:
+  - name: "parent-server"
+    scope: "user"
+    transport: "http"
+    url: "http://localhost:3000/parent"
+
+dependencies:
+  common:
+    - "echo parent-common"
+  linux:
+    - "echo parent-linux"
+
+hooks:
+  files:
+    - "hooks/parent-hook.py"
+  events:
+    - event: "PostToolUse"
+      matcher: "Edit"
+      type: "command"
+      command: "parent-hook.py"
+
+global-config:
+  parentKey: "parentValue"
+  sharedKey: "fromParent"
+
+user-settings:
+  language: "english"
+  permissions:
+    allow:
+      - "Read"
+
+env-variables:
+  PARENT_VAR: "parent_val"
+  SHARED_VAR: "from_parent"
+
+os-env-variables:
+  PARENT_OS: "parent_os_val"
+
+skills:
+  - name: "parent-skill"
+    base: "skills/"
+    files:
+      - "SKILL.md"
+
+files-to-download:
+  - source: "configs/parent-file.txt"
+    dest: "~/.claude/parent-file.txt"

--- a/tests/e2e/golden_config.yaml
+++ b/tests/e2e/golden_config.yaml
@@ -7,6 +7,11 @@ name: "E2E Test Environment"
 # Configuration version for update checking
 version: "1.0.0"
 
+# Selective merge keys (no-op without inherit; exercises warning path)
+merge-keys:
+  - agents
+  - mcp-servers
+
 # Description shown in installation summary
 description: |
   A comprehensive test environment for validating

--- a/tests/e2e/test_merge_keys.py
+++ b/tests/e2e/test_merge_keys.py
@@ -1,0 +1,272 @@
+"""E2E tests for the merge-keys selective merge feature.
+
+Tests verify that configuration inheritance with merge-keys correctly merges
+specified keys using type-aware strategies while replacing non-listed keys.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts import setup_environment
+
+
+@pytest.fixture
+def fixtures_dir() -> Path:
+    """Return the path to E2E fixtures directory."""
+    return Path(__file__).parent / 'fixtures'
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    """Load a YAML file and return its content."""
+    with path.open('r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+
+def _resolve(
+    config: dict[str, Any],
+    source: str,
+) -> tuple[dict[str, Any], list[setup_environment.InheritanceChainEntry]]:
+    """Resolve config inheritance from a source path."""
+    return setup_environment.resolve_config_inheritance(config, source)
+
+
+class TestTwoLevelMerge:
+    """Test two-level parent-child inheritance with merge-keys."""
+
+    def test_agents_merged(self, fixtures_dir):
+        """Agents from parent and child are concatenated with dedup."""
+        child_path = fixtures_dir / 'merge_child.yaml'
+        config = _load_yaml(child_path)
+        resolved, _ = _resolve(config, str(child_path))
+        assert 'agents/parent-agent.md' in resolved['agents']
+        assert 'agents/child-agent.md' in resolved['agents']
+
+    def test_rules_merged(self, fixtures_dir):
+        """Rules from parent and child are concatenated."""
+        child_path = fixtures_dir / 'merge_child.yaml'
+        config = _load_yaml(child_path)
+        resolved, _ = _resolve(config, str(child_path))
+        assert 'rules/parent-rule.md' in resolved['rules']
+        assert 'rules/child-rule.md' in resolved['rules']
+
+    def test_mcp_servers_in_position_replacement(self, fixtures_dir):
+        """MCP server with same name replaced in-position; new server appended."""
+        child_path = fixtures_dir / 'merge_child.yaml'
+        config = _load_yaml(child_path)
+        resolved, _ = _resolve(config, str(child_path))
+        servers = resolved['mcp-servers']
+        # parent-server replaced in-position (was at index 0)
+        assert servers[0]['name'] == 'parent-server'
+        assert servers[0]['url'] == 'http://localhost:3000/child-override'
+        assert servers[0]['scope'] == 'project'
+        # child-server appended
+        assert servers[1]['name'] == 'child-server'
+
+    def test_dependencies_per_platform_merge(self, fixtures_dir):
+        """Dependencies merged per-platform with dedup."""
+        child_path = fixtures_dir / 'merge_child.yaml'
+        config = _load_yaml(child_path)
+        resolved, _ = _resolve(config, str(child_path))
+        deps = resolved['dependencies']
+        assert 'echo parent-common' in deps['common']
+        assert 'echo child-common' in deps['common']
+        assert 'echo parent-linux' in deps['linux']
+        assert 'echo child-windows' in deps['windows']
+
+    def test_hooks_files_dedup_events_concat(self, fixtures_dir):
+        """Hooks files deduplicated, events concatenated."""
+        child_path = fixtures_dir / 'merge_child.yaml'
+        config = _load_yaml(child_path)
+        resolved, _ = _resolve(config, str(child_path))
+        hooks = resolved['hooks']
+        assert 'hooks/parent-hook.py' in hooks['files']
+        assert 'hooks/child-hook.py' in hooks['files']
+        assert len(hooks['events']) == 2
+
+    def test_global_config_deep_merge(self, fixtures_dir):
+        """Global-config deep merged: child overrides shared key, parent-only preserved."""
+        child_path = fixtures_dir / 'merge_child.yaml'
+        config = _load_yaml(child_path)
+        resolved, _ = _resolve(config, str(child_path))
+        gc = resolved['global-config']
+        assert gc['parentKey'] == 'parentValue'
+        assert gc['childKey'] == 'childValue'
+        assert gc['sharedKey'] == 'fromChild'
+
+    def test_user_settings_deep_merge_with_permission_union(self, fixtures_dir):
+        """User-settings deep merged with permission array union."""
+        child_path = fixtures_dir / 'merge_child.yaml'
+        config = _load_yaml(child_path)
+        resolved, _ = _resolve(config, str(child_path))
+        us = resolved['user-settings']
+        assert us['language'] == 'english'
+        assert us['theme'] == 'dark'
+        perms = us['permissions']['allow']
+        assert 'Read' in perms
+        assert 'Write' in perms
+
+    def test_env_variables_shallow_merge_null_delete(self, fixtures_dir):
+        """Env-variables shallow merged, null deletes parent key."""
+        child_path = fixtures_dir / 'merge_child.yaml'
+        config = _load_yaml(child_path)
+        resolved, _ = _resolve(config, str(child_path))
+        env = resolved['env-variables']
+        assert env['PARENT_VAR'] == 'parent_val'
+        assert env['CHILD_VAR'] == 'child_val'
+        assert 'SHARED_VAR' not in env
+
+    def test_os_env_variables_shallow_merge(self, fixtures_dir):
+        """Os-env-variables shallow merged."""
+        child_path = fixtures_dir / 'merge_child.yaml'
+        config = _load_yaml(child_path)
+        resolved, _ = _resolve(config, str(child_path))
+        os_env = resolved['os-env-variables']
+        assert os_env['PARENT_OS'] == 'parent_os_val'
+        assert os_env['CHILD_OS'] == 'child_os_val'
+
+    def test_skills_merged_by_name(self, fixtures_dir):
+        """Skills merged by name identity."""
+        child_path = fixtures_dir / 'merge_child.yaml'
+        config = _load_yaml(child_path)
+        resolved, _ = _resolve(config, str(child_path))
+        skill_names = [s['name'] for s in resolved['skills']]
+        assert 'parent-skill' in skill_names
+        assert 'child-skill' in skill_names
+
+    def test_files_to_download_merged_by_dest(self, fixtures_dir):
+        """Files-to-download merged by dest identity."""
+        child_path = fixtures_dir / 'merge_child.yaml'
+        config = _load_yaml(child_path)
+        resolved, _ = _resolve(config, str(child_path))
+        files = resolved['files-to-download']
+        dest_map = {f['dest']: f['source'] for f in files}
+        # parent-file.txt overridden by child (same dest)
+        assert dest_map['~/.claude/parent-file.txt'] == 'configs/override-parent.txt'
+        # child-file.txt added
+        assert '~/.claude/child-file.txt' in dest_map
+
+    def test_name_replaced_not_merged(self, fixtures_dir):
+        """Name is not in merge-keys, so child replaces parent."""
+        child_path = fixtures_dir / 'merge_child.yaml'
+        config = _load_yaml(child_path)
+        resolved, _ = _resolve(config, str(child_path))
+        assert resolved['name'] == 'Merge Child'
+
+    def test_meta_keys_stripped(self, fixtures_dir):
+        """inherit and merge-keys are not present in resolved config."""
+        child_path = fixtures_dir / 'merge_child.yaml'
+        config = _load_yaml(child_path)
+        resolved, _ = _resolve(config, str(child_path))
+        assert 'inherit' not in resolved
+        assert 'merge-keys' not in resolved
+
+
+class TestFourLevelChain:
+    """Test 4-level inheritance chain with mixed merge/replace semantics."""
+
+    def test_merge_replace_merge_pattern(self, fixtures_dir):
+        """L1 source -> L2 merge -> L3 replace -> L4 merge = L3+L4 only."""
+        l4_path = fixtures_dir / 'merge_chain_l4.yaml'
+        config = _load_yaml(l4_path)
+        resolved, chain = _resolve(config, str(l4_path))
+
+        agents = resolved['agents']
+        # L3 replaces everything from L1+L2 with ['agents/l3-agent.md']
+        # L4 merges with L3, adding ['agents/l4-agent.md']
+        assert 'agents/l3-agent.md' in agents
+        assert 'agents/l4-agent.md' in agents
+        # L1 and L2 agents should NOT be present (L3 replaced)
+        assert 'agents/l1-agent.md' not in agents
+        assert 'agents/l2-agent.md' not in agents
+
+    def test_mcp_servers_chain(self, fixtures_dir):
+        """MCP servers follow same merge-replace-merge pattern."""
+        l4_path = fixtures_dir / 'merge_chain_l4.yaml'
+        config = _load_yaml(l4_path)
+        resolved, _ = _resolve(config, str(l4_path))
+
+        server_names = [s['name'] for s in resolved['mcp-servers']]
+        assert 'l3-server' in server_names
+        assert 'l4-server' in server_names
+        assert 'l1-server' not in server_names
+        assert 'l2-server' not in server_names
+
+    def test_rules_chain(self, fixtures_dir):
+        """Rules follow same merge-replace-merge pattern."""
+        l4_path = fixtures_dir / 'merge_chain_l4.yaml'
+        config = _load_yaml(l4_path)
+        resolved, _ = _resolve(config, str(l4_path))
+
+        rules = resolved['rules']
+        assert 'rules/l3-rule.md' in rules
+        assert 'rules/l4-rule.md' in rules
+        assert 'rules/l1-rule.md' not in rules
+        assert 'rules/l2-rule.md' not in rules
+
+    def test_chain_length(self, fixtures_dir):
+        """Inheritance chain has 3 entries (L1, L2, L3 as ancestors of L4)."""
+        l4_path = fixtures_dir / 'merge_chain_l4.yaml'
+        config = _load_yaml(l4_path)
+        _, chain = _resolve(config, str(l4_path))
+        assert len(chain) == 3
+
+    def test_name_from_last_child(self, fixtures_dir):
+        """Name comes from L4 (last child replaces)."""
+        l4_path = fixtures_dir / 'merge_chain_l4.yaml'
+        config = _load_yaml(l4_path)
+        resolved, _ = _resolve(config, str(l4_path))
+        assert resolved['name'] == 'Chain Level 4'
+
+
+class TestTwoLevelReplace:
+    """Test two-level inheritance WITHOUT merge-keys (plain replace)."""
+
+    def test_no_merge_keys_replaces_completely(self, fixtures_dir):
+        """Without merge-keys, child completely replaces parent agents."""
+        l3_path = fixtures_dir / 'merge_chain_l3.yaml'
+        config = _load_yaml(l3_path)
+        resolved, _ = _resolve(config, str(l3_path))
+
+        # L3 has no merge-keys, so it replaces L2's (merged) agents
+        agents = resolved['agents']
+        assert agents == ['agents/l3-agent.md']
+
+
+class TestMergeKeysWithoutInherit:
+    """Test merge-keys behavior when inherit is absent."""
+
+    def test_warning_emitted(self, capsys):
+        """Warning about merge-keys without inherit is emitted."""
+        config = {'name': 'test', 'merge-keys': ['agents']}
+        setup_environment.resolve_config_inheritance(config, 'test.yaml')
+        captured = capsys.readouterr()
+        assert 'has no effect without' in captured.out
+
+    def test_merge_keys_stripped_from_result(self):
+        """merge-keys is stripped from result when no inherit."""
+        config = {'name': 'test', 'merge-keys': ['agents'], 'agents': ['a.md']}
+        resolved, _ = setup_environment.resolve_config_inheritance(config, 'test.yaml')
+        assert 'merge-keys' not in resolved
+        assert resolved['agents'] == ['a.md']
+
+    def test_golden_config_has_merge_keys(self, golden_config):
+        """Golden config includes merge-keys for testing."""
+        assert 'merge-keys' in golden_config
+
+
+class TestMixedMergeAndReplace:
+    """Test that some keys merge while others replace in the same child."""
+
+    def test_mixed_within_single_child(self, fixtures_dir):
+        """In merge_child.yaml, agents merges but name replaces."""
+        child_path = fixtures_dir / 'merge_child.yaml'
+        config = _load_yaml(child_path)
+        resolved, _ = _resolve(config, str(child_path))
+
+        # Merged key
+        assert len(resolved['agents']) == 2
+        # Replaced key (name is not in merge-keys)
+        assert resolved['name'] == 'Merge Child'

--- a/tests/scripts/models/test_environment_config.py
+++ b/tests/scripts/models/test_environment_config.py
@@ -1036,3 +1036,62 @@ class TestPostInstallNotesField:
             'post-install-notes': notes,
         })
         assert config.post_install_notes == notes
+
+
+class TestMergeKeysField:
+    """Tests for the merge_keys field in EnvironmentConfig."""
+
+    def test_merge_keys_accepts_valid_keys(self) -> None:
+        """Field accepts a list of valid mergeable key names."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'merge-keys': ['agents', 'mcp-servers', 'dependencies'],
+        })
+        assert config.merge_keys == ['agents', 'mcp-servers', 'dependencies']
+
+    def test_merge_keys_default_none(self) -> None:
+        """Field defaults to None when not provided."""
+        config = EnvironmentConfig.model_validate({'name': 'Test'})
+        assert config.merge_keys is None
+
+    def test_merge_keys_rejects_invalid_key(self) -> None:
+        """Field rejects keys not in the mergeable set."""
+        with pytest.raises(ValidationError, match='Invalid merge-keys'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'merge-keys': ['model'],
+            })
+
+    def test_merge_keys_alias(self) -> None:
+        """Field uses 'merge-keys' as YAML alias."""
+        field_info = EnvironmentConfig.model_fields['merge_keys']
+        assert field_info.alias == 'merge-keys'
+
+    def test_merge_keys_empty_list(self) -> None:
+        """Field accepts an empty list (valid, semantically a no-op)."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'merge-keys': [],
+        })
+        assert config.merge_keys == []
+
+    def test_merge_keys_all_valid_keys(self) -> None:
+        """Field accepts all 12 mergeable keys at once."""
+        all_keys = [
+            'dependencies', 'agents', 'slash-commands', 'rules', 'skills',
+            'files-to-download', 'hooks', 'mcp-servers',
+            'global-config', 'user-settings', 'env-variables', 'os-env-variables',
+        ]
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'merge-keys': all_keys,
+        })
+        assert config.merge_keys == all_keys
+
+    def test_merge_keys_rejects_multiple_invalid(self) -> None:
+        """Field error message lists all invalid keys."""
+        with pytest.raises(ValidationError, match='model'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'merge-keys': ['agents', 'model', 'name'],
+            })

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -4664,6 +4664,290 @@ class TestMergeConfigs:
         assert 'inherit' not in result
 
 
+class TestMergeKeys:
+    """Tests for merge-keys selective merge feature."""
+
+    # === Helper function tests ===
+
+    def test_merge_string_list_basic(self):
+        """String list merge: parent first, then new child items."""
+        result = setup_environment._merge_string_list(['A', 'B'], ['C', 'D'])
+        assert result == ['A', 'B', 'C', 'D']
+
+    def test_merge_string_list_dedup(self):
+        """String list merge deduplicates by string equality."""
+        result = setup_environment._merge_string_list(['A', 'B'], ['B', 'C'])
+        assert result == ['A', 'B', 'C']
+
+    def test_merge_string_list_empty_parent(self):
+        """String list merge with empty parent."""
+        result = setup_environment._merge_string_list([], ['X', 'Y'])
+        assert result == ['X', 'Y']
+
+    def test_merge_string_list_empty_child(self):
+        """String list merge with empty child."""
+        result = setup_environment._merge_string_list(['X', 'Y'], [])
+        assert result == ['X', 'Y']
+
+    def test_merge_string_list_full_overlap(self):
+        """String list merge with complete overlap keeps parent order."""
+        result = setup_environment._merge_string_list(['A', 'B'], ['B', 'A'])
+        assert result == ['A', 'B']
+
+    def test_merge_named_list_in_position_replacement(self):
+        """Named list: child replaces parent item at parent's position."""
+        parent = [{'name': 'srv1', 'url': 'old'}, {'name': 'srv2', 'url': 'keep'}]
+        child = [{'name': 'srv1', 'url': 'new'}]
+        result = setup_environment._merge_named_list(parent, child, 'name')
+        assert result == [{'name': 'srv1', 'url': 'new'}, {'name': 'srv2', 'url': 'keep'}]
+
+    def test_merge_named_list_new_items_appended(self):
+        """Named list: new child items are appended at the end."""
+        parent = [{'name': 'srv1'}]
+        child = [{'name': 'srv2'}]
+        result = setup_environment._merge_named_list(parent, child, 'name')
+        assert result == [{'name': 'srv1'}, {'name': 'srv2'}]
+
+    def test_merge_named_list_mixed_replace_and_append(self):
+        """Named list: some replaced in-position, some appended."""
+        parent = [{'name': 'A', 'v': 1}, {'name': 'B', 'v': 2}]
+        child = [{'name': 'B', 'v': 20}, {'name': 'C', 'v': 3}]
+        result = setup_environment._merge_named_list(parent, child, 'name')
+        assert result == [{'name': 'A', 'v': 1}, {'name': 'B', 'v': 20}, {'name': 'C', 'v': 3}]
+
+    def test_merge_named_list_empty_lists(self):
+        """Named list: empty parent and child."""
+        result = setup_environment._merge_named_list([], [], 'name')
+        assert result == []
+
+    def test_merge_named_list_missing_identity_key(self):
+        """Named list: items missing identity key are kept and appended independently."""
+        parent = [{'v': 1}]
+        child = [{'v': 2}]
+        result = setup_environment._merge_named_list(parent, child, 'name')
+        # Items without identity key are not matched; both are kept
+        assert len(result) == 2
+        assert result[0] == {'v': 1}
+        assert result[1] == {'v': 2}
+
+    def test_merge_hooks_files_dedup_events_concat(self):
+        """Hooks merge: files deduped, events concatenated."""
+        parent = {'files': ['a.py', 'b.py'], 'events': [{'event': 'E1'}]}
+        child = {'files': ['b.py', 'c.py'], 'events': [{'event': 'E2'}]}
+        result = setup_environment._merge_hooks(parent, child)
+        assert result['files'] == ['a.py', 'b.py', 'c.py']
+        assert result['events'] == [{'event': 'E1'}, {'event': 'E2'}]
+
+    def test_merge_hooks_missing_keys(self):
+        """Hooks merge: missing 'files' or 'events' treated as empty."""
+        result = setup_environment._merge_hooks({}, {'files': ['x.py']})
+        assert result['files'] == ['x.py']
+        assert result['events'] == []
+
+    def test_merge_dependencies_per_platform(self):
+        """Dependencies merge: per-platform sub-key merge with dedup."""
+        parent = {'common': ['echo a'], 'linux': ['apt install x']}
+        child = {'common': ['echo b', 'echo a'], 'windows': ['choco install y']}
+        result = setup_environment._merge_dependencies(parent, child)
+        assert result['common'] == ['echo a', 'echo b']
+        assert result['linux'] == ['apt install x']
+        assert result['windows'] == ['choco install y']
+
+    # === _merge_config_key dispatch tests ===
+
+    def test_merge_config_key_agents(self):
+        """Dispatch: agents uses string list merge."""
+        result = setup_environment._merge_config_key('agents', ['a.md'], ['b.md'])
+        assert result == ['a.md', 'b.md']
+
+    def test_merge_config_key_slash_commands(self):
+        """Dispatch: slash-commands uses string list merge."""
+        result = setup_environment._merge_config_key('slash-commands', ['x.md'], ['y.md'])
+        assert result == ['x.md', 'y.md']
+
+    def test_merge_config_key_rules(self):
+        """Dispatch: rules uses string list merge."""
+        result = setup_environment._merge_config_key('rules', ['r1'], ['r2'])
+        assert result == ['r1', 'r2']
+
+    def test_merge_config_key_mcp_servers(self):
+        """Dispatch: mcp-servers uses named list merge by 'name'."""
+        parent = [{'name': 's1', 'url': 'old'}]
+        child = [{'name': 's1', 'url': 'new'}, {'name': 's2', 'url': 'added'}]
+        result = setup_environment._merge_config_key('mcp-servers', parent, child)
+        assert result == [{'name': 's1', 'url': 'new'}, {'name': 's2', 'url': 'added'}]
+
+    def test_merge_config_key_skills(self):
+        """Dispatch: skills uses named list merge by 'name'."""
+        parent = [{'name': 'sk1', 'base': '/a'}]
+        child = [{'name': 'sk2', 'base': '/b'}]
+        result = setup_environment._merge_config_key('skills', parent, child)
+        assert result == [{'name': 'sk1', 'base': '/a'}, {'name': 'sk2', 'base': '/b'}]
+
+    def test_merge_config_key_files_to_download(self):
+        """Dispatch: files-to-download uses named list merge by 'dest'."""
+        parent = [{'source': 'a', 'dest': '~/.claude/a.txt'}]
+        child = [{'source': 'b', 'dest': '~/.claude/a.txt'}]
+        result = setup_environment._merge_config_key('files-to-download', parent, child)
+        assert result == [{'source': 'b', 'dest': '~/.claude/a.txt'}]
+
+    def test_merge_config_key_dependencies(self):
+        """Dispatch: dependencies uses per-platform merge."""
+        parent = {'common': ['cmd1']}
+        child = {'common': ['cmd2']}
+        result = setup_environment._merge_config_key('dependencies', parent, child)
+        assert result == {'common': ['cmd1', 'cmd2']}
+
+    def test_merge_config_key_hooks(self):
+        """Dispatch: hooks uses composite merge."""
+        parent = {'files': ['f1'], 'events': [{'e': 1}]}
+        child = {'files': ['f2'], 'events': [{'e': 2}]}
+        result = setup_environment._merge_config_key('hooks', parent, child)
+        assert result['files'] == ['f1', 'f2']
+        assert len(result['events']) == 2
+
+    def test_merge_config_key_global_config(self):
+        """Dispatch: global-config uses deep merge with no array union."""
+        parent = {'a': 1, 'b': {'c': 2}}
+        child = {'b': {'d': 3}, 'e': 4}
+        result = setup_environment._merge_config_key('global-config', parent, child)
+        assert result == {'a': 1, 'b': {'c': 2, 'd': 3}, 'e': 4}
+
+    def test_merge_config_key_user_settings(self):
+        """Dispatch: user-settings uses deep merge with DEFAULT_ARRAY_UNION_KEYS."""
+        parent = {'permissions': {'allow': ['Read']}}
+        child = {'permissions': {'allow': ['Write']}}
+        result = setup_environment._merge_config_key('user-settings', parent, child)
+        assert set(result['permissions']['allow']) == {'Read', 'Write'}
+
+    def test_merge_config_key_env_variables(self):
+        """Dispatch: env-variables uses shallow dict merge with null deletes."""
+        parent = {'A': '1', 'B': '2'}
+        child = {'B': None, 'C': '3'}
+        result = setup_environment._merge_config_key('env-variables', parent, child)
+        assert result == {'A': '1', 'C': '3'}
+
+    def test_merge_config_key_os_env_variables(self):
+        """Dispatch: os-env-variables uses shallow dict merge with null deletes."""
+        parent = {'X': 'val1'}
+        child = {'X': None, 'Y': 'val2'}
+        result = setup_environment._merge_config_key('os-env-variables', parent, child)
+        assert result == {'Y': 'val2'}
+
+    def test_merge_config_key_fallback(self):
+        """Dispatch: unknown key uses replace semantics."""
+        result = setup_environment._merge_config_key('unknown-key', 'old', 'new')
+        assert result == 'new'
+
+    # === _merge_configs with merge_keys parameter ===
+
+    def test_merge_configs_with_merge_keys(self):
+        """Listed keys are merged, unlisted keys are replaced."""
+        parent = {'agents': ['a.md'], 'model': 'old', 'rules': ['r1']}
+        child = {'agents': ['b.md'], 'model': 'new', 'rules': ['r2']}
+        result = setup_environment._merge_configs(
+            parent, child, merge_keys=frozenset({'agents', 'rules'}),
+        )
+        assert result['agents'] == ['a.md', 'b.md']
+        assert result['rules'] == ['r1', 'r2']
+        assert result['model'] == 'new'
+
+    def test_merge_configs_no_merge_keys_backward_compat(self):
+        """Without merge_keys, child replaces parent (backward compatible)."""
+        parent = {'agents': ['a.md']}
+        child = {'agents': ['b.md']}
+        result = setup_environment._merge_configs(parent, child)
+        assert result['agents'] == ['b.md']
+
+    def test_merge_configs_strips_inherit_and_merge_keys(self):
+        """Both inherit and merge-keys are stripped from result."""
+        parent = {'a': 1}
+        child = {'inherit': 'base.yaml', 'merge-keys': ['agents'], 'b': 2}
+        result = setup_environment._merge_configs(parent, child, merge_keys=frozenset({'agents'}))
+        assert 'inherit' not in result
+        assert 'merge-keys' not in result
+        assert result == {'a': 1, 'b': 2}
+
+    def test_merge_configs_key_only_in_child(self):
+        """Merge key present only in child is added (not merged)."""
+        parent = {'model': 'opus'}
+        child = {'agents': ['new.md']}
+        result = setup_environment._merge_configs(
+            parent, child, merge_keys=frozenset({'agents'}),
+        )
+        assert result['agents'] == ['new.md']
+        assert result['model'] == 'opus'
+
+    def test_merge_configs_empty_merge_keys(self):
+        """Empty merge_keys set: all keys use replace semantics."""
+        parent = {'agents': ['a.md']}
+        child = {'agents': ['b.md']}
+        result = setup_environment._merge_configs(parent, child, merge_keys=frozenset())
+        assert result['agents'] == ['b.md']
+
+    # === Validation tests ===
+
+    @patch.object(setup_environment, 'load_config_from_source')
+    def test_validation_invalid_key_in_merge_keys(self, mock_load):
+        """Invalid key in merge-keys raises ValueError."""
+        mock_load.return_value = ({'name': 'Parent'}, 'parent.yaml')
+        config = {'inherit': 'parent.yaml', 'merge-keys': ['model']}
+        with pytest.raises(ValueError, match='Invalid keys in merge-keys'):
+            setup_environment.resolve_config_inheritance(config, 'child.yaml')
+
+    @patch.object(setup_environment, 'load_config_from_source')
+    def test_validation_non_list_merge_keys(self, mock_load):
+        """Non-list merge-keys raises ValueError."""
+        mock_load.return_value = ({'name': 'Parent'}, 'parent.yaml')
+        config = {'inherit': 'parent.yaml', 'merge-keys': 'agents'}
+        with pytest.raises(ValueError, match='must be a list'):
+            setup_environment.resolve_config_inheritance(config, 'child.yaml')
+
+    @patch.object(setup_environment, 'load_config_from_source')
+    def test_validation_non_string_entries(self, mock_load):
+        """Non-string entries in merge-keys list raise ValueError."""
+        mock_load.return_value = ({'name': 'Parent'}, 'parent.yaml')
+        config = {'inherit': 'parent.yaml', 'merge-keys': [123]}
+        with pytest.raises(ValueError, match='must be a string'):
+            setup_environment.resolve_config_inheritance(config, 'child.yaml')
+
+    def test_merge_keys_without_inherit_warns(self, capsys):
+        """merge-keys without inherit emits warning."""
+        config = {'name': 'test', 'merge-keys': ['agents']}
+        result, chain = setup_environment.resolve_config_inheritance(config, 'test.yaml')
+        captured = capsys.readouterr()
+        assert 'has no effect without' in captured.out
+        assert 'merge-keys' not in result
+
+    def test_merge_keys_without_inherit_strips_key(self):
+        """merge-keys is stripped from result when no inherit."""
+        config = {'name': 'test', 'merge-keys': ['agents']}
+        result, _ = setup_environment.resolve_config_inheritance(config, 'test.yaml')
+        assert 'merge-keys' not in result
+        assert result == {'name': 'test'}
+
+    def test_empty_merge_keys_list_valid(self):
+        """Empty merge-keys list is valid (no-op)."""
+        parent = {'agents': ['a.md']}
+        child = {'agents': ['b.md']}
+        result = setup_environment._merge_configs(
+            parent, child, merge_keys=frozenset(),
+        )
+        # Empty frozenset = no merge, so replace
+        assert result['agents'] == ['b.md']
+
+    def test_duplicate_entries_in_merge_keys_deduped(self):
+        """Duplicate entries in merge-keys are handled via frozenset."""
+        parent = {'agents': ['a.md']}
+        child = {'agents': ['b.md']}
+        # frozenset automatically deduplicates
+        result = setup_environment._merge_configs(
+            parent, child,
+            merge_keys=frozenset(['agents', 'agents']),
+        )
+        assert result['agents'] == ['a.md', 'b.md']
+
+
 class TestDeepMergeSettings:
     """Tests for deep_merge_settings function and its helpers."""
 


### PR DESCRIPTION
Add a new top-level YAML directive `merge-keys` that enables selective per-key merge during configuration inheritance, allowing child configs to extend parent values instead of replacing them entirely. Merge strategies are type-aware: string lists use concat with dedup, named object lists use identity-based in-position replacement, hooks merge files with dedup and concatenate events, dependencies merge per-platform, and dict-typed keys use deep merge or shallow RFC 7396 semantics as appropriate. The directive is opt-in, evaluated independently at each inheritance level, validated against MERGEABLE_CONFIG_KEYS (12 eligible keys), and stripped from the final merged output for backward compatibility.