### PR TITLE
Filter installation summary dependencies to current OS only

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -123,6 +123,15 @@ SENSITIVE_PATH_PREFIXES: tuple[str, ...] = (
     '~/.config/',
 )
 
+# Mapping from platform.system() return values to dependency config keys.
+# Used by collect_installation_plan(), install_dependencies(), and check_admin_needed()
+# to determine which platform-specific dependencies apply to the current OS.
+PLATFORM_SYSTEM_TO_CONFIG_KEY: dict[str, str] = {
+    'Windows': 'windows',
+    'Darwin': 'macos',
+    'Linux': 'linux',
+}
+
 # OS environment variables constants
 OS_ENV_VARIABLES_KEY = 'os-env-variables'
 ENV_VAR_MARKER_START = '# >>> claude-code-toolbox >>>'
@@ -505,10 +514,11 @@ def check_admin_needed(config: dict[str, Any], args: argparse.Namespace) -> bool
     # Check for dependencies that need admin
     dependencies = config.get('dependencies', {})
     if dependencies:
-        # Check Windows-specific dependencies
-        win_deps = dependencies.get('windows', [])
+        # Check current platform + common dependencies
+        current_platform_key = PLATFORM_SYSTEM_TO_CONFIG_KEY.get(platform.system())
+        platform_deps = dependencies.get(current_platform_key, []) if current_platform_key else []
         common_deps = dependencies.get('common', [])
-        all_deps = win_deps + common_deps
+        all_deps = list(platform_deps) + list(common_deps)
 
         for dep in all_deps:
             # Check for commands that typically need admin
@@ -4000,10 +4010,14 @@ def collect_installation_plan(
         cast(dict[str, Any], s) for s in mcp_raw if isinstance(s, dict)
     ]
 
-    # Extract dependency commands by platform
+    # Extract dependency commands for current OS only
     dependency_commands: dict[str, list[str]] = {}
     deps_raw: dict[str, Any] = config.get('dependencies') or {}
-    for platform_key in ('common', 'windows', 'linux', 'macos'):
+    current_platform_key = PLATFORM_SYSTEM_TO_CONFIG_KEY.get(platform.system())
+    relevant_keys = ['common']
+    if current_platform_key:
+        relevant_keys.append(current_platform_key)
+    for platform_key in relevant_keys:
         dep_cmds: list[Any] = deps_raw.get(platform_key) or []
         if dep_cmds:
             dependency_commands[platform_key] = [str(c) for c in dep_cmds]
@@ -5471,11 +5485,12 @@ def install_dependencies(dependencies: dict[str, list[str]] | None) -> bool:
 
     info('Installing dependencies...')
 
-    # Check if any Windows dependencies need admin
+    # Check if any dependencies on the current platform need admin
     if platform.system() == 'Windows' and not is_admin():
-        win_deps = dependencies.get('windows', [])
+        platform_key = PLATFORM_SYSTEM_TO_CONFIG_KEY.get(platform.system())
+        platform_deps = dependencies.get(platform_key, []) if platform_key else []
         common_deps = dependencies.get('common', [])
-        all_deps = win_deps + common_deps
+        all_deps = list(platform_deps) + list(common_deps)
 
         admin_needed_deps = [dep for dep in all_deps if 'winget' in dep and '--scope machine' in dep]
 
@@ -5498,15 +5513,7 @@ def install_dependencies(dependencies: dict[str, list[str]] | None) -> bool:
 
     # Get system platform
     system = platform.system()
-
-    # Platform mapping: platform.system() returns -> config key
-    platform_map = {
-        'Windows': 'windows',
-        'Darwin': 'macos',
-        'Linux': 'linux',
-    }
-
-    current_platform_key = platform_map.get(system)
+    current_platform_key = PLATFORM_SYSTEM_TO_CONFIG_KEY.get(system)
 
     if not current_platform_key:
         warning(f'Unknown platform: {system}. Skipping platform-specific dependencies.')

--- a/tests/e2e/test_confirmation.py
+++ b/tests/e2e/test_confirmation.py
@@ -8,6 +8,7 @@ Uses isolated home directories and golden config for comprehensive validation.
 from __future__ import annotations
 
 import io
+import platform
 from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -146,12 +147,25 @@ class TestConfirmationSummaryContent:
     def test_summary_shows_dependency_commands(
         self, golden_config: dict[str, Any],
     ) -> None:
-        """Full dependency commands from golden config are visible."""
+        """Only common + current platform dependency commands are visible."""
         plan = self._make_plan_from_golden(golden_config)
         buf = io.StringIO()
         setup_environment.display_installation_summary(plan, output=buf)
         output = buf.getvalue()
+        # Common deps always present
         assert "echo 'common-dependency-installed'" in output
