### PR TITLE
Coerce non-string YAML env values to strings in env loader and config

### DIFF
--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -665,6 +665,7 @@ os-env-variables:
   OLD_UNUSED_VAR: null  # Deletes this variable
 ```
 
+- **Automatic string conversion:** Non-string YAML values (integers, booleans, floats) in both `env-variables` and `os-env-variables` are automatically converted to strings by the setup script. For example, `MCP_TIMEOUT: 30000` (YAML integer) becomes `"30000"` (string), and `ENABLE_FEATURE: true` (YAML boolean) becomes `"True"` (string). To preserve exact string representation, quote values in YAML: `ENABLE_FEATURE: "true"`.
 - **Current session guidance (Linux/macOS):** When variables are deleted via `null`, the setup script outputs shell-specific `unset` commands so the user can remove those variables from the running session without opening a new terminal:
   - **Bash/Zsh:** `unset VARNAME` for each deleted variable
   - **Fish** (when installed): `set -e VARNAME` for each deleted variable

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -4793,7 +4793,7 @@ def generate_env_loader_files(
         Dict mapping file type to generated Path (e.g., {"sh": Path(...)}).
     """
     # Filter to only non-None values (deletions are excluded from loader files)
-    active_vars = {k: v for k, v in os_env_vars.items() if v is not None}
+    active_vars = {k: str(v) for k, v in os_env_vars.items() if v is not None}
 
     if not active_vars:
         return {}
@@ -7111,7 +7111,7 @@ def create_profile_config(
 
     # Add environment variables if specified
     if env:
-        settings['env'] = env
+        settings['env'] = {k: str(v) for k, v in env.items()}
         info(f'Setting {len(env)} environment variables')
         for key in env:
             info(f'  - {key}')

--- a/tests/e2e/golden_config.yaml
+++ b/tests/e2e/golden_config.yaml
@@ -207,6 +207,7 @@ env-variables:
   E2E_TEST_VAR: "test_value"
   E2E_ANOTHER_VAR: "another_value"
   E2E_PATH_VAR: "~/.claude/e2e-data"
+  E2E_INT_VAR: 42
 
 # OS-level environment variables
 os-env-variables:
@@ -214,6 +215,8 @@ os-env-variables:
   E2E_OS_PATH: "/opt/e2e/bin"
   E2E_OS_DELETE_VAR: null
   E2E_OS_DELETE_TOKEN: null
+  E2E_OS_INT_VAR: 30000
+  E2E_OS_BOOL_VAR: true
 
 # Command defaults
 command-defaults:

--- a/tests/e2e/test_file_reorganization.py
+++ b/tests/e2e/test_file_reorganization.py
@@ -226,6 +226,7 @@ class TestFileReorganization:
         assert 'CLAUDE_CONFIG_DIR' not in env_block
         assert env_block.get('E2E_TEST_VAR') == 'test_value'
         assert env_block.get('E2E_ANOTHER_VAR') == 'another_value'
+        assert env_block.get('E2E_INT_VAR') == '42'  # YAML int -> string conversion
 
         # Verify user-settings content NOT in config.json
         assert 'theme' not in content

--- a/tests/e2e/validators.py
+++ b/tests/e2e/validators.py
@@ -345,9 +345,11 @@ def validate_settings(path: Path, config: dict[str, Any]) -> list[str]:
     config_env = config.get('env-variables', {})
     for key, expected_value in config_env.items():
         actual = data.get('env', {}).get(key)
-        if actual != expected_value:
+        # Production code coerces env values to strings via str(v)
+        expected_str = str(expected_value)
+        if actual != expected_str:
             errors.append(
-                f"Env var '{key}': expected {expected_value!r}, got {actual!r}",
+                f"Env var '{key}': expected {expected_str!r}, got {actual!r}",
             )
 
     # Hooks structure validation
@@ -1217,7 +1219,7 @@ def validate_env_loader_files(
     errors: list[str] = []
 
     # Determine which vars should appear (non-None only)
-    active_vars = {k: v for k, v in os_env_vars.items() if v is not None}
+    active_vars = {k: str(v) for k, v in os_env_vars.items() if v is not None}
     deletion_vars = [k for k, v in os_env_vars.items() if v is None]
 
     if not active_vars:

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -10809,6 +10809,38 @@ class TestGenerateEnvLoaderFiles:
         content = cmd_path.read_text()
         assert 'SET "MY_VAR=value"' in content
 
+    def test_non_string_values_converted_to_strings(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Non-string YAML values (int, bool, float) are converted to strings in loader files."""
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        monkeypatch.setattr(shutil, 'which', lambda _cmd: None)  # No fish
+
+        # Simulate YAML-parsed non-string values
+        mixed_type_vars: dict[str, Any] = {
+            'INT_VAR': 30000,
+            'BOOL_VAR': True,
+            'FLOAT_VAR': 0.5,
+            'STR_VAR': 'normal_string',
+            'DELETE_VAR': None,
+        }
+
+        result = setup_environment.generate_env_loader_files(mixed_type_vars, None, None)
+        assert len(result) > 0
+
+        # Check that the sh file contains string representations
+        sh_files = [p for k, p in result.items() if k.startswith('sh:')]
+        assert len(sh_files) == 1
+        content = sh_files[0].read_text()
+
+        # All non-None values should be present as strings
+        assert 'export INT_VAR="30000"' in content
+        assert 'export BOOL_VAR="True"' in content
+        assert 'export FLOAT_VAR="0.5"' in content
+        assert 'export STR_VAR="normal_string"' in content
+        # Deletion var should be absent
+        assert 'DELETE_VAR' not in content
+
 
 class TestLauncherEnvSourcing:
     """Tests for env loader sourcing in launcher scripts."""

--- a/tests/test_setup_environment_additional.py
+++ b/tests/test_setup_environment_additional.py
@@ -22,6 +22,7 @@ import yaml
 # Add scripts directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / 'scripts'))
 
+
 import setup_environment
 
 
@@ -1018,6 +1019,35 @@ class TestCreateSettingsComplex:
             settings = json.loads(settings_file.read_text())
 
             assert settings['env'] == env_vars
+
+    def test_create_profile_config_with_non_string_env_values(self) -> None:
+        """Non-string env variable values are coerced to strings in config.json."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            claude_dir = Path(tmpdir)
+
+            # Simulate YAML-parsed non-string values
+            env_vars: dict[str, Any] = {
+                'TIMEOUT': 30000,
+                'ENABLE_FEATURE': True,
+                'THRESHOLD': 0.5,
+                'NORMAL_VAR': 'string_value',
+            }
+
+            setup_environment.create_profile_config(
+                {},
+                claude_dir,
+                env=env_vars,
+            )
+
+            settings_file = claude_dir / 'config.json'
+            settings = json.loads(settings_file.read_text())
+
+            # All values must be strings in the output
+            env_output = settings['env']
+            assert env_output['TIMEOUT'] == '30000'
+            assert env_output['ENABLE_FEATURE'] == 'True'
+            assert env_output['THRESHOLD'] == '0.5'
+            assert env_output['NORMAL_VAR'] == 'string_value'
 
     @patch('setup_environment.download_file')
     @patch('platform.system', return_value='Windows')


### PR DESCRIPTION
YAML-parsed non-string values (int, bool, float) in env-variables and os-env-variables caused AttributeError crashes in generate_env_loader_files() when .replace() was called on non-string values, and semantic bugs in create_profile_config() where env values were written as JSON numbers/booleans.

- Add str(v) conversion in generate_env_loader_files() active_vars
- Add str(v) conversion in create_profile_config() env dict
- Add unit tests for non-string YAML value code paths
- Update E2E golden config with unquoted YAML values (int, bool)
- Update E2E validators for type parity with production code
- Document automatic string conversion in environment config guide