### PR TITLE
Add env loader file generation with CMD batch parity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,12 @@ The setup script requires explicit user confirmation before installing. CLI flag
 
 YAML configs define complete environments: dependencies, agents, MCP servers (auto-permission), slash commands, system prompts (append/replace modes), hooks, global config (`~/.claude.json` via deep merge), and selective inheritance via `merge-keys` directive.
 
+**Env Loader Files:** `generate_env_loader_files()` creates Rustup-style shell scripts containing ONLY `os-env-variables` (not `env-variables`). Per-command files: `~/.claude/{cmd}/env.sh`, `env.fish` (if Fish installed), `env.ps1` (Windows), `env.cmd` (Windows). Global files: `~/.claude/toolbox-env.sh`, `toolbox-env.fish`, `toolbox-env.ps1` (Windows), `toolbox-env.cmd` (Windows). `None`-valued (deletion) vars are excluded. `create_launcher_script()` injects guarded source lines in all 6 launcher variants so commands auto-load env vars.
+
+**Fish Dual-Mechanism:** `set_os_env_variable_unix()` writes `set -gx` to `config.fish` (durable persistence) AND calls `set -Ux` via subprocess (instant propagation to all running Fish sessions). For deletions, `set -Ue` removes the universal variable. The `config.fish` write is authoritative; `set -Ux` is complementary.
+
+**WM_SETTINGCHANGE Broadcast:** `_broadcast_wm_settingchange()` in `setup_environment.py` uses the dummy `setx CLAUDE_CODE_TOOLBOX_TEMP temp` + `reg delete` pattern to trigger `WM_SETTINGCHANGE`. Called from `add_directory_to_windows_path()`, `cleanup_temp_paths_from_registry()`, `set_os_env_variable_windows()` (after `reg delete` for deletions), and `set_all_os_env_variables()` (batch broadcast after all operations). `install_claude.py` has its own independent copy at `ensure_local_bin_in_path_windows()` (standalone script policy).
+
 ### Global Config (`global-config`)
 
 Writes to `~/.claude.json`. Merge: `deep_merge_settings()` with `array_union_keys=set()` (arrays replaced, not unioned -- differs from `user-settings` which unions `permissions.allow/deny/ask`). Only `oauthAccount` blocked from non-null values (`GLOBAL_CONFIG_EXCLUDED_KEYS`); `null` allowed for clearing OAuth. `install_claude.py`'s `update_install_method_config()` also writes to `~/.claude.json` via the same pattern. Both `write_user_settings()` and `write_global_config()` delegate to `_write_merged_json()`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,23 @@ Step comments/print statements in `main()` MUST use continuous whole integers (n
 | Linux    | `'linux'`      | `'Linux'`           | `'posix'` |
 | macOS    | `'darwin'`     | `'Darwin'`          | `'posix'` |
 
+### Agent Development Pitfalls
+
+Recurring patterns that cause CI failures. Every item below has caused at least one real CI failure. Read this section before modifying `setup_environment.py` or its tests.
+
+**Cross-platform test verification:** Local `uv run pytest` skips tests targeting other platforms (`@pytest.mark.skipif`). Developing on Windows means Unix-only tests are SKIPPED locally but WILL RUN in CI on Linux/macOS (and vice versa). A 100% local pass rate does NOT guarantee CI success. Before committing, review skipped tests to verify they would pass on their target platform. NEVER report a clean test run as definitive when platform-skipped tests exist.
+
+**Tests must match implementation:** Every test assertion MUST correspond to actually implemented behavior. Do NOT write tests that assert behavior which has not been coded yet. If a test is for a new feature, implement the feature BEFORE or SIMULTANEOUSLY with the test. Tests that pass only because they are platform-skipped on the development machine will fail in CI on the target platform. This is the single most common cause of CI failures in this project.
+
+**Parallel mock side effects:** Tests calling functions that use `execute_parallel()` (which uses `ThreadPoolExecutor`) MUST NOT use `mock.side_effect = [list]` with distinct values per item. The list is consumed in thread-scheduling order, not submission order. This causes non-deterministic failures depending on OS thread scheduling. Use either:
+
+- `@patch.dict(os.environ, {'CLAUDE_CODE_TOOLBOX_SEQUENTIAL_MODE': '1'})` to force sequential execution in tests that verify logic (not parallelism)
+- Function-based `side_effect` that maps inputs to deterministic outputs for tests that must run in parallel
+
+**Shell escape sequence levels:** Modifying shell template strings (especially ANSI escape sequences like `\\\\033`) requires tracking three escaping layers: Python source string, generated shell script file, and final shell execution. A change that appears correct in Python source may produce wrong output in the generated `.sh` file. After modifying escape sequences, always verify the generated file content matches expectations.
+
+**Multi-phase implementation counting:** When implementing multi-phase changes that introduce intermediate test failures, ALL failures MUST be explicitly counted including BOTH unit tests AND E2E tests. Agents have historically undercounted by omitting E2E failures. Each phase validation MUST confirm the exact failure count matches expectations before proceeding.
+
 ## Script Dependencies
 
 Python 3.12 required. **uv** installed by bootstrap scripts. Dependencies: PyYAML, Pydantic. Dev: pytest, ruff, pre-commit.

--- a/docs/cross-shell-launcher-architecture.md
+++ b/docs/cross-shell-launcher-architecture.md
@@ -442,7 +442,7 @@ After this step, `p` holds the entire prompt file as a single string, with `\r` 
 
 - PowerShell by default parses and expands `$`, `$(...)`, quotes, and backticks. When you try to embed a Bash command substitution inside a PowerShell string, you create two different quoting layers that both want to process `$` and quotes. That is why `--%` was necessary, it stops PowerShell from interpreting the rest of the line and lets Bash be the only parser. ([Microsoft Learn][ps3])
 
-- The `claude.cmd` or `claude.ps1` shims on Windows are not friendly to very long, multi-line arguments. The legacy `cmd.exe` command line length limit and argument handling make this especially brittle, which is why you saw errors like "Too long command line" or spurious option parsing. Launching the real Bash first, then `exec`-ing the CLI from Bash, avoids those layers and their limitations. Microsoft documents the stop-parsing token for exactly these scenarios, where you must pass complex arguments to a native tool without PowerShell interference. ([Microsoft Learn][ps3])
+- The `claude.cmd` or `claude.ps1` shims on Windows are not friendly to very long, multi-line arguments. The `cmd.exe` command line length limit and argument handling make this especially brittle, which is why you saw errors like "Too long command line" or spurious option parsing. Launching the real Bash first, then `exec`-ing the CLI from Bash, avoids those layers and their limitations. Microsoft documents the stop-parsing token for exactly these scenarios, where you must pass complex arguments to a native tool without PowerShell interference. ([Microsoft Learn][ps3])
 
 ### Micro-timeline of what happens (PowerShell)
 

--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -665,6 +665,10 @@ os-env-variables:
   OLD_UNUSED_VAR: null  # Deletes this variable
 ```
 
+- **Current session guidance (Linux/macOS):** When variables are deleted via `null`, the setup script outputs shell-specific `unset` commands so the user can remove those variables from the running session without opening a new terminal:
+  - **Bash/Zsh:** `unset VARNAME` for each deleted variable
+  - **Fish** (when installed): `set -e VARNAME` for each deleted variable
+
 #### Environment Variable Loading
 
 The setup script provides two distinct mechanisms for environment variables, each serving a different scope:

--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -665,6 +665,84 @@ os-env-variables:
   OLD_UNUSED_VAR: null  # Deletes this variable
 ```
 