+
+        # Current platform deps present, other platforms absent
+        current_platform = setup_environment.PLATFORM_SYSTEM_TO_CONFIG_KEY.get(
+            platform.system(),
+        )
+        if current_platform:
+            assert f"echo '{current_platform}-dependency-installed'" in output
+
+        # Other platform deps must NOT appear
+        other_platforms = {'windows', 'linux', 'macos'} - {current_platform}
+        for other in other_platforms:
+            assert f"echo '{other}-dependency-installed'" not in output
 
     def test_summary_shows_resource_counts(
         self, golden_config: dict[str, Any],

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -2078,6 +2078,63 @@ class TestInstallDependencies:
         assert '~/.local/tools/custom-tool' in call_arg
 
 
+class TestCheckAdminNeeded:
+    """Tests for check_admin_needed()."""
+
+    @staticmethod
+    def _make_args(skip_install: bool = True) -> MagicMock:
+        args = MagicMock()
+        args.skip_install = skip_install
+        return args
+
+    def test_returns_false_on_non_windows(self) -> None:
+        """Non-Windows platforms never need admin."""
+        config: dict[str, Any] = {
+            'dependencies': {
+                'common': ['npm install -g something'],
+            },
+        }
+        with patch.object(setup_environment.platform, 'system', return_value='Linux'):
+            assert setup_environment.check_admin_needed(config, self._make_args()) is False
+
+    def test_returns_true_when_skip_install_false_on_windows(self) -> None:
+        """Windows needs admin when installation is not skipped."""
+        with patch.object(setup_environment.platform, 'system', return_value='Windows'):
+            assert setup_environment.check_admin_needed({}, self._make_args(skip_install=False)) is True
+
+    def test_detects_admin_needed_for_machine_scope_winget(self) -> None:
+        """Windows admin needed for machine-scope winget commands."""
+        config: dict[str, Any] = {
+            'dependencies': {
+                'windows': ['winget install Something --scope machine'],
+                'common': [],
+            },
+        }
+        with patch.object(setup_environment.platform, 'system', return_value='Windows'):
+            assert setup_environment.check_admin_needed(config, self._make_args()) is True
+
+    def test_detects_admin_needed_for_global_npm(self) -> None:
+        """Windows admin needed for global npm installs."""
+        config: dict[str, Any] = {
+            'dependencies': {
+                'common': ['npm install -g typescript'],
+            },
+        }
+        with patch.object(setup_environment.platform, 'system', return_value='Windows'):
+            assert setup_environment.check_admin_needed(config, self._make_args()) is True
+
+    def test_no_admin_needed_when_no_elevated_deps(self) -> None:
+        """Windows does not need admin for non-elevated deps."""
+        config: dict[str, Any] = {
+            'dependencies': {
+                'windows': ['winget install Something --scope user'],
+                'common': ['pip install requests'],
+            },
+        }
+        with patch.object(setup_environment.platform, 'system', return_value='Windows'):
+            assert setup_environment.check_admin_needed(config, self._make_args()) is False
+
+
 class TestInstallNodejsIfRequested:
     """Test install_nodejs_if_requested() function."""
 
@@ -10070,11 +10127,27 @@ class TestCollectInstallationPlan:
         assert '~/.ssh/authorized_keys' in plan.sensitive_paths
         assert '~/.claude/data/safe.txt' not in plan.sensitive_paths
 
-    def test_collect_plan_dependency_commands(self) -> None:
-        """All platform dependency commands are collected."""
+    @pytest.mark.parametrize(
+        ('mocked_system', 'expected_keys', 'unexpected_keys'),
+        [
+            ('Linux', {'common', 'linux'}, {'windows', 'macos'}),
+            ('Windows', {'common', 'windows'}, {'linux', 'macos'}),
+            ('Darwin', {'common', 'macos'}, {'linux', 'windows'}),
+            ('FreeBSD', {'common'}, {'linux', 'windows', 'macos'}),
+        ],
+        ids=['linux', 'windows', 'macos', 'unknown-platform'],
+    )
+    def test_collect_plan_dependency_commands(
+        self,
+        mocked_system: str,
+        expected_keys: set[str],
+        unexpected_keys: set[str],
+    ) -> None:
+        """Only common + current OS dependency commands are collected."""
         config: dict[str, Any] = {
             'dependencies': {
                 'common': ['pip install requests'],
+                'windows': ['winget install something'],
                 'linux': ['apt-get install -y curl'],
                 'macos': ['brew install wget'],
             },
@@ -10082,18 +10155,19 @@ class TestCollectInstallationPlan:
         chain = [setup_environment.InheritanceChainEntry(
             source='test', source_type='repo', name='test',
         )]
-        plan = setup_environment.collect_installation_plan(
-            config=config,
-            config_source='test',
-            config_name='test',
-            config_version=None,
-            inheritance_chain=chain,
-            args=self._make_args(),
-        )
-        assert 'common' in plan.dependency_commands
-        assert 'linux' in plan.dependency_commands
-        assert 'macos' in plan.dependency_commands
-        assert 'windows' not in plan.dependency_commands
+        with patch.object(setup_environment.platform, 'system', return_value=mocked_system):
+            plan = setup_environment.collect_installation_plan(
+                config=config,
+                config_source='test',
+                config_name='test',
+                config_version=None,
+                inheritance_chain=chain,
+                args=self._make_args(),
+            )
+        for key in expected_keys:
+            assert key in plan.dependency_commands, f'{key} should be in plan'
+        for key in unexpected_keys:
+            assert key not in plan.dependency_commands, f'{key} should NOT be in plan'
         assert plan.dependency_commands['common'] == ['pip install requests']
 
     def test_collect_plan_total_resources(self) -> None:


### PR DESCRIPTION
The installation summary displayed dependency commands for all platforms (common, windows, linux, macos) regardless of which OS the script runs on. Now collect_installation_plan() includes only common + current platform deps.

Extract PLATFORM_SYSTEM_TO_CONFIG_KEY module-level constant to replace duplicated platform_map dicts in collect_installation_plan(), install_dependencies(), and check_admin_needed().