+#### Environment Variable Loading
+
+The setup script provides two distinct mechanisms for environment variables, each serving a different scope:
+
+| YAML Key           | Scope                | Storage                           | Available In                         |
+|--------------------|----------------------|-----------------------------------|--------------------------------------|
+| `env-variables`    | Claude Code internal | `config.json` `env` key (profile) | Claude Code sessions only            |
+| `os-env-variables` | OS-level persistent  | Shell profiles + Windows registry | All processes (terminals, programs)  |
+
+##### Env Loader Files
+
+When `os-env-variables` are configured, the setup generates Rustup-style env loader files that can be sourced to load the variables into the current shell session. These files contain **only** `os-env-variables` (not `env-variables`, which are handled by Claude Code's `config.json`).
+
+**Per-command files** (generated when `command-names` is specified):
+
+| File                         | Shell      | Generated When |
+|------------------------------|------------|----------------|
+| `~/.claude/{cmd}/env.sh`     | Bash/Zsh   | Always         |
+| `~/.claude/{cmd}/env.fish`   | Fish       | Fish installed |
+| `~/.claude/{cmd}/env.ps1`    | PowerShell | Windows only   |
+| `~/.claude/{cmd}/env.cmd`    | CMD batch  | Windows only   |
+
+**Global convenience files** (always generated when `os-env-variables` are non-empty):
+
+| File                          | Shell      | Generated When |
+|-------------------------------|------------|----------------|
+| `~/.claude/toolbox-env.sh`    | Bash/Zsh   | Always         |
+| `~/.claude/toolbox-env.fish`  | Fish       | Fish installed |
+| `~/.claude/toolbox-env.ps1`   | PowerShell | Windows only   |
+| `~/.claude/toolbox-env.cmd`   | CMD batch  | Windows only   |
+
+Variables set to `null` (deletions) are excluded from loader files.
+
+##### Automatic Loading via Launchers
+
+When `command-names` is specified, the generated launcher scripts automatically source the per-command env loader file before starting Claude Code. No manual action is required -- running the command (for example, `claude-python`) loads all OS environment variables.
+
+The source line is guarded by a file-existence check, so launchers work normally even when no `os-env-variables` are configured.
+
+##### Manual Sourcing for Bare `claude`
+
+Users who run bare `claude` (without a command-name launcher) can manually source the global loader to apply OS environment variables to their current shell session:
+
+**Bash/Zsh:**
+
+```bash
+source ~/.claude/toolbox-env.sh
+```
+
+**Fish:**
+
+```fish
+source ~/.claude/toolbox-env.fish
+```
+
+**PowerShell (Windows):**
+
+```powershell
+. ~/.claude/toolbox-env.ps1
+```
+
+**CMD (Windows):**
+
+```batch
+%USERPROFILE%\.claude\toolbox-env.cmd
+```
+
+Alternatively, open a new terminal -- shell profiles are updated during setup and will load the variables automatically.
+
+##### Fish Dual-Mechanism
+
+On systems with Fish shell installed, the setup uses two complementary mechanisms for OS environment variables:
+
+- **`set -gx` in `config.fish`**: Durable persistence. Variables are loaded when Fish starts. This is the primary mechanism.
+- **`set -Ux` (Universal Exported)**: Instant propagation. Variables are immediately visible in all running Fish sessions without requiring `source` or a new terminal. For deletions, `set -Ue` removes the universal variable.
+
+The `config.fish` write is always the authoritative source. The `set -Ux` call is a complementary enhancement that provides immediate availability.
+
 ### User Interface
 
 #### `command-defaults`
@@ -1281,10 +1359,10 @@ Here is a conceptual overview of what the setup script does when you run it with
 3. **Download custom files** -- Processes `files-to-download` entries.
 4. **Install Node.js** -- If `install-nodejs: true` is set in the config.
 5. **Install dependencies** -- Runs platform-specific dependency commands.
-6. **Set OS environment variables** -- Writes persistent environment variables from `os-env-variables`.
-7. **Process agents** -- Downloads agent markdown files to `~/.claude/agents/`.
+6. **Set OS environment variables** -- Writes persistent environment variables from `os-env-variables`. Generates env loader files (`env.sh`, `env.fish`, `env.ps1`, `env.cmd`) for launcher auto-sourcing.
+7. **Process agents** -- Downloads agent Markdown files to `~/.claude/agents/`.
 8. **Process slash commands** -- Downloads command files to `~/.claude/commands/`.
-9. **Process rules** -- Downloads rule markdown files to `~/.claude/rules/`.
+9. **Process rules** -- Downloads rule Markdown files to `~/.claude/rules/`.
 10. **Process skills** -- Downloads skill file sets to `~/.claude/skills/{name}/`.
 11. **Process system prompt** -- Downloads the prompt file if configured.
 12. **Configure MCP servers** -- Sets up MCP servers with scope-based routing.

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -1907,6 +1907,24 @@ def parse_mcp_command(command_str: str) -> dict[str, Any]:
 _WIN_PATH_VALUE_MAX_LENGTH = 32762
 
 
+def _broadcast_wm_settingchange() -> None:
+    """Broadcast WM_SETTINGCHANGE to notify GUI applications of environment changes.
+
+    Uses a dummy setx+reg-delete trick to trigger the broadcast.
+    Only affects new windows opened from Explorer; does NOT update
+    existing CLI terminal sessions (cmd, PowerShell, Git Bash).
+    """
+    if sys.platform == 'win32':
+        subprocess.run(
+            ['setx', 'CLAUDE_CODE_TOOLBOX_TEMP', 'temp'],
+            capture_output=True, check=False,
+        )
+        subprocess.run(
+            ['reg', 'delete', r'HKCU\Environment', '/v', 'CLAUDE_CODE_TOOLBOX_TEMP', '/f'],
+            capture_output=True, check=False,
+        )
+
+
 def add_directory_to_windows_path(directory: str) -> tuple[bool, str]:
     """Add a directory to the Windows user PATH environment variable.
 
@@ -2032,15 +2050,8 @@ def add_directory_to_windows_path(directory: str) -> tuple[bool, str]:
                     f'Restart your terminal to apply changes.',
                 )
 
-            # Broadcast WM_SETTINGCHANGE to notify other processes
-            # This is done via setx which broadcasts the change
-            # We use a dummy variable to trigger the broadcast without modifying anything
-            subprocess.run(['setx', 'CLAUDE_CODE_TOOLBOX_TEMP', 'temp'], capture_output=True, check=False)
-            subprocess.run(
-                ['reg', 'delete', r'HKCU\Environment', '/v', 'CLAUDE_CODE_TOOLBOX_TEMP', '/f'],
-                capture_output=True,
-                check=False,
-            )
+            # Broadcast WM_SETTINGCHANGE to notify GUI applications
+            _broadcast_wm_settingchange()
 
             return True, f'Successfully added to PATH: {normalized_dir}'
 
@@ -2148,13 +2159,8 @@ def cleanup_temp_paths_from_registry() -> tuple[int, list[str]]:
                 new_path = ';'.join(clean_components)
                 winreg.SetValueEx(reg_key, 'PATH', 0, winreg.REG_EXPAND_SZ, new_path)
 
-                # Broadcast WM_SETTINGCHANGE to notify other processes
-                subprocess.run(['setx', 'CLAUDE_CODE_TOOLBOX_TEMP', 'temp'], capture_output=True, check=False)
-                subprocess.run(
-                    ['reg', 'delete', r'HKCU\Environment', '/v', 'CLAUDE_CODE_TOOLBOX_TEMP', '/f'],
-                    capture_output=True,
-                    check=False,
-                )
+                # Broadcast WM_SETTINGCHANGE to notify GUI applications
+                _broadcast_wm_settingchange()
 
             winreg.CloseKey(reg_key)
             return (len(removed_paths), removed_paths)
@@ -4591,6 +4597,8 @@ def set_os_env_variable_windows(name: str, value: str | None) -> bool:
                     warning(f'Could not delete environment variable {name}: {result.stderr}')
                 else:
                     success = True
+                    # reg delete does not broadcast WM_SETTINGCHANGE (unlike setx)
+                    _broadcast_wm_settingchange()
             else:
                 # Set the variable using setx
                 result = subprocess.run(
@@ -4637,6 +4645,24 @@ def set_os_env_variable_unix(name: str, value: str | None) -> bool:
                 # Set the variable
                 if not add_export_to_file(config_file, name, value):
                     all_success = False
+
+        # Fish universal variables: propagate immediately to all running Fish instances
+        # config.fish (set -gx) remains the durable persistence mechanism;
+        # set -Ux provides instant propagation to open Fish sessions
+        if shutil.which('fish'):
+            try:
+                if value is None:
+                    subprocess.run(
+                        ['fish', '-c', f'set -Ue {name}'],
+                        capture_output=True, check=False, timeout=5,
+                    )
+                else:
+                    subprocess.run(
+                        ['fish', '-c', f'set -Ux {name} "{value}"'],
+                        capture_output=True, check=False, timeout=5,
+                    )
+            except (OSError, subprocess.TimeoutExpired):
+                pass  # Non-critical: config.fish write is the durable mechanism
 
     return all_success
 
@@ -4717,15 +4743,140 @@ def set_all_os_env_variables(env_vars: dict[str, str | None]) -> bool:
     if failed_count > 0:
         warning(f'Failed to configure {failed_count} environment variable(s)')
 
-    # Provide reload instructions for Unix systems
-    if sys.platform != 'win32' and (set_count > 0 or delete_count > 0):
-        info('Note: Open a new terminal to apply changes')
-        # Provide explicit unset instructions for deleted variables
-        if deleted_names:
-            unset_cmds = ' '.join(f'unset {n};' for n in deleted_names)
-            info(f'To remove deleted variables from current shell: {unset_cmds}')
+    # Broadcast WM_SETTINGCHANGE after all env var operations (Windows)
+    if sys.platform == 'win32' and (set_count > 0 or delete_count > 0):
+        _broadcast_wm_settingchange()
 
     return failed_count == 0
+
+
+def generate_env_loader_files(
+    os_env_vars: dict[str, str | None],
+    command_names: list[str] | None,
+    config_base_dir: Path | None,
+) -> dict[str, Path]:
+    """Generate shell-specific env loader files for OS environment variables.
+
+    Creates Rustup-pattern env files that can be sourced by launchers
+    and users. Contains ONLY os-env-variables (NOT env-variables,
+    which are handled by Claude Code's config.json env key).
+
+    Per-command files (when command_names provided):
+        ~/.claude/{cmd}/env.sh      (Bash/Zsh)
+        ~/.claude/{cmd}/env.fish    (Fish, if Fish installed)
+        ~/.claude/{cmd}/env.ps1     (PowerShell, Windows only)
+        ~/.claude/{cmd}/env.cmd     (CMD batch, Windows only)
+
+    Global convenience files (always generated when os_env_vars non-empty):
+        ~/.claude/toolbox-env.sh
+        ~/.claude/toolbox-env.fish  (if Fish installed)
+        ~/.claude/toolbox-env.ps1   (PowerShell, Windows only)
+        ~/.claude/toolbox-env.cmd   (CMD batch, Windows only)
+
+    Args:
+        os_env_vars: Dict of env var names to values. None values = deletions
+                     (excluded from loader files since the var should not exist).
+        command_names: List of command names, or None for non-command configs.
+        config_base_dir: Base dir for per-command files (e.g., ~/.claude/{cmd}/).
+
+    Returns:
+        Dict mapping file type to generated Path (e.g., {"sh": Path(...)}).
+    """
+    # Filter to only non-None values (deletions are excluded from loader files)
+    active_vars = {k: v for k, v in os_env_vars.items() if v is not None}
+
+    if not active_vars:
+        return {}
+
+    generated: dict[str, Path] = {}
+    home = get_real_user_home()
+    claude_dir = home / '.claude'
+
+    # Build file content for each shell type
+    sh_header = '# Auto-generated by claude-code-toolbox -- do not edit manually\n'
+    sh_header += '# Re-run setup to update. Source this file to load OS env vars.\n'
+
+    fish_header = '# Auto-generated by claude-code-toolbox -- do not edit manually\n'
+    fish_header += '# Re-run setup to update. Source this file to load OS env vars.\n'
+
+    ps1_header = '# Auto-generated by claude-code-toolbox -- do not edit manually\n'
+    ps1_header += '# Re-run setup to update. Dot-source this file to load OS env vars.\n'
+
+    # Bash/Zsh content
+    sh_lines = [sh_header]
+    for name, value in active_vars.items():
+        # Escape special characters for double-quoted bash strings
+        escaped = value.replace('\\', '\\\\').replace('"', '\\"').replace('$', '\\$').replace('`', '\\`')
+        sh_lines.append(f'export {name}="{escaped}"')
+    sh_content = '\n'.join(sh_lines) + '\n'
+
+    # Fish content
+    fish_lines = [fish_header]
+    for name, value in active_vars.items():
+        # Escape special characters for double-quoted fish strings
+        escaped = value.replace('\\', '\\\\').replace('"', '\\"')
+        fish_lines.append(f'set -gx {name} "{escaped}"')
+    fish_content = '\n'.join(fish_lines) + '\n'
+
+    # PowerShell content
+    ps1_lines = [ps1_header]
+    for name, value in active_vars.items():
+        # Single-quote for literal PowerShell strings; double internal single-quotes
+        escaped = value.replace("'", "''")
+        ps1_lines.append(f"$env:{name} = '{escaped}'")
+    ps1_content = '\n'.join(ps1_lines) + '\n'
+
+    # CMD batch content (Windows only)
+    cmd_header = '@echo off\n'
+    cmd_header += 'REM Auto-generated by claude-code-toolbox -- do not edit manually\n'
+    cmd_header += 'REM Re-run setup to update. Call this file to load OS env vars.\n'
+
+    cmd_lines = [cmd_header]
+    for name, value in active_vars.items():
+        # Double percent signs for batch files (% -> %%)
+        escaped = value.replace('%', '%%')
+        cmd_lines.append(f'SET "{name}={escaped}"')
+    cmd_content = '\n'.join(cmd_lines) + '\n'
+
+    has_fish = bool(shutil.which('fish'))
+
+    def _write_loader(
+        directory: Path,
+        sh_name: str,
+        fish_name: str | None,
+        ps1_name: str | None,
+        cmd_name: str | None,
+    ) -> None:
+        """Write loader files into the given directory."""
+        directory.mkdir(parents=True, exist_ok=True)
+
+        sh_path = directory / sh_name
+        sh_path.write_text(sh_content, newline='\n')
+        generated[f'sh:{sh_path}'] = sh_path
+
+        if fish_name and has_fish:
+            fish_path = directory / fish_name
+            fish_path.write_text(fish_content, newline='\n')
+            generated[f'fish:{fish_path}'] = fish_path
+
+        if ps1_name and sys.platform == 'win32':
+            ps1_path = directory / ps1_name
+            ps1_path.write_text(ps1_content)
+            generated[f'ps1:{ps1_path}'] = ps1_path
+
+        if cmd_name and sys.platform == 'win32':
+            cmd_path = directory / cmd_name
+            cmd_path.write_text(cmd_content)
+            generated[f'cmd:{cmd_path}'] = cmd_path
+
+    # Per-command files
+    if command_names and config_base_dir:
+        _write_loader(config_base_dir, 'env.sh', 'env.fish', 'env.ps1', 'env.cmd')
+
+    # Global convenience files (always generated)
+    _write_loader(claude_dir, 'toolbox-env.sh', 'toolbox-env.fish', 'toolbox-env.ps1', 'toolbox-env.cmd')
+
+    return generated
 
 
 # --- Standalone Node.js installation functions ---
@@ -7373,6 +7524,10 @@ def create_launcher_script(
 
 $claudeUserDir = Join-Path $env:USERPROFILE ".claude"
 
+# Source OS-level environment variables (if configured)
+$envFile = Join-Path (Join-Path $claudeUserDir "{command_name}") "env.ps1"
+if (Test-Path $envFile) {{ . $envFile }}
+
 Write-Host "Starting Claude Code with {command_name} configuration..." -ForegroundColor Green
 
 # Find Git Bash (required for Claude Code on Windows)
@@ -7404,6 +7559,10 @@ if ($args.Count -gt 0) {{
 REM Claude Code Environment Launcher for CMD
 REM This script starts Claude Code with the configured environment
 
+REM Source OS-level environment variables (if configured)
+set "ENV_FILE=%USERPROFILE%\\.claude\\{command_name}\\env.cmd"
+if exist "%ENV_FILE%" call "%ENV_FILE%"
+
 echo Starting Claude Code with {command_name} configuration...
 
 REM Call shared script
@@ -7432,6 +7591,10 @@ set -euo pipefail
 
 # Set isolated environment directory
 export CLAUDE_CONFIG_DIR="$HOME/.claude/{command_name}"
+
+# Source OS-level environment variables (if configured)
+ENV_FILE="$HOME/.claude/{command_name}/env.sh"
+[ -f "$ENV_FILE" ] && . "$ENV_FILE"
 
 # Get Windows path for settings
 SETTINGS_WIN="$(cygpath -m "$HOME/.claude/{command_name}/config.json" 2>/dev/null ||
@@ -7596,6 +7759,10 @@ set -euo pipefail
 # Set isolated environment directory
 export CLAUDE_CONFIG_DIR="$HOME/.claude/{command_name}"
 
+# Source OS-level environment variables (if configured)
+ENV_FILE="$HOME/.claude/{command_name}/env.sh"
+[ -f "$ENV_FILE" ] && . "$ENV_FILE"
+
 # Get Windows path for settings
 SETTINGS_WIN="$(cygpath -m "$HOME/.claude/{command_name}/config.json" 2>/dev/null ||
   echo "$HOME/.claude/{command_name}/config.json")"
@@ -7627,6 +7794,10 @@ fi
 
 # Set isolated environment directory
 export CLAUDE_CONFIG_DIR="$HOME/.claude/{command_name}"
+
+# Source OS-level environment variables (if configured)
+ENV_FILE="$HOME/.claude/{command_name}/env.sh"
+[ -f "$ENV_FILE" ] && . "$ENV_FILE"
 
 SETTINGS_PATH="$HOME/.claude/{command_name}/config.json"
 PROMPT_PATH="$HOME/.claude/{command_name}/prompts/{system_prompt_file}"
@@ -7797,6 +7968,10 @@ fi
 # Set isolated environment directory
 export CLAUDE_CONFIG_DIR="$HOME/.claude/{command_name}"
 
+# Source OS-level environment variables (if configured)
+ENV_FILE="$HOME/.claude/{command_name}/env.sh"
+[ -f "$ENV_FILE" ] && . "$ENV_FILE"
+
 SETTINGS_PATH="$HOME/.claude/{command_name}/config.json"
 
 # MCP configuration for profile-scoped servers
@@ -7882,6 +8057,9 @@ def register_global_command(
             batch_path = local_bin / f'{command_name}.cmd'
             batch_content = f'''@echo off
 REM Global {command_name} command for CMD
+REM Source OS-level environment variables (if configured)
+set "ENV_FILE=%USERPROFILE%\\.claude\\{command_name}\\env.cmd"
+if exist "%ENV_FILE%" call "%ENV_FILE%"
 set "BASH_EXE=C:\\Program Files\\Git\\bin\\bash.exe"
 if not exist "%BASH_EXE%" set "BASH_EXE=C:\\Program Files (x86)\\Git\\bin\\bash.exe"
 set "SCRIPT_WIN={cmd_script_path}"
@@ -7921,6 +8099,9 @@ exec "{bash_script_path}" "$@"
                     alias_batch_path = local_bin / f'{alias_name}.cmd'
                     alias_batch_content = f'''@echo off
 REM Global {alias_name} command for CMD (alias for {command_name})
+REM Source OS-level environment variables (if configured)
+set "ENV_FILE=%USERPROFILE%\\.claude\\{command_name}\\env.cmd"
+if exist "%ENV_FILE%" call "%ENV_FILE%"
 set "BASH_EXE=C:\\Program Files\\Git\\bin\\bash.exe"
 if not exist "%BASH_EXE%" set "BASH_EXE=C:\\Program Files (x86)\\Git\\bin\\bash.exe"
 set "SCRIPT_WIN={cmd_script_path}"
@@ -7959,7 +8140,6 @@ exec "{bash_script_path}" "$@"
                     info(path_message)
                 else:
                     success(path_message)
-                    info('You may need to restart your terminal for PATH changes to take effect')
             else:
                 warning(f'Failed to add directory to PATH: {path_message}')
                 info('')
@@ -8553,6 +8733,15 @@ def main() -> None:
         else:
             info('No OS environment variables to configure')
 
+        # Generate env loader files for OS environment variables
+        generated_env_files: dict[str, Path] = {}
+        if os_env_variables:
+            generated_env_files = generate_env_loader_files(
+                os_env_variables, command_names, artifact_base_dir if command_names else None,
+            )
+            if generated_env_files:
+                success(f'Generated {len(generated_env_files)} env loader file(s)')
+
         # Step 7: Process agents
         print()
         print(f'{Colors.CYAN}Step 7: Processing agents...{Colors.NC}')
@@ -8883,6 +9072,44 @@ def main() -> None:
                 print(f'   * Global command: {primary_command_name}')
         else:
             print('   * Use "claude" to start Claude Code with configured environment')
+
+        # Environment guidance based on what was configured
+        if os_env_variables and generated_env_files:
+            active_env_count = sum(1 for v in os_env_variables.values() if v is not None)
+            if active_env_count > 0:
+                if command_names:
+                    print(f'   * Environment: Commands auto-load {active_env_count} OS env var(s)')
+                    home = get_real_user_home()
+                    if sys.platform == 'win32':
+                        ps1_loader = home / '.claude' / 'toolbox-env.ps1'
+                        cmd_loader = home / '.claude' / 'toolbox-env.cmd'
+                        print(f'     For bare "claude" (PowerShell): . {ps1_loader}')
+                        print(f'     For bare "claude" (CMD): {cmd_loader}')
+                    else:
+                        shell_name = os.environ.get('SHELL', '')
+                        if 'fish' in shell_name:
+                            fish_loader = home / '.claude' / 'toolbox-env.fish'
+                            print(f'     For bare "claude": source {fish_loader}')
+                        else:
+                            sh_loader = home / '.claude' / 'toolbox-env.sh'
+                            print(f'     For bare "claude": source {sh_loader}')
+                else:
+                    print(f'   * Environment: {active_env_count} OS env var(s) configured')
+                    home = get_real_user_home()
+                    if sys.platform == 'win32':
+                        ps1_loader = home / '.claude' / 'toolbox-env.ps1'
+                        cmd_loader = home / '.claude' / 'toolbox-env.cmd'
+                        print(f'     To apply now (PowerShell): . {ps1_loader}')
+                        print(f'     To apply now (CMD): {cmd_loader}')
+                    else:
+                        shell_name = os.environ.get('SHELL', '')
+                        if 'fish' in shell_name:
+                            fish_loader = home / '.claude' / 'toolbox-env.fish'
+                            print(f'     To apply now: source {fish_loader}')
+                        else:
+                            sh_loader = home / '.claude' / 'toolbox-env.sh'
+                            print(f'     To apply now: source {sh_loader}')
+                    print('     Or open a new terminal for automatic loading')
 
         print()
         print(f'{Colors.YELLOW}Available Commands (after starting Claude):{Colors.NC}')

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -4743,6 +4743,16 @@ def set_all_os_env_variables(env_vars: dict[str, str | None]) -> bool:
     if failed_count > 0:
         warning(f'Failed to configure {failed_count} environment variable(s)')
 
+    # Print unset guidance for deleted variables on Unix
+    if sys.platform != 'win32' and deleted_names:
+        info('To remove deleted variable(s) from your current shell session, run:')
+        for var_name in deleted_names:
+            print(f'  unset {var_name}')
+        if shutil.which('fish'):
+            info('For Fish shell:')
+            for var_name in deleted_names:
+                print(f'  set -e {var_name}')
+
     # Broadcast WM_SETTINGCHANGE after all env var operations (Windows)
     if sys.platform == 'win32' and (set_count > 0 or delete_count > 0):
         _broadcast_wm_settingchange()

--- a/tests/e2e/test_env_loader_files.py
+++ b/tests/e2e/test_env_loader_files.py
@@ -1,0 +1,256 @@
+"""E2E tests for env loader file generation and launcher env sourcing.
+
+These tests validate that generate_env_loader_files() creates correct
+shell-specific loader files and that create_launcher_script() injects
+guarded source lines for loading OS-level environment variables.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.setup_environment import create_launcher_script
+from scripts.setup_environment import generate_env_loader_files
+from tests.e2e.validators import validate_env_loader_files
+from tests.e2e.validators import validate_launcher_env_sourcing
+
+
+class TestEnvLoaderFileGeneration:
+    """E2E tests for generate_env_loader_files() output."""
+
+    def test_global_env_loader_files_exist(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        golden_config: dict[str, Any],
+    ) -> None:
+        """Verify global convenience files are generated for os-env-variables.
+
+        Checks:
+        - toolbox-env.sh exists in ~/.claude/
+        - toolbox-env.ps1 exists in ~/.claude/ (Windows only)
+        - Content contains correct export syntax
+        - Deletion variables (None values) are excluded
+        """
+        paths = e2e_isolated_home
+        os_env_vars = golden_config.get('os-env-variables', {})
+        if not os_env_vars:
+            pytest.skip('No os-env-variables in golden config')
+
+        generate_env_loader_files(os_env_vars, None, None)
+
+        errors = validate_env_loader_files(
+            paths['claude_dir'], os_env_vars, command_name=None,
+        )
+        assert not errors, 'Global env loader validation failed:\n' + '\n'.join(errors)
+
+    def test_per_command_env_loader_files_exist(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        golden_config: dict[str, Any],
+    ) -> None:
+        """Verify per-command env loader files are generated alongside global files.
+
+        Checks:
+        - env.sh exists in ~/.claude/{cmd}/
+        - env.ps1 exists in ~/.claude/{cmd}/ (Windows only)
+        - Global files are also generated
+        """
+        paths = e2e_isolated_home
+        os_env_vars = golden_config.get('os-env-variables', {})
+        cmd_names = golden_config.get('command-names', [])
+        if not os_env_vars or not cmd_names:
+            pytest.skip('No os-env-variables or command-names in golden config')
+
+        cmd = cmd_names[0]
+        cmd_dir = paths['claude_dir'] / cmd
+        cmd_dir.mkdir(parents=True, exist_ok=True)
+
+        generate_env_loader_files(os_env_vars, cmd_names, cmd_dir)
+
+        errors = validate_env_loader_files(
+            paths['claude_dir'], os_env_vars, command_name=cmd,
+        )
+        assert not errors, 'Per-command env loader validation failed:\n' + '\n'.join(errors)
+
+    def test_no_files_when_all_deletions(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """Verify no env loader files are generated when all vars are deletions."""
+        paths = e2e_isolated_home
+        all_deletions: dict[str, str | None] = {'DEL_A': None, 'DEL_B': None}
+
+        result = generate_env_loader_files(all_deletions, None, None)
+
+        assert result == {}, 'Expected empty result for all-deletion vars'
+        global_sh = paths['claude_dir'] / 'toolbox-env.sh'
+        assert not global_sh.exists(), 'toolbox-env.sh should not exist for all-deletion vars'
+
+    def test_deletion_vars_excluded_from_content(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """Verify deletion vars (None values) do not appear in loader files."""
+        paths = e2e_isolated_home
+        mixed_vars: dict[str, str | None] = {
+            'KEEP_VAR': 'keep_value',
+            'DELETE_VAR': None,
+        }
+
+        generate_env_loader_files(mixed_vars, None, None)
+
+        errors = validate_env_loader_files(
+            paths['claude_dir'], mixed_vars, command_name=None,
+        )
+        assert not errors, 'Mixed vars validation failed:\n' + '\n'.join(errors)
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    def test_cmd_env_loader_files_on_windows(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        golden_config: dict[str, Any],
+    ) -> None:
+        """Verify env.cmd and toolbox-env.cmd generated on Windows."""
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+        cmd_names = golden_config.get('command-names', [])
+        os_env_vars = golden_config.get('os-env-variables', {})
+        if not os_env_vars:
+            pytest.skip('No os-env-variables in golden config')
+        if not cmd_names:
+            pytest.skip('No command-names in golden config')
+
+        cmd = cmd_names[0]
+        cmd_dir = claude_dir / cmd
+        cmd_dir.mkdir(parents=True, exist_ok=True)
+
+        generate_env_loader_files(os_env_vars, cmd_names, cmd_dir)
+
+        errors = validate_env_loader_files(claude_dir, os_env_vars, cmd)
+        cmd_errors = [e for e in errors if 'cmd' in e.lower()]
+        assert not cmd_errors, 'CMD env loader validation failed:\n' + '\n'.join(cmd_errors)
+
+
+class TestLauncherEnvSourcing:
+    """E2E tests for launcher script env loader integration."""
+
+    @pytest.mark.skipif(sys.platform == 'win32', reason='Unix-only test')
+    def test_unix_launcher_contains_env_source_guard(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        golden_config: dict[str, Any],
+    ) -> None:
+        """Verify Unix launch.sh contains guarded source for env.sh.
+
+        Checks:
+        - File-existence guard ([ -f ... ]) is present
+        - Reference to env.sh is present
+        """
+        paths = e2e_isolated_home
+        cmd = golden_config['command-names'][0]
+        claude_dir = paths['claude_dir']
+
+        launcher_result = create_launcher_script(
+            config_base_dir=claude_dir,
+            command_name=cmd,
+            system_prompt_file=None,
+            mode='replace',
+            has_profile_mcp_servers=False,
+        )
+        launcher_path = launcher_result[0] if launcher_result else None
+        assert launcher_path is not None, 'create_launcher_script returned None'
+
+        errors = validate_launcher_env_sourcing(launcher_path)
+        assert not errors, 'Unix launcher env sourcing validation failed:\n' + '\n'.join(errors)
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    def test_windows_ps1_launcher_contains_env_source_guard(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        golden_config: dict[str, Any],
+    ) -> None:
+        """Verify Windows start.ps1 contains guarded dot-source for env.ps1.
+
+        Checks:
+        - Test-Path guard is present
+        - Reference to env.ps1 is present
+        """
+        paths = e2e_isolated_home
+        cmd = golden_config['command-names'][0]
+        claude_dir = paths['claude_dir']
+
+        create_launcher_script(
+            config_base_dir=claude_dir,
+            command_name=cmd,
+            system_prompt_file=None,
+            mode='replace',
+            has_profile_mcp_servers=False,
+        )
+
+        # Find the PS1 wrapper
+        ps1_path = claude_dir / 'start.ps1'
+        if not ps1_path.exists():
+            # Try alternate location
+            ps1_path = paths['local_bin'] / f'{cmd}.ps1'
+
+        if ps1_path.exists():
+            errors = validate_launcher_env_sourcing(ps1_path)
+            assert not errors, 'Windows PS1 launcher env sourcing failed:\n' + '\n'.join(errors)
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    def test_windows_bash_launcher_contains_env_source_guard(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        golden_config: dict[str, Any],
+    ) -> None:
+        """Verify Windows launch.sh (shared POSIX) contains env.sh source guard."""
+        paths = e2e_isolated_home
+        cmd = golden_config['command-names'][0]
+        claude_dir = paths['claude_dir']
+
+        launcher_result = create_launcher_script(
+            config_base_dir=claude_dir,
+            command_name=cmd,
+            system_prompt_file=None,
+            mode='replace',
+            has_profile_mcp_servers=False,
+        )
+        launcher_path = launcher_result[0] if launcher_result else None
+        assert launcher_path is not None, 'create_launcher_script returned None'
+
+        errors = validate_launcher_env_sourcing(launcher_path)
+        assert not errors, 'Windows bash launcher env sourcing failed:\n' + '\n'.join(errors)
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    def test_windows_cmd_launcher_contains_env_source_guard(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        golden_config: dict[str, Any],
+    ) -> None:
+        """Verify Windows start.cmd contains guarded call for env.cmd.
+
+        Checks:
+        - if exist guard is present
+        - Reference to env.cmd is present
+        - call command is present
+        """
+        paths = e2e_isolated_home
+        cmd = golden_config['command-names'][0]
+        claude_dir = paths['claude_dir']
+
+        create_launcher_script(
+            config_base_dir=claude_dir,
+            command_name=cmd,
+            system_prompt_file=None,
+            mode='replace',
+            has_profile_mcp_servers=False,
+        )
+
+        cmd_path = claude_dir / 'start.cmd'
+        if cmd_path.exists():
+            errors = validate_launcher_env_sourcing(cmd_path)
+            assert not errors, 'Windows CMD launcher env sourcing failed:\n' + '\n'.join(errors)

--- a/tests/e2e/validators.py
+++ b/tests/e2e/validators.py
@@ -1187,3 +1187,296 @@ def validate_auto_update_controls(home_dir: Path, pinned: bool) -> list[str]:
         errors.append('Pinned version: ~/.claude.json does not exist')
 
     return errors
+
+
+def validate_env_loader_files(
+    claude_dir: Path,
+    os_env_vars: dict[str, str | None],
+    command_name: str | None = None,
+) -> list[str]:
+    """Validate env loader files exist with correct content.
+
+    Checks that generate_env_loader_files() produced the expected shell-specific
+    loader files containing ONLY non-None os-env-variables with proper syntax.
+
+    Validates:
+    - Global toolbox-env.sh exists in ~/.claude/
+    - Per-command env.sh exists in ~/.claude/{cmd}/ (when command_name provided)
+    - File content contains correct export syntax for each shell type
+    - None-valued (deletion) variables are excluded from loader files
+    - Header comment is present
+
+    Args:
+        claude_dir: Path to the ~/.claude directory
+        os_env_vars: OS env vars dict from config (None values = deletions)
+        command_name: Command name for per-command file checks, or None
+
+    Returns:
+        List of error strings (empty if validation passes)
+    """
+    errors: list[str] = []
+
+    # Determine which vars should appear (non-None only)
+    active_vars = {k: v for k, v in os_env_vars.items() if v is not None}
+    deletion_vars = [k for k, v in os_env_vars.items() if v is None]
+
+    if not active_vars:
+        # No active vars means no files should be generated
+        global_sh = claude_dir / 'toolbox-env.sh'
+        if global_sh.exists():
+            errors.append(
+                f'toolbox-env.sh exists but no active os-env-variables: {global_sh}',
+            )
+        return errors
+
+    # --- Global convenience files ---
+    global_sh = claude_dir / 'toolbox-env.sh'
+    if not global_sh.exists():
+        errors.append(f'Global env loader not found: {global_sh}')
+    else:
+        sh_content = global_sh.read_text(encoding='utf-8')
+        errors.extend(_validate_sh_loader_content(sh_content, active_vars, deletion_vars, 'toolbox-env.sh'))
+
+    # Global PS1 on Windows
+    if sys.platform == 'win32':
+        global_ps1 = claude_dir / 'toolbox-env.ps1'
+        if not global_ps1.exists():
+            errors.append(f'Global PS1 env loader not found on Windows: {global_ps1}')
+        else:
+            ps1_content = global_ps1.read_text(encoding='utf-8')
+            errors.extend(
+                _validate_ps1_loader_content(ps1_content, active_vars, deletion_vars, 'toolbox-env.ps1'),
+            )
+
+    # Global CMD on Windows
+    if sys.platform == 'win32':
+        global_cmd = claude_dir / 'toolbox-env.cmd'
+        if not global_cmd.exists():
+            errors.append(f'Global CMD env loader not found on Windows: {global_cmd}')
+        else:
+            cmd_content = global_cmd.read_text(encoding='utf-8')
+            errors.extend(
+                _validate_cmd_loader_content(cmd_content, active_vars, deletion_vars, 'toolbox-env.cmd'),
+            )
+
+    # --- Per-command files ---
+    if command_name:
+        cmd_dir = claude_dir / command_name
+        cmd_sh = cmd_dir / 'env.sh'
+        if not cmd_sh.exists():
+            errors.append(f'Per-command env loader not found: {cmd_sh}')
+        else:
+            sh_content = cmd_sh.read_text(encoding='utf-8')
+            errors.extend(_validate_sh_loader_content(sh_content, active_vars, deletion_vars, 'env.sh'))
+
+        if sys.platform == 'win32':
+            cmd_ps1 = cmd_dir / 'env.ps1'
+            if not cmd_ps1.exists():
+                errors.append(f'Per-command PS1 env loader not found on Windows: {cmd_ps1}')
+            else:
+                ps1_content = cmd_ps1.read_text(encoding='utf-8')
+                errors.extend(
+                    _validate_ps1_loader_content(ps1_content, active_vars, deletion_vars, 'env.ps1'),
+                )
+
+        if sys.platform == 'win32':
+            cmd_cmd = cmd_dir / 'env.cmd'
+            if not cmd_cmd.exists():
+                errors.append(f'Per-command CMD env loader not found on Windows: {cmd_cmd}')
+            else:
+                cmd_content = cmd_cmd.read_text(encoding='utf-8')
+                errors.extend(
+                    _validate_cmd_loader_content(cmd_content, active_vars, deletion_vars, 'env.cmd'),
+                )
+
+    return errors
+
+
+def _validate_sh_loader_content(
+    content: str,
+    active_vars: dict[str, str],
+    deletion_vars: list[str],
+    filename: str,
+) -> list[str]:
+    """Validate Bash/Zsh env loader file content.
+
+    Args:
+        content: File content
+        active_vars: Variables that should be present (name -> value, non-None only)
+        deletion_vars: Variable names that must NOT appear
+        filename: Filename for error messages
+
+    Returns:
+        List of error strings
+    """
+    errors: list[str] = []
+
+    # Header check
+    if not content.startswith('# Auto-generated by claude-code-toolbox'):
+        errors.append(f'{filename}: missing header comment')
+
+    # Each active var should have an export line
+    errors.extend(
+        f'{filename}: missing export for {name}'
+        for name in active_vars
+        if f'export {name}=' not in content
+    )
+
+    # Deletion vars must NOT appear
+    errors.extend(
+        f'{filename}: deletion var {name} should not appear'
+        for name in deletion_vars
+        if f'export {name}=' in content
+    )
+
+    return errors
+
+
+def _validate_ps1_loader_content(
+    content: str,
+    active_vars: dict[str, str],
+    deletion_vars: list[str],
+    filename: str,
+) -> list[str]:
+    """Validate PowerShell env loader file content.
+
+    Args:
+        content: File content
+        active_vars: Variables that should be present (name -> value, non-None only)
+        deletion_vars: Variable names that must NOT appear
+        filename: Filename for error messages
+
+    Returns:
+        List of error strings
+    """
+    errors: list[str] = []
+
+    # Header check
+    if not content.startswith('# Auto-generated by claude-code-toolbox'):
+        errors.append(f'{filename}: missing header comment')
+
+    # Each active var should have a $env: line
+    errors.extend(
+        f'{filename}: missing $env:{name} assignment'
+        for name in active_vars
+        if f'$env:{name} =' not in content
+    )
+
+    # Deletion vars must NOT appear
+    errors.extend(
+        f'{filename}: deletion var {name} should not appear'
+        for name in deletion_vars
+        if f'$env:{name} =' in content
+    )
+
+    return errors
+
+
+def _validate_cmd_loader_content(
+    content: str,
+    active_vars: dict[str, str],
+    deletion_vars: list[str],
+    filename: str,
+) -> list[str]:
+    """Validate CMD batch env loader file content.
+
+    Args:
+        content: File content
+        active_vars: Variables that should be present (name -> value, non-None only)
+        deletion_vars: Variable names that must NOT appear
+        filename: Filename for error messages
+
+    Returns:
+        List of error strings
+    """
+    errors: list[str] = []
+
+    # Header check
+    if not content.startswith('@echo off'):
+        errors.append(f'{filename}: missing @echo off header')
+
+    # Each active var should have a SET line
+    errors.extend(
+        f'{filename}: missing SET for {name}'
+        for name in active_vars
+        if f'SET "{name}=' not in content
+    )
+
+    # Deletion vars must NOT appear
+    errors.extend(
+        f'{filename}: deletion var {name} should not appear'
+        for name in deletion_vars
+        if f'SET "{name}=' in content
+    )
+
+    return errors
+
+
+def validate_launcher_env_sourcing(
+    launcher_path: Path,
+) -> list[str]:
+    """Validate that a launcher script contains env loader source guard.
+
+    Checks that create_launcher_script() injected the guarded source line
+    for loading OS-level environment variables from the per-command env file.
+
+    Validates:
+    - Bash/POSIX launchers contain file-existence guard and source command
+    - PowerShell launchers contain Test-Path guard and dot-source command
+    - CMD batch launchers contain if exist guard and call to env.cmd
+
+    Args:
+        launcher_path: Path to the launcher script
+
+    Returns:
+        List of error strings (empty if validation passes)
+    """
+    errors: list[str] = []
+
+    if not launcher_path.exists():
+        return [f'Launcher script not found: {launcher_path}']
+
+    try:
+        content = launcher_path.read_text(encoding='utf-8')
+    except OSError as e:
+        return [f'Failed to read launcher {launcher_path}: {e}']
+
+    suffix = launcher_path.suffix.lower()
+
+    if suffix == '.ps1':
+        # PowerShell: expect Test-Path guard and dot-source
+        if 'env.ps1' not in content:
+            errors.append(
+                f'{launcher_path.name}: missing env.ps1 reference in PowerShell launcher',
+            )
+        if 'Test-Path' not in content:
+            errors.append(
+                f'{launcher_path.name}: missing Test-Path guard for env.ps1',
+            )
+    elif suffix == '.cmd':
+        # CMD batch: expect if exist guard and call to env.cmd
+        if 'env.cmd' not in content:
+            errors.append(
+                f'{launcher_path.name}: missing env.cmd reference in CMD launcher',
+            )
+        if 'if exist' not in content:
+            errors.append(
+                f'{launcher_path.name}: missing if exist guard for env.cmd',
+            )
+        if 'call' not in content:
+            errors.append(
+                f'{launcher_path.name}: missing call command for env.cmd',
+            )
+    elif suffix in ('.sh', ''):
+        # Bash/POSIX: expect file-existence guard and source/dot-source
+        if 'env.sh' not in content:
+            errors.append(
+                f'{launcher_path.name}: missing env.sh reference in shell launcher',
+            )
+        # Check for file-existence guard ([ -f ... ] pattern)
+        if '[ -f' not in content and '[-f' not in content:
+            errors.append(
+                f'{launcher_path.name}: missing file-existence guard for env.sh',
+            )
+
+    return errors

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -10584,3 +10584,463 @@ class TestApplyAutoUpdateSettings:
         param_names = list(sig.parameters.keys())
         assert 'command_names' not in param_names
         assert 'primary_command_name' not in param_names
+
+
+class TestBroadcastWmSettingchange:
+    """Tests for _broadcast_wm_settingchange() helper."""
+
+    def test_noop_on_non_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify no subprocess calls on non-Windows platforms."""
+        monkeypatch.setattr(sys, 'platform', 'linux')
+        called: list[list[str]] = []
+
+        def mock_run(cmd: list[str], **_kw: object) -> MagicMock:
+            called.append(cmd)
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(subprocess, 'run', mock_run)
+        setup_environment._broadcast_wm_settingchange()
+        assert called == []
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-specific test')
+    def test_calls_setx_and_reg_delete_on_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify setx + reg delete pattern on Windows."""
+        called: list[list[str]] = []
+
+        def mock_run(cmd: list[str], **_kw: object) -> MagicMock:
+            called.append(cmd)
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(subprocess, 'run', mock_run)
+        setup_environment._broadcast_wm_settingchange()
+        assert len(called) == 2
+        assert called[0] == ['setx', 'CLAUDE_CODE_TOOLBOX_TEMP', 'temp']
+        assert called[1][0] == 'reg'
+        assert called[1][1] == 'delete'
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-specific test')
+    def test_does_not_raise_on_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify check=False prevents exceptions."""
+        def mock_run(_cmd: list[str], **_kw: object) -> MagicMock:
+            return MagicMock(returncode=1)
+
+        monkeypatch.setattr(subprocess, 'run', mock_run)
+        # Should not raise
+        setup_environment._broadcast_wm_settingchange()
+
+
+class TestGenerateEnvLoaderFiles:
+    """Tests for generate_env_loader_files() function."""
+
+    def test_empty_vars_returns_empty(self) -> None:
+        """Empty os_env_vars produces no files."""
+        result = setup_environment.generate_env_loader_files({}, None, None)
+        assert result == {}
+
+    def test_all_none_values_returns_empty(self) -> None:
+        """All None values (deletions) produce no files."""
+        result = setup_environment.generate_env_loader_files(
+            {'DEL_VAR': None, 'DEL_OTHER': None}, None, None,
+        )
+        assert result == {}
+
+    def test_none_values_excluded_from_files(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """None values (deletions) are not written to loader files."""
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        monkeypatch.setattr(shutil, 'which', lambda _cmd: None)  # No fish
+
+        result = setup_environment.generate_env_loader_files(
+            {'KEEP': 'val', 'DELETE': None}, None, None,
+        )
+        assert len(result) > 0
+        # Check that the sh file only has KEEP, not DELETE
+        sh_files = [p for k, p in result.items() if k.startswith('sh:')]
+        assert len(sh_files) == 1
+        content = sh_files[0].read_text()
+        assert 'KEEP' in content
+        assert 'DELETE' not in content
+
+    def test_global_files_generated_without_commands(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without command_names, only global convenience files are generated."""
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        monkeypatch.setattr(shutil, 'which', lambda _cmd: None)
+
+        result = setup_environment.generate_env_loader_files(
+            {'MY_VAR': 'value'}, None, None,
+        )
+        # Should generate toolbox-env.sh
+        sh_files = [p for k, p in result.items() if k.startswith('sh:')]
+        assert len(sh_files) == 1
+        assert sh_files[0].name == 'toolbox-env.sh'
+
+    def test_per_command_and_global_files(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With command_names, generates per-command + global files."""
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        monkeypatch.setattr(shutil, 'which', lambda _cmd: None)
+
+        cmd_dir = tmp_path / '.claude' / 'my-cmd'
+        result = setup_environment.generate_env_loader_files(
+            {'VAR1': 'val1'}, ['my-cmd'], cmd_dir,
+        )
+        sh_files = [p for k, p in result.items() if k.startswith('sh:')]
+        names = {p.name for p in sh_files}
+        assert 'env.sh' in names  # per-command
+        assert 'toolbox-env.sh' in names  # global
+
+    def test_sh_format_correctness(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify bash/zsh export syntax."""
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        monkeypatch.setattr(shutil, 'which', lambda _cmd: None)
+
+        setup_environment.generate_env_loader_files({'FOO': 'bar', 'BAZ': 'qux'}, None, None)
+        sh_path = tmp_path / '.claude' / 'toolbox-env.sh'
+        content = sh_path.read_text()
+        assert 'export FOO="bar"' in content
+        assert 'export BAZ="qux"' in content
+        assert content.startswith('# Auto-generated by claude-code-toolbox')
+
+    def test_fish_format_generated_when_fish_available(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify fish set -gx syntax when fish is installed."""
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        monkeypatch.setattr(shutil, 'which', lambda cmd: '/usr/bin/fish' if cmd == 'fish' else None)
+
+        setup_environment.generate_env_loader_files({'FOO': 'bar'}, None, None)
+        fish_path = tmp_path / '.claude' / 'toolbox-env.fish'
+        assert fish_path.exists()
+        content = fish_path.read_text()
+        assert 'set -gx FOO "bar"' in content
+
+    def test_fish_not_generated_when_unavailable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No fish file when fish is not installed."""
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        monkeypatch.setattr(shutil, 'which', lambda _cmd: None)
+
+        setup_environment.generate_env_loader_files({'FOO': 'bar'}, None, None)
+        fish_path = tmp_path / '.claude' / 'toolbox-env.fish'
+        assert not fish_path.exists()
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-specific test')
+    def test_ps1_format_on_windows(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify PowerShell syntax on Windows."""
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        monkeypatch.setattr(shutil, 'which', lambda _cmd: None)
+
+        cmd_dir = tmp_path / '.claude' / 'my-cmd'
+        setup_environment.generate_env_loader_files({'FOO': 'bar'}, ['my-cmd'], cmd_dir)
+        ps1_path = cmd_dir / 'env.ps1'
+        assert ps1_path.exists()
+        content = ps1_path.read_text()
+        assert "$env:FOO = 'bar'" in content
+
+    def test_special_chars_escaped_in_sh(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Values with special chars are properly escaped in bash."""
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        monkeypatch.setattr(shutil, 'which', lambda _cmd: None)
+
+        setup_environment.generate_env_loader_files(
+            {'TRICKY': 'has "quotes" and $dollar and `backtick`'}, None, None,
+        )
+        sh_path = tmp_path / '.claude' / 'toolbox-env.sh'
+        content = sh_path.read_text()
+        assert r'\"quotes\"' in content
+        assert r'\$dollar' in content
+        assert r'\`backtick\`' in content
+
+    def test_special_chars_escaped_in_ps1(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Values with single quotes are properly escaped in PowerShell."""
+        if sys.platform != 'win32':
+            pytest.skip('Windows-specific test')
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        monkeypatch.setattr(shutil, 'which', lambda _cmd: None)
+
+        cmd_dir = tmp_path / '.claude' / 'my-cmd'
+        setup_environment.generate_env_loader_files(
+            {'TRICKY': "it's a value"}, ['my-cmd'], cmd_dir,
+        )
+        ps1_path = cmd_dir / 'env.ps1'
+        content = ps1_path.read_text()
+        assert "$env:TRICKY = 'it''s a value'" in content
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-specific test')
+    def test_cmd_format_on_windows(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify CMD batch SET syntax on Windows."""
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        monkeypatch.setattr(shutil, 'which', lambda _cmd: None)
+
+        cmd_dir = tmp_path / '.claude' / 'my-cmd'
+        setup_environment.generate_env_loader_files({'FOO': 'bar'}, ['my-cmd'], cmd_dir)
+        cmd_path = cmd_dir / 'env.cmd'
+        assert cmd_path.exists()
+        content = cmd_path.read_text()
+        assert 'SET "FOO=bar"' in content
+        assert content.startswith('@echo off')
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-specific test')
+    def test_special_chars_escaped_in_cmd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Percent signs are doubled in CMD batch files."""
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        monkeypatch.setattr(shutil, 'which', lambda _cmd: None)
+
+        cmd_dir = tmp_path / '.claude' / 'my-cmd'
+        setup_environment.generate_env_loader_files(
+            {'TRICKY': 'has 50% discount'}, ['my-cmd'], cmd_dir,
+        )
+        cmd_path = cmd_dir / 'env.cmd'
+        content = cmd_path.read_text()
+        assert 'SET "TRICKY=has 50%% discount"' in content
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-specific test')
+    def test_global_cmd_file_on_windows(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Global toolbox-env.cmd generated on Windows."""
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        monkeypatch.setattr(shutil, 'which', lambda _cmd: None)
+
+        setup_environment.generate_env_loader_files({'MY_VAR': 'value'}, None, None)
+        cmd_path = tmp_path / '.claude' / 'toolbox-env.cmd'
+        assert cmd_path.exists()
+        content = cmd_path.read_text()
+        assert 'SET "MY_VAR=value"' in content
+
+
+class TestLauncherEnvSourcing:
+    """Tests for env loader sourcing in launcher scripts."""
+
+    def test_unix_launcher_contains_env_source_guard(self, tmp_path: Path) -> None:
+        """Unix launch.sh contains guarded env.sh source line."""
+        config_dir = tmp_path / '.claude' / 'test-cmd'
+        config_dir.mkdir(parents=True)
+
+        result = setup_environment.create_launcher_script(
+            config_base_dir=config_dir,
+            command_name='test-cmd',
+            system_prompt_file=None,
+            mode='replace',
+            has_profile_mcp_servers=False,
+        )
+        assert result is not None
+        launcher_path = result[1]  # launch.sh
+        content = launcher_path.read_text()
+        assert 'ENV_FILE="$HOME/.claude/test-cmd/env.sh"' in content
+        assert '[ -f "$ENV_FILE" ] && . "$ENV_FILE"' in content
+
+    def test_unix_launcher_with_prompt_contains_env_source(self, tmp_path: Path) -> None:
+        """Unix launch.sh with system prompt also has env source."""
+        config_dir = tmp_path / '.claude' / 'test-cmd'
+        prompts_dir = config_dir / 'prompts'
+        prompts_dir.mkdir(parents=True)
+        (prompts_dir / 'test.md').write_text('# Test prompt')
+
+        result = setup_environment.create_launcher_script(
+            config_base_dir=config_dir,
+            command_name='test-cmd',
+            system_prompt_file='test.md',
+            mode='replace',
+            has_profile_mcp_servers=False,
+        )
+        assert result is not None
+        launcher_path = result[1]
+        content = launcher_path.read_text()
+        assert 'ENV_FILE="$HOME/.claude/test-cmd/env.sh"' in content
+        assert '[ -f "$ENV_FILE" ] && . "$ENV_FILE"' in content
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-specific test')
+    def test_windows_ps1_contains_env_source(self, tmp_path: Path) -> None:
+        """Windows start.ps1 contains PowerShell dot-source guard."""
+        config_dir = tmp_path / '.claude' / 'test-cmd'
+        config_dir.mkdir(parents=True)
+
+        result = setup_environment.create_launcher_script(
+            config_base_dir=config_dir,
+            command_name='test-cmd',
+            system_prompt_file=None,
+            mode='replace',
+            has_profile_mcp_servers=False,
+        )
+        assert result is not None
+        ps1_path = result[0]  # start.ps1
+        content = ps1_path.read_text()
+        assert 'env.ps1' in content
+        assert 'Test-Path' in content
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-specific test')
+    def test_windows_shared_sh_contains_env_source(self, tmp_path: Path) -> None:
+        """Windows shared launch.sh contains env.sh source guard."""
+        config_dir = tmp_path / '.claude' / 'test-cmd'
+        config_dir.mkdir(parents=True)
+
+        result = setup_environment.create_launcher_script(
+            config_base_dir=config_dir,
+            command_name='test-cmd',
+            system_prompt_file=None,
+            mode='replace',
+            has_profile_mcp_servers=False,
+        )
+        assert result is not None
+        launch_sh = result[1]  # launch.sh
+        content = launch_sh.read_text()
+        assert 'ENV_FILE="$HOME/.claude/test-cmd/env.sh"' in content
+        assert '[ -f "$ENV_FILE" ] && . "$ENV_FILE"' in content
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-specific test')
+    def test_windows_cmd_contains_env_source(self, tmp_path: Path) -> None:
+        """Windows start.cmd contains guarded call to env.cmd."""
+        config_dir = tmp_path / '.claude' / 'test-cmd'
+        config_dir.mkdir(parents=True)
+
+        result = setup_environment.create_launcher_script(
+            config_base_dir=config_dir,
+            command_name='test-cmd',
+            system_prompt_file=None,
+            mode='replace',
+            has_profile_mcp_servers=False,
+        )
+        assert result is not None
+        cmd_path = config_dir / 'start.cmd'
+        assert cmd_path.exists()
+        content = cmd_path.read_text()
+        assert 'env.cmd' in content
+        assert 'if exist' in content
+        assert 'call' in content
+
+
+class TestFishSetUx:
+    """Tests for Fish set -Ux in set_os_env_variable_unix()."""
+
+    def test_fish_set_ux_called_when_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When fish is installed, set -Ux is called for setting values."""
+        monkeypatch.setattr(sys, 'platform', 'linux')
+        monkeypatch.setattr(setup_environment, 'get_all_shell_config_files', lambda: [])
+
+        fish_cmds: list[list[str]] = []
+
+        original_which = shutil.which
+
+        def mock_which(cmd: str) -> str | None:
+            if cmd == 'fish':
+                return '/usr/bin/fish'
+            return original_which(cmd)
+
+        monkeypatch.setattr(shutil, 'which', mock_which)
+
+        def mock_run(cmd: list[str], **_kw: object) -> MagicMock:
+            fish_cmds.append(cmd)
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(subprocess, 'run', mock_run)
+        setup_environment.set_os_env_variable_unix('MY_VAR', 'my_value')
+
+        assert len(fish_cmds) == 1
+        assert fish_cmds[0] == ['fish', '-c', 'set -Ux MY_VAR "my_value"']
+
+    def test_fish_set_ue_called_for_deletion(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When fish is installed, set -Ue is called for deletions."""
+        monkeypatch.setattr(sys, 'platform', 'linux')
+        monkeypatch.setattr(setup_environment, 'get_all_shell_config_files', lambda: [])
+
+        fish_cmds: list[list[str]] = []
+
+        def mock_which(cmd: str) -> str | None:
+            if cmd == 'fish':
+                return '/usr/bin/fish'
+            return None
+
+        monkeypatch.setattr(shutil, 'which', mock_which)
+
+        def mock_run(cmd: list[str], **_kw: object) -> MagicMock:
+            fish_cmds.append(cmd)
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(subprocess, 'run', mock_run)
+        setup_environment.set_os_env_variable_unix('MY_VAR', None)
+
+        assert len(fish_cmds) == 1
+        assert fish_cmds[0] == ['fish', '-c', 'set -Ue MY_VAR']
+
+    def test_no_fish_calls_when_not_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When fish is not installed, no subprocess calls for fish."""
+        monkeypatch.setattr(sys, 'platform', 'linux')
+        monkeypatch.setattr(setup_environment, 'get_all_shell_config_files', lambda: [])
+        monkeypatch.setattr(shutil, 'which', lambda _cmd: None)
+
+        fish_cmds: list[list[str]] = []
+
+        def mock_run(cmd: list[str], **_kw: object) -> MagicMock:
+            fish_cmds.append(cmd)
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(subprocess, 'run', mock_run)
+        setup_environment.set_os_env_variable_unix('MY_VAR', 'value')
+        assert fish_cmds == []
+
+    def test_timeout_gracefully_handled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """TimeoutExpired is caught and ignored."""
+        monkeypatch.setattr(sys, 'platform', 'linux')
+        monkeypatch.setattr(setup_environment, 'get_all_shell_config_files', lambda: [])
+
+        def mock_which(cmd: str) -> str | None:
+            if cmd == 'fish':
+                return '/usr/bin/fish'
+            return None
+
+        monkeypatch.setattr(shutil, 'which', mock_which)
+
+        def mock_run(cmd: list[str], **_kw: object) -> None:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=5)
+
+        monkeypatch.setattr(subprocess, 'run', mock_run)
+        # Should not raise
+        setup_environment.set_os_env_variable_unix('MY_VAR', 'value')
+
+    def test_oserror_gracefully_handled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """OSError is caught and ignored."""
+        monkeypatch.setattr(sys, 'platform', 'linux')
+        monkeypatch.setattr(setup_environment, 'get_all_shell_config_files', lambda: [])
+
+        def mock_which(cmd: str) -> str | None:
+            if cmd == 'fish':
+                return '/usr/bin/fish'
+            return None
+
+        monkeypatch.setattr(shutil, 'which', mock_which)
+
+        def mock_run(_cmd: list[str], **_kw: object) -> None:
+            raise OSError('fish not found')
+
+        monkeypatch.setattr(subprocess, 'run', mock_run)
+        # Should not raise
+        setup_environment.set_os_env_variable_unix('MY_VAR', 'value')
+
+
+class TestSetOsEnvVariableWindowsBroadcast:
+    """Tests for WM_SETTINGCHANGE broadcast after reg delete in set_os_env_variable_windows()."""
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-specific test')
+    def test_broadcast_called_after_successful_deletion(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify broadcast is called after successful reg delete."""
+        called_with: list[list[str]] = []
+
+        class MockResult:
+            returncode = 0
+            stderr = ''
+
+        def mock_run(cmd: list[str], **_kw: object) -> MockResult:
+            called_with.append(cmd)
+            return MockResult()
+
+        monkeypatch.setattr(subprocess, 'run', mock_run)
+        result = setup_environment.set_os_env_variable_windows('MY_VAR', None)
+        assert result is True
+        # First call: reg delete for the variable
+        assert called_with[0][0] == 'reg'
+        # Next calls: broadcast (setx + reg delete for temp)
+        assert called_with[1] == ['setx', 'CLAUDE_CODE_TOOLBOX_TEMP', 'temp']
+        assert called_with[2][0] == 'reg'
+        assert 'CLAUDE_CODE_TOOLBOX_TEMP' in called_with[2]


### PR DESCRIPTION
Implement Rustup-style env loader files for OS environment variables with full CMD batch support, bringing cmd.exe to feature parity with PowerShell, Bash, and Fish launchers.

Key changes:
- Add generate_env_loader_files() producing per-command and global loader files (env.sh, env.fish, env.ps1, env.cmd / toolbox-env.*)
- Add CMD batch env.cmd generation with SET "NAME=value" syntax and percent-sign escaping (% -> %%)
- Add guarded env.cmd sourcing to start.cmd and global CMD wrappers
- Extract _broadcast_wm_settingchange() into shared helper and add missing broadcast after reg-delete operations
- Add Fish dual-mechanism: set -Ux for instant propagation to all running Fish sessions alongside durable config.fish persistence
- Remove false "legacy" label from cmd.exe in documentation