### PR TITLE
Extend inherit to accept a list for composition chains

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ The setup script requires explicit user confirmation before installing. CLI flag
 
 ### Environment Configuration System
 
-YAML configs define complete environments: dependencies, agents, MCP servers (auto-permission), slash commands, system prompts (append/replace modes), hooks, global config (`~/.claude.json` via deep merge), and selective inheritance via `merge-keys` directive.
+YAML configs define complete environments: dependencies, agents, MCP servers (auto-permission), slash commands, system prompts (append/replace modes), hooks, global config (`~/.claude.json` via deep merge), and selective inheritance via `merge-keys` directive. `inherit` supports both single strings (`inherit: "base.yaml"`) and lists (`inherit: ["base.yaml", "lib.yaml"]`) for composition chains. List entries are composed left-to-right with replace semantics; only the leaf config's `merge-keys` applies to the final merge.
 
 **Env Loader Files:** `generate_env_loader_files()` creates Rustup-style shell scripts containing ONLY `os-env-variables` (not `env-variables`). Per-command files: `~/.claude/{cmd}/env.sh`, `env.fish` (if Fish installed), `env.ps1` (Windows), `env.cmd` (Windows). Global files: `~/.claude/toolbox-env.sh`, `toolbox-env.fish`, `toolbox-env.ps1` (Windows), `toolbox-env.cmd` (Windows). `None`-valued (deletion) vars are excluded. `create_launcher_script()` injects guarded source lines in all 6 launcher variants so commands auto-load env vars.
 

--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -137,7 +137,7 @@ Quick-reference table of all configuration keys. Each key links to its detailed 
 | [`description`](#description)                         | `str`                  | No       | `None`  | Config description (shown in summary)      |
 | [`post-install-notes`](#post-install-notes)           | `str`                  | No       | `None`  | Notes shown after successful installation  |
 | [`version`](#version)                                 | `str`                  | No       | `None`  | Config version (semver)                    |
-| [`inherit`](#inherit)                                 | `str`                  | No       | `None`  | Parent config URL/path/name                |
+| [`inherit`](#inherit)                                 | `str \| list[str]`     | No       | `None`  | Parent config URL/path/name or list        |
 | [`merge-keys`](#merge-keys)                           | `list[str]`            | No       | `None`  | Keys to merge instead of replace           |
 | [`command-names`](#command-names)                     | `list[str]`            | No*      | `[]`    | Command names and aliases                  |
 | [`base-url`](#base-url)                               | `str`                  | No       | `None`  | Base URL for relative resource paths       |
@@ -271,22 +271,29 @@ Base URL for resolving relative resource paths (agents, commands, skills, hooks,
 
 #### `inherit`
 
-URL, local path, or repository config name to inherit from. The child configuration overrides parent values at the top level by default. Use `merge-keys` to selectively merge specific keys instead of replacing them.
+URL, local path, repository config name, or a list of these to inherit from. The child configuration overrides parent values at the top level by default. Use `merge-keys` to selectively merge specific keys instead of replacing them.
 
-- **Type:** `str | None`
+- **Type:** `str | list[str] | None`
 - **Default:** `None`
-- **Validation:** Cannot be empty, no null bytes
-- **Max depth:** 10 levels
+- **Validation:** Cannot be empty string/list; no null bytes; list entries must be non-empty strings
+- **Max depth:** 10 levels (recursive resolution)
 - **Circular dependency detection:** Automatic
 - **Inheritance:** Not applicable (structural meta-key consumed during resolution)
-- **Example:**
+- **Examples:**
 
 ```yaml
+# Single source (backward compatible)
 inherit: "https://raw.githubusercontent.com/org/repo/main/base.yaml"
 # or
 inherit: "./base-config.yaml"
 # or
 inherit: "base-config"  # fetched from artifacts-public repo
+
+# Composition chain (list)
+inherit:
+  - "base-config.yaml"        # Base layer
+  - "library-config.yaml"     # Overrides base
+# File's own keys override everything above
 ```
 
 See [Configuration Inheritance](#configuration-inheritance) for details.
@@ -1138,6 +1145,7 @@ The `inherit` key allows a configuration to extend a parent configuration.
 
 - Child values completely **replace** parent values for the same top-level key by default
 - Use `merge-keys` to selectively **merge** (extend) specific keys instead of replacing them -- see [Selective Merge (merge-keys)](#selective-merge-merge-keys)
+- When `inherit` is a **list**, entries are composed left-to-right (first = base, each subsequent overrides). See [Composition Chain (List Inherit)](#composition-chain-list-inherit).
 - Maximum inheritance depth is 10 levels
 - Circular dependencies are detected automatically
 - The `version` key is extracted from the root config **before** inheritance resolution
@@ -1170,6 +1178,66 @@ agents:                       # Completely REPLACES parent's agents list
   - "agents/extra-agent.md"
 effort-level: "high"          # Added (not in parent)
 # model: "sonnet" is inherited from parent (not overridden)
+```
+
+#### Composition Chain (List Inherit)
+
+When `inherit` is a list, configurations are composed sequentially:
+
+1. The **first entry** is the base layer
+2. Each **subsequent entry** overrides the previous (replace semantics)
+3. The **file's own keys** are the final override
+
+This is analogous to TypeScript 5.0 `extends: [...]` and ESLint flat config.
+
+##### Semantics
+
+- **Inter-entry merges:** Plain REPLACE. No `merge-keys` between list entries.
+- **Per-entry inheritance:** Each list entry's own `inherit` and `merge-keys` are recursively resolved before the entry participates in the composition chain.
+- **Leaf `merge-keys`:** Applies ONLY to the final merge (accumulated chain result + leaf's own keys).
+- **Circular detection:** The `visited` set tracks all resolved sources across the entire composition.
+- **Depth counting:** Each entry resolves at `depth + 1` (entries are siblings, not a recursive chain).
+
+##### Example
+
+```yaml
+# corporate-base.yaml
+name: "Corporate Base"
+model: "sonnet"
+agents:
+  - "agents/compliance.md"
+```
+
+```yaml
+# aegis.yaml (library config, unchanged)
+inherit: "some-parent.yaml"
+merge-keys:
+  - agents
+  - mcp-servers
+# ... hundreds of lines of configuration ...
+```
+
+```yaml
+# my-environment.yaml (leaf config)
+inherit:
+  - "corporate-base.yaml"
+  - "aegis.yaml"
+merge-keys:
+  - agents
+name: "My Custom Environment"
+agents:
+  - "agents/my-extra-agent.md"
+# Result: corporate-base is the base, aegis.yaml overrides it (with its own
+# inheritance resolved first), then this file's agents are MERGED with the
+# accumulated agents list because merge-keys is specified.
+```
+
+##### Error Messages
+
+Error messages include the list index for debugging:
+
+```text
+Failed to load inherit[1]: aegis.yaml - File not found
 ```
 
 ### Selective Merge (`merge-keys`)

--- a/scripts/models/environment_config.py
+++ b/scripts/models/environment_config.py
@@ -743,10 +743,13 @@ class EnvironmentConfig(BaseModel):
         'Semantic versioning string (e.g., "1.0.0"). Optional; configs without '
         'this field skip all version checking.',
     )
-    inherit: str | None = Field(
+    inherit: str | list[str] | None = Field(
         None,
-        description='URL or path to parent configuration to inherit from. '
-        'Supports full URLs, local paths, or repository config names.',
+        description='URL, path, or list of URLs/paths to parent configurations to inherit from. '
+        'Supports full URLs, local paths, or repository config names. '
+        'When a list, configs are composed left-to-right: the first entry is the base, '
+        "each subsequent entry overrides the previous, and the file's own keys "
+        'are the final override.',
     )
     merge_keys: list[str] | None = Field(
         None,
@@ -920,21 +923,43 @@ class EnvironmentConfig(BaseModel):
 
     @field_validator('inherit')
     @classmethod
-    def validate_inherit(cls, v: str | None) -> str | None:
-        """Validate inherit path or URL format.
+    def validate_inherit(cls, v: str | list[str] | None) -> str | list[str] | None:
+        """Validate inherit path, URL, or list of paths/URLs.
+
+        Accepts a single string, a non-empty list of non-empty strings, or None.
+        Each entry must be a non-blank string without null bytes.
 
         Args:
-            v: Inherit path/URL string to validate.
+            v: Inherit value to validate.
 
         Returns:
             The validated inherit value.
 
         Raises:
-            ValueError: If inherit path is empty or contains null bytes.
+            ValueError: If inherit path is empty, contains null bytes,
+                list is empty, or list entries are invalid.
         """
         if v is None:
             return v
 
+        if isinstance(v, list):
+            if not v:
+                raise ValueError('inherit list cannot be empty')
+
+            for i, entry in enumerate(v):
+                if not isinstance(entry, str):
+                    raise ValueError(
+                        f'inherit[{i}] must be a string, '
+                        f'got {type(entry).__name__}',
+                    )
+                if not entry or not entry.strip():
+                    raise ValueError(f'inherit[{i}] cannot be empty string')
+                if '\x00' in entry:
+                    raise ValueError(f'inherit[{i}] cannot contain null bytes')
+
+            return v
+
+        # Single string validation (existing behavior)
         if not v or not v.strip():
             raise ValueError('inherit cannot be empty string')
 

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -4218,6 +4218,49 @@ def _merge_configs(
     return result
 
 
+def _validate_merge_keys(
+    merge_keys_value: object,
+) -> frozenset[str] | None:
+    """Validate and convert merge-keys from config to a frozenset.
+
+    Args:
+        merge_keys_value: Raw value from config's 'merge-keys' key.
+
+    Returns:
+        Validated frozenset of merge key names, or None if not specified.
+
+    Raises:
+        ValueError: If merge-keys is not a list of valid string key names.
+    """
+    if merge_keys_value is None:
+        return None
+
+    if not isinstance(merge_keys_value, list):
+        error(f"Invalid 'merge-keys' value: expected list, got {type(merge_keys_value).__name__}")
+        raise ValueError(
+            f"The 'merge-keys' key must be a list of strings, "
+            f"got {type(merge_keys_value).__name__}: {merge_keys_value!r}",
+        )
+
+    merge_keys_list = cast(list[object], merge_keys_value)
+
+    for i, entry in enumerate(merge_keys_list):
+        if not isinstance(entry, str):
+            error(f'Invalid merge-keys[{i}]: expected string, got {type(entry).__name__}')
+            raise ValueError(f'merge-keys[{i}] must be a string, got {type(entry).__name__}')
+
+    merge_keys_str = cast(list[str], merge_keys_list)
+    invalid_keys = [k for k in merge_keys_str if k not in MERGEABLE_CONFIG_KEYS]
+    if invalid_keys:
+        error(f'Invalid merge-keys: {invalid_keys}')
+        raise ValueError(
+            f'Invalid keys in merge-keys: {invalid_keys}. '
+            f'Valid mergeable keys: {sorted(MERGEABLE_CONFIG_KEYS)}',
+        )
+
+    return frozenset(merge_keys_str)
+
+
 def resolve_config_inheritance(
     config: dict[str, Any],
     source: str,
@@ -4228,60 +4271,32 @@ def resolve_config_inheritance(
 ) -> tuple[dict[str, Any], list[InheritanceChainEntry]]:
     """Resolve configuration inheritance by loading and merging parent configs.
 
-    Implements top-level key override semantics by default: child config values
-    completely replace parent values for the same key. When 'merge-keys' is
-    specified, listed keys are merged using type-aware strategies instead.
-
-    The inheritance chain is resolved recursively:
-    1. If config has 'inherit' key, load the parent config
-    2. If parent also has 'inherit', load its parent (recursive)
-    3. Merge configs from oldest ancestor to newest child
-    4. If 'merge-keys' is present, listed keys use merge instead of replace
+    Supports single-string inherit (backward compatible) and list-of-strings
+    inherit for composition chains. When inherit is a list, configs are composed
+    sequentially: the first entry is the base, each subsequent entry overrides
+    the previous, and the current config's own keys are the final override.
 
     Args:
         config: The configuration dictionary to resolve inheritance for.
         source: Source path/URL where this config was loaded from.
-            Used to resolve relative inherit paths.
         auth_param: Optional authentication parameter for private repositories.
-            Passed through the inheritance chain.
         visited: Set of already-visited sources for circular dependency detection.
-            Used internally for recursion tracking. Callers should not provide this.
         depth: Current recursion depth for safety limits.
-            Used internally. Callers should not provide this.
         chain: Accumulator for the inheritance chain entries.
-            Used internally. Callers should not provide this.
 
     Returns:
-        Tuple of (merged_config, inheritance_chain) where merged_config is the
-        configuration with inheritance resolved and inheritance_chain is the
-        list of InheritanceChainEntry from root ancestor to immediate parent.
+        Tuple of (merged_config, inheritance_chain).
 
     Raises:
-        ValueError: If circular dependency is detected, maximum inheritance
-            depth is exceeded, or inherit value is invalid.
-        FileNotFoundError: If parent config file not found (propagated from
-            load_config_from_source).
-
-    Examples:
-        >>> # Simple inheritance
-        >>> child = {'inherit': 'base.yaml', 'name': 'Child'}
-        >>> resolved, chain = resolve_config_inheritance(child, 'child.yaml')
-        >>> # resolved contains parent's keys + child's 'name' override
-
-        >>> # Chain: grandparent -> parent -> child
-        >>> child = {'inherit': 'parent.yaml', 'model': 'claude-3'}
-        >>> resolved, chain = resolve_config_inheritance(child, 'child.yaml')
-        >>> # resolved contains all ancestors' keys, child overrides take precedence
+        ValueError: If circular dependency detected, max depth exceeded,
+            or inherit value is invalid.
+        FileNotFoundError: If a parent config file is not found.
     """
-    # Initialize visited set for circular dependency detection
     if visited is None:
         visited = set()
-
-    # Initialize chain accumulator
     if chain is None:
         chain = []
 
-    # Check for maximum depth exceeded
     if depth > MAX_INHERITANCE_DEPTH:
         error(f'Maximum inheritance depth ({MAX_INHERITANCE_DEPTH}) exceeded')
         error('This may indicate a very deep inheritance chain or a logic error')
@@ -4290,7 +4305,6 @@ def resolve_config_inheritance(
             f'Check your configuration inheritance chain.',
         )
 
-    # Check if this config has inheritance
     inherit_value = config.get(INHERIT_KEY)
     if inherit_value is None:
         # Warn if merge-keys present without inherit
@@ -4299,113 +4313,114 @@ def resolve_config_inheritance(
                 "Warning: 'merge-keys' has no effect without 'inherit'. "
                 "Did you mean to add an 'inherit' key?",
             )
-        # No inheritance - return config as-is (without meta-keys)
         return {k: v for k, v in config.items() if k not in (INHERIT_KEY, MERGE_KEYS_KEY)}, chain
 
-    # Validate inherit value is a string
-    if not isinstance(inherit_value, str):
-        error(f"Invalid 'inherit' value: expected string, got {type(inherit_value).__name__}")
+    # Normalize to list for uniform processing
+    if isinstance(inherit_value, str):
+        inherit_list = [inherit_value]
+    elif isinstance(inherit_value, list):
+        if not inherit_value:
+            error("Empty 'inherit' list in configuration")
+            raise ValueError(
+                "The 'inherit' key must be a string or list of strings, "
+                f"got {type(inherit_value).__name__}: {inherit_value!r}",
+            )
+        # Defense-in-depth validation (Pydantic validates upstream)
+        for i, entry in enumerate(inherit_value):
+            if not isinstance(entry, str):
+                error(f'Invalid inherit[{i}]: expected string, got {type(entry).__name__}')
+                raise ValueError(
+                    f'inherit[{i}] must be a string, got {type(entry).__name__}: {entry!r}',
+                )
+        inherit_list = inherit_value
+    else:
+        error(f"Invalid 'inherit' value: expected string or list, got {type(inherit_value).__name__}")
         raise ValueError(
-            f"The 'inherit' key must be a string (URL or path), "
+            f"The 'inherit' key must be a string or list of strings, "
             f"got {type(inherit_value).__name__}: {inherit_value!r}",
         )
 
-    # Validate inherit value is not empty
-    inherit_value = inherit_value.strip()
-    if not inherit_value:
-        error("Empty 'inherit' value in configuration")
-        raise ValueError("The 'inherit' key cannot be empty")
+    # Validate no empty entries
+    for i, entry in enumerate(inherit_list):
+        stripped = entry.strip()
+        if not stripped:
+            idx_label = f'inherit[{i}]' if len(inherit_list) > 1 else 'inherit'
+            error(f"Empty '{idx_label}' value in configuration")
+            raise ValueError(f"The '{idx_label}' key cannot be empty")
 
-    # Resolve the parent path (could be URL, local path, or repo name)
-    parent_source = _resolve_inherit_path(inherit_value, source)
+    # Process each inherit entry sequentially to build the accumulated base
+    accumulated: dict[str, Any] | None = None
 
-    # Normalize source for circular dependency detection
-    normalized_source = _normalize_source_for_comparison(parent_source)
+    for i, entry in enumerate(inherit_list):
+        entry = entry.strip()
+        parent_source = _resolve_inherit_path(entry, source)
+        normalized_source = _normalize_source_for_comparison(parent_source)
 
-    # Check for circular dependency
-    if normalized_source in visited:
-        cycle_path = ' -> '.join(list(visited) + [normalized_source])
-        error('Circular dependency detected in configuration inheritance')
-        error(f'Cycle: {cycle_path}')
-        raise ValueError(
-            f'Circular dependency detected: {normalized_source} was already visited. '
-            f'Inheritance chain: {cycle_path}',
+        # Circular dependency check
+        if normalized_source in visited:
+            cycle_path = ' -> '.join(list(visited) + [normalized_source])
+            error('Circular dependency detected in configuration inheritance')
+            error(f'Cycle: {cycle_path}')
+            raise ValueError(
+                f'Circular dependency detected: {normalized_source} was already visited. '
+                f'Inheritance chain: {cycle_path}',
+            )
+
+        visited.add(normalized_source)
+
+        idx_label = f'inherit[{i}]' if len(inherit_list) > 1 else 'inherit'
+        info(f'Resolving inheritance from: {entry} ({idx_label})')
+
+        # Load the entry's config
+        try:
+            entry_config, actual_entry_source = load_config_from_source(
+                parent_source, auth_param,
+            )
+        except FileNotFoundError:
+            error(f'Failed to load {idx_label}: {entry} - File not found')
+            error(f'Resolved path: {parent_source}')
+            raise
+        except Exception as e:
+            error(f'Failed to load {idx_label}: {entry}')
+            error(f'Error: {e}')
+            raise
+
+        # Recursively resolve this entry's OWN inheritance
+        resolved_entry, chain = resolve_config_inheritance(
+            entry_config,
+            actual_entry_source,
+            auth_param=auth_param,
+            visited=visited,
+            depth=depth + 1,
+            chain=chain,
         )
 
-    # Add current source to visited set
-    visited.add(normalized_source)
+        # Append entry to the chain
+        chain.append(InheritanceChainEntry(
+            source=actual_entry_source,
+            source_type=classify_config_source(actual_entry_source),
+            name=entry_config.get('name', entry),
+        ))
 
-    # Log inheritance resolution
-    info(f'Resolving inheritance from: {inherit_value}')
+        # Compose: REPLACE semantics between list entries (no merge-keys)
+        accumulated = resolved_entry if accumulated is None else _merge_configs(accumulated, resolved_entry)
 
-    # Load parent configuration
-    try:
-        parent_config, actual_parent_source = load_config_from_source(
-            parent_source, auth_param,
-        )
-    except FileNotFoundError:
-        error(f'Parent configuration not found: {inherit_value}')
-        error(f'Resolved path: {parent_source}')
-        raise
-    except Exception as e:
-        error(f'Failed to load parent configuration: {inherit_value}')
-        error(f'Error: {e}')
-        raise
+        success(f'Inherited from: {entry} ({idx_label})')
 
-    # Recursively resolve parent's inheritance (chain accumulates ancestors)
-    resolved_parent, chain = resolve_config_inheritance(
-        parent_config,
-        actual_parent_source,
-        auth_param=auth_param,
-        visited=visited,
-        depth=depth + 1,
-        chain=chain,
-    )
-
-    # Append the parent entry to the chain after recursion resolves deeper ancestors
-    chain.append(InheritanceChainEntry(
-        source=actual_parent_source,
-        source_type=classify_config_source(actual_parent_source),
-        name=parent_config.get('name', inherit_value),
-    ))
-
-    # Extract and validate merge-keys from child config
+    # Merge the accumulated base with the leaf config's own keys
+    # Leaf's merge-keys applies ONLY to this final merge
     merge_keys_value = config.get(MERGE_KEYS_KEY)
-    validated_merge_keys: frozenset[str] | None = None
+    validated_merge_keys = _validate_merge_keys(merge_keys_value)
 
-    if merge_keys_value is not None:
-        if not isinstance(merge_keys_value, list):
-            error(f"Invalid 'merge-keys' value: expected list, got {type(merge_keys_value).__name__}")
-            raise ValueError(
-                f"The 'merge-keys' key must be a list of strings, "
-                f"got {type(merge_keys_value).__name__}: {merge_keys_value!r}",
-            )
+    if accumulated is None:
+        accumulated = {}
 
-        # Cast to list[object] after isinstance narrowing
-        merge_keys_list = cast(list[object], merge_keys_value)
+    merged = _merge_configs(accumulated, config, merge_keys=validated_merge_keys)
 
-        # Validate all entries are strings
-        for i, entry in enumerate(merge_keys_list):
-            if not isinstance(entry, str):
-                error(f'Invalid merge-keys[{i}]: expected string, got {type(entry).__name__}')
-                raise ValueError(f'merge-keys[{i}] must be a string, got {type(entry).__name__}')
-
-        # Validate entries against MERGEABLE_CONFIG_KEYS
-        merge_keys_str = cast(list[str], merge_keys_list)
-        invalid_keys = [k for k in merge_keys_str if k not in MERGEABLE_CONFIG_KEYS]
-        if invalid_keys:
-            error(f'Invalid merge-keys: {invalid_keys}')
-            raise ValueError(
-                f'Invalid keys in merge-keys: {invalid_keys}. '
-                f'Valid mergeable keys: {sorted(MERGEABLE_CONFIG_KEYS)}',
-            )
-
-        validated_merge_keys = frozenset(merge_keys_str)
-
-    # Merge: parent first, then child overrides
-    merged = _merge_configs(resolved_parent, config, merge_keys=validated_merge_keys)
-
-    success(f'Inherited from: {inherit_value}')
+    if len(inherit_list) == 1:
+        success(f'Inherited from: {inherit_list[0]}')
+    else:
+        success(f'Composed from {len(inherit_list)} sources')
 
     return merged, chain
 

--- a/tests/e2e/fixtures/list_inherit_base.yaml
+++ b/tests/e2e/fixtures/list_inherit_base.yaml
@@ -1,0 +1,6 @@
+name: "List Inherit Base"
+model: "sonnet"
+agents:
+  - "agents/base-agent.md"
+env-variables:
+  BASE_VAR: "from-base"

--- a/tests/e2e/fixtures/list_inherit_leaf.yaml
+++ b/tests/e2e/fixtures/list_inherit_leaf.yaml
@@ -1,0 +1,6 @@
+name: "List Inherit Leaf"
+inherit:
+  - list_inherit_base.yaml
+  - list_inherit_middle.yaml
+env-variables:
+  LEAF_VAR: "from-leaf"

--- a/tests/e2e/fixtures/list_inherit_middle.yaml
+++ b/tests/e2e/fixtures/list_inherit_middle.yaml
@@ -1,0 +1,6 @@
+name: "List Inherit Middle"
+agents:
+  - "agents/middle-agent.md"
+env-variables:
+  MIDDLE_VAR: "from-middle"
+  BASE_VAR: "overridden-by-middle"

--- a/tests/e2e/fixtures/list_inherit_with_merge.yaml
+++ b/tests/e2e/fixtures/list_inherit_with_merge.yaml
@@ -1,0 +1,11 @@
+name: "List Inherit With Merge"
+inherit:
+  - list_inherit_base.yaml
+  - list_inherit_middle.yaml
+merge-keys:
+  - agents
+  - env-variables
+env-variables:
+  LEAF_VAR: "from-leaf"
+agents:
+  - "agents/leaf-agent.md"

--- a/tests/e2e/test_list_inherit.py
+++ b/tests/e2e/test_list_inherit.py
@@ -1,0 +1,127 @@
+"""E2E tests for list-based inherit (composition chains).
+
+Tests verify that configuration inheritance with a list of sources composes
+configs sequentially: first entry is the base, each subsequent entry overrides
+the previous, and the leaf's own keys are the final override. Leaf merge-keys
+applies only to the final merge step.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts import setup_environment
+
+
+def _fixtures_dir() -> Path:
+    """Return the path to E2E fixtures directory."""
+    return Path(__file__).parent / 'fixtures'
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    """Load a YAML file and return its content."""
+    with path.open('r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+
+def _resolve(
+    config: dict[str, Any],
+    source: str,
+) -> tuple[dict[str, Any], list[setup_environment.InheritanceChainEntry]]:
+    """Resolve config inheritance from a source path."""
+    return setup_environment.resolve_config_inheritance(config, source)
+
+
+class TestListInheritBasicComposition:
+    """Test basic list inherit composition with real fixture files."""
+
+    def test_model_inherited_from_base(self):
+        """Model comes from base (not overridden by middle or leaf)."""
+        leaf_path = _fixtures_dir() / 'list_inherit_leaf.yaml'
+        config = _load_yaml(leaf_path)
+        resolved, _ = _resolve(config, str(leaf_path))
+        assert resolved['model'] == 'sonnet'
+
+    def test_agents_replaced_by_middle(self):
+        """Agents from middle replace base agents (inter-entry replace)."""
+        leaf_path = _fixtures_dir() / 'list_inherit_leaf.yaml'
+        config = _load_yaml(leaf_path)
+        resolved, _ = _resolve(config, str(leaf_path))
+        assert resolved['agents'] == ['agents/middle-agent.md']
+
+    def test_env_variables_replaced_by_leaf(self):
+        """Leaf env-variables replaces accumulated (no merge-keys)."""
+        leaf_path = _fixtures_dir() / 'list_inherit_leaf.yaml'
+        config = _load_yaml(leaf_path)
+        resolved, _ = _resolve(config, str(leaf_path))
+        env = resolved['env-variables']
+        # Leaf's env-variables replaces the accumulated base+middle entirely
+        assert env == {'LEAF_VAR': 'from-leaf'}
+        assert 'BASE_VAR' not in env
+        assert 'MIDDLE_VAR' not in env
+
+    def test_name_from_leaf(self):
+        """Name comes from leaf (final override)."""
+        leaf_path = _fixtures_dir() / 'list_inherit_leaf.yaml'
+        config = _load_yaml(leaf_path)
+        resolved, _ = _resolve(config, str(leaf_path))
+        assert resolved['name'] == 'List Inherit Leaf'
+
+    def test_meta_keys_stripped(self):
+        """inherit and merge-keys are stripped from resolved config."""
+        leaf_path = _fixtures_dir() / 'list_inherit_leaf.yaml'
+        config = _load_yaml(leaf_path)
+        resolved, _ = _resolve(config, str(leaf_path))
+        assert 'inherit' not in resolved
+        assert 'merge-keys' not in resolved
+
+    def test_chain_length(self):
+        """Inheritance chain contains both base and middle entries."""
+        leaf_path = _fixtures_dir() / 'list_inherit_leaf.yaml'
+        config = _load_yaml(leaf_path)
+        _, chain = _resolve(config, str(leaf_path))
+        assert len(chain) == 2
+
+
+class TestListInheritWithLeafMergeKeys:
+    """Test list inherit with leaf-level merge-keys."""
+
+    def test_agents_merged_across_chain(self):
+        """Agents are MERGED (not replaced) because leaf declares merge-keys."""
+        leaf_path = _fixtures_dir() / 'list_inherit_with_merge.yaml'
+        config = _load_yaml(leaf_path)
+        resolved, _ = _resolve(config, str(leaf_path))
+        agents = resolved['agents']
+        # Between base and middle: REPLACE (inter-entry, no merge-keys)
+        # So accumulated agents = ['agents/middle-agent.md']
+        # Final merge with leaf: MERGE (leaf has merge-keys: [agents])
+        assert 'agents/middle-agent.md' in agents
+        assert 'agents/leaf-agent.md' in agents
+        # Base agent was replaced by middle (not merged)
+        assert 'agents/base-agent.md' not in agents
+
+    def test_env_variables_merged(self):
+        """Env-variables are MERGED because leaf declares merge-keys."""
+        leaf_path = _fixtures_dir() / 'list_inherit_with_merge.yaml'
+        config = _load_yaml(leaf_path)
+        resolved, _ = _resolve(config, str(leaf_path))
+        env = resolved['env-variables']
+        # Accumulated from base+middle (replace): BASE_VAR=overridden, MIDDLE_VAR=from-middle
+        # Leaf merges: LEAF_VAR=from-leaf added
+        assert env['BASE_VAR'] == 'overridden-by-middle'
+        assert env['MIDDLE_VAR'] == 'from-middle'
+        assert env['LEAF_VAR'] == 'from-leaf'
+
+
+class TestListInheritChainDisplay:
+    """Test that inheritance chain entries are present for display in summary."""
+
+    def test_chain_entries_have_names(self):
+        """Chain entries carry the config name for display."""
+        leaf_path = _fixtures_dir() / 'list_inherit_leaf.yaml'
+        config = _load_yaml(leaf_path)
+        _, chain = _resolve(config, str(leaf_path))
+        names = [entry.name for entry in chain]
+        assert 'List Inherit Base' in names
+        assert 'List Inherit Middle' in names

--- a/tests/scripts/models/test_environment_config.py
+++ b/tests/scripts/models/test_environment_config.py
@@ -1482,3 +1482,93 @@ class TestMergeKeysField:
                 'name': 'Test',
                 'merge-keys': ['agents', 'model', 'name'],
             })
+
+
+class TestInheritField:
+    """Tests for the inherit field in EnvironmentConfig."""
+
+    def test_inherit_single_string(self) -> None:
+        """Field accepts a single string path."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'inherit': 'base.yaml',
+        })
+        assert config.inherit == 'base.yaml'
+
+    def test_inherit_list_of_strings(self) -> None:
+        """Field accepts a list of string paths."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'inherit': ['a.yaml', 'b.yaml'],
+        })
+        assert config.inherit == ['a.yaml', 'b.yaml']
+
+    def test_inherit_single_element_list(self) -> None:
+        """Single-element list is accepted without normalization to string."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'inherit': ['a.yaml'],
+        })
+        assert config.inherit == ['a.yaml']
+        assert isinstance(config.inherit, list)
+
+    def test_inherit_none_default(self) -> None:
+        """Default value is None when not provided."""
+        config = EnvironmentConfig.model_validate({'name': 'Test'})
+        assert config.inherit is None
+
+    def test_inherit_empty_string_rejected(self) -> None:
+        """Empty string is rejected."""
+        with pytest.raises(ValidationError, match='inherit cannot be empty string'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'inherit': '',
+            })
+
+    def test_inherit_empty_list_rejected(self) -> None:
+        """Empty list is rejected."""
+        with pytest.raises(ValidationError, match='inherit list cannot be empty'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'inherit': [],
+            })
+
+    def test_inherit_list_with_empty_string_rejected(self) -> None:
+        """List containing an empty string is rejected with index."""
+        with pytest.raises(ValidationError, match=r'inherit\[1\] cannot be empty string'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'inherit': ['a.yaml', ''],
+            })
+
+    def test_inherit_list_with_null_bytes_rejected(self) -> None:
+        """List containing a string with null bytes is rejected."""
+        with pytest.raises(ValidationError, match=r'inherit\[0\] cannot contain null bytes'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'inherit': ['a\x00b'],
+            })
+
+    def test_inherit_list_with_non_string_rejected(self) -> None:
+        """List containing a non-string entry is rejected."""
+        with pytest.raises(ValidationError, match='Input should be a valid string'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'inherit': [123],
+            })
+
+    def test_inherit_whitespace_string_rejected(self) -> None:
+        """Whitespace-only string is rejected."""
+        with pytest.raises(ValidationError, match='inherit cannot be empty string'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'inherit': '   ',
+            })
+
+    def test_inherit_list_with_whitespace_entry_rejected(self) -> None:
+        """List containing a whitespace-only entry is rejected."""
+        with pytest.raises(ValidationError, match=r'inherit\[1\] cannot be empty string'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'inherit': ['a.yaml', '   '],
+            })

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -7076,11 +7076,11 @@ class TestConfigInheritance:
                 setup_environment.resolve_config_inheritance(config, 'start.yaml')
 
     def test_invalid_inherit_value_not_string(self):
-        """Test error when inherit value is not a string."""
-        config = {'inherit': ['parent.yaml'], 'name': 'Test'}  # List instead of string
+        """Test error when inherit value is not a string or list."""
+        config = {'inherit': 123, 'name': 'Test'}  # Integer instead of string or list
         import pytest
 
-        with pytest.raises(ValueError, match='must be a string'):
+        with pytest.raises(ValueError, match='must be a string or list of strings'):
             setup_environment.resolve_config_inheritance(config, 'test.yaml')
 
     def test_invalid_inherit_value_dict(self):
@@ -7088,7 +7088,7 @@ class TestConfigInheritance:
         config = {'inherit': {'source': 'parent.yaml'}, 'name': 'Test'}
         import pytest
 
-        with pytest.raises(ValueError, match='must be a string'):
+        with pytest.raises(ValueError, match='must be a string or list of strings'):
             setup_environment.resolve_config_inheritance(config, 'test.yaml')
 
     def test_empty_inherit_value(self):
@@ -7241,6 +7241,232 @@ agents:
             assert resolved['agents'] == ['my-agent.md']  # From child
             assert resolved['dependencies'] == {'common': ['pip install base']}  # From grandparent
             assert 'inherit' not in resolved
+
+    # --- List inherit tests ---
+
+    @patch('setup_environment.load_config_from_source')
+    def test_list_inherit_two_sources(self, mock_load: MagicMock) -> None:
+        """Two-source list: first is base, second overrides, leaf overrides both."""
+        mock_load.side_effect = [
+            ({'name': 'Base', 'model': 'sonnet', 'agents': ['a.md']}, '/path/base.yaml'),
+            ({'name': 'Middle', 'agents': ['b.md']}, '/path/middle.yaml'),
+        ]
+
+        child: dict[str, Any] = {
+            'inherit': ['base.yaml', 'middle.yaml'],
+            'name': 'Leaf',
+        }
+
+        result, chain = setup_environment.resolve_config_inheritance(child, '/path/leaf.yaml')
+
+        assert result['name'] == 'Leaf'
+        assert result['model'] == 'sonnet'
+        assert result['agents'] == ['b.md']
+        assert len(chain) == 2
+
+    @patch('setup_environment.load_config_from_source')
+    def test_list_inherit_three_sources(self, mock_load: MagicMock) -> None:
+        """Three-source list: sequential override chain."""
+        mock_load.side_effect = [
+            ({'name': 'A', 'x': 1, 'y': 2, 'z': 3}, '/path/a.yaml'),
+            ({'name': 'B', 'y': 20}, '/path/b.yaml'),
+            ({'name': 'C', 'z': 300}, '/path/c.yaml'),
+        ]
+
+        child: dict[str, Any] = {
+            'inherit': ['a.yaml', 'b.yaml', 'c.yaml'],
+        }
+
+        result, chain = setup_environment.resolve_config_inheritance(child, '/path/leaf.yaml')
+
+        assert result['name'] == 'C'
+        assert result['x'] == 1
+        assert result['y'] == 20
+        assert result['z'] == 300
+        assert len(chain) == 3
+
+    @patch('setup_environment.load_config_from_source')
+    def test_list_inherit_single_element(self, mock_load: MagicMock) -> None:
+        """Single-element list works identically to a string inherit."""
+        mock_load.return_value = ({'name': 'Parent', 'model': 'opus'}, '/path/parent.yaml')
+
+        child: dict[str, Any] = {
+            'inherit': ['parent.yaml'],
+            'name': 'Child',
+        }
+
+        result, chain = setup_environment.resolve_config_inheritance(child, '/path/child.yaml')
+
+        assert result['name'] == 'Child'
+        assert result['model'] == 'opus'
+        assert len(chain) == 1
+
+    def test_list_inherit_empty_raises(self) -> None:
+        """Empty list raises ValueError."""
+        child: dict[str, Any] = {'inherit': [], 'name': 'Child'}
+
+        with pytest.raises(ValueError, match='string or list of strings'):
+            setup_environment.resolve_config_inheritance(child, '/path/child.yaml')
+
+    def test_list_inherit_invalid_entry_type(self) -> None:
+        """Non-string entry in list raises ValueError."""
+        child: dict[str, Any] = {'inherit': [123], 'name': 'Child'}
+
+        with pytest.raises(ValueError, match='inherit\\[0\\] must be a string'):
+            setup_environment.resolve_config_inheritance(child, '/path/child.yaml')
+
+    def test_list_inherit_empty_entry(self) -> None:
+        """Empty string entry in list raises ValueError with index."""
+        child: dict[str, Any] = {'inherit': ['a.yaml', ''], 'name': 'Child'}
+
+        with pytest.raises(ValueError, match='inherit\\[1\\].*cannot be empty'):
+            setup_environment.resolve_config_inheritance(child, '/path/child.yaml')
+
+    @patch('setup_environment.load_config_from_source')
+    def test_list_inherit_circular_dependency(self, mock_load: MagicMock) -> None:
+        """Circular dependency across list entries detected."""
+        mock_load.side_effect = [
+            ({'name': 'A', 'inherit': 'b.yaml'}, '/path/a.yaml'),
+            ({'name': 'B'}, '/path/b.yaml'),
+        ]
+
+        # b.yaml is in list AND also inherited by a.yaml
+        child: dict[str, Any] = {'inherit': ['a.yaml', 'b.yaml'], 'name': 'Leaf'}
+
+        with pytest.raises(ValueError, match='Circular dependency'):
+            setup_environment.resolve_config_inheritance(child, '/path/leaf.yaml')
+
+    @patch('setup_environment.load_config_from_source')
+    def test_list_inherit_depth_exceeded(self, mock_load: MagicMock) -> None:
+        """Depth exceeding MAX_INHERITANCE_DEPTH raises ValueError."""
+        # Create a chain deeper than MAX_INHERITANCE_DEPTH
+        def deep_chain(source: str, _auth: str | None = None) -> tuple[dict[str, Any], str]:
+            # Each config inherits from a deeper one
+            depth_num = int(source.split('_')[-1].replace('.yaml', ''))
+            if depth_num > 0:
+                return (
+                    {'name': f'Config_{depth_num}', 'inherit': f'config_{depth_num - 1}.yaml'},
+                    source,
+                )
+            return ({'name': 'Config_0'}, source)
+
+        mock_load.side_effect = deep_chain
+
+        child: dict[str, Any] = {'inherit': ['config_15.yaml'], 'name': 'Leaf'}
+
+        with pytest.raises(ValueError, match='Maximum inheritance depth'):
+            setup_environment.resolve_config_inheritance(child, '/path/leaf.yaml')
+
+    @patch('setup_environment.load_config_from_source')
+    def test_list_inherit_merge_keys_leaf_only(self, mock_load: MagicMock) -> None:
+        """Leaf merge-keys applies only to the final merge, not between entries."""
+        mock_load.side_effect = [
+            ({'name': 'Base', 'agents': ['base.md']}, '/path/base.yaml'),
+            ({'name': 'Middle', 'agents': ['middle.md']}, '/path/middle.yaml'),
+        ]
+
+        child: dict[str, Any] = {
+            'inherit': ['base.yaml', 'middle.yaml'],
+            'merge-keys': ['agents'],
+            'agents': ['leaf.md'],
+        }
+
+        result, _chain = setup_environment.resolve_config_inheritance(child, '/path/leaf.yaml')
+
+        # Between base and middle: REPLACE (no merge-keys)
+        # So accumulated agents = ['middle.md'] after composing base+middle
+        # Final merge with leaf: MERGE (leaf declares merge-keys: [agents])
+        # So final agents = ['middle.md', 'leaf.md']
+        assert 'base.md' not in result['agents']
+        assert 'middle.md' in result['agents']
+        assert 'leaf.md' in result['agents']
+
+    @patch('setup_environment.load_config_from_source')
+    def test_list_inherit_entry_has_own_inheritance(self, mock_load: MagicMock) -> None:
+        """Entry with its own inherit is recursively resolved before composing."""
+        mock_load.side_effect = [
+            # First entry (base.yaml) has its own parent
+            ({'name': 'Base', 'inherit': 'grandparent.yaml', 'agents': ['base.md']}, '/path/base.yaml'),
+            # Grandparent loaded during base resolution
+            ({'name': 'Grandparent', 'model': 'opus', 'agents': ['gp.md']}, '/path/grandparent.yaml'),
+            # Second entry (middle.yaml) has no parent
+            ({'name': 'Middle', 'agents': ['middle.md']}, '/path/middle.yaml'),
+        ]
+
+        child: dict[str, Any] = {
+            'inherit': ['base.yaml', 'middle.yaml'],
+            'name': 'Leaf',
+        }
+
+        result, chain = setup_environment.resolve_config_inheritance(child, '/path/leaf.yaml')
+
+        # Grandparent's model survives through base resolution
+        assert result['model'] == 'opus'
+        # Middle replaces base's agents (inter-entry replace)
+        assert result['agents'] == ['middle.md']
+        assert result['name'] == 'Leaf'
+        # Chain: grandparent, base, middle
+        assert len(chain) == 3
+
+    @patch('setup_environment.load_config_from_source')
+    def test_list_inherit_inter_entry_replace_semantics(self, mock_load: MagicMock) -> None:
+        """No merge-keys between list entries, even when entry declares merge-keys."""
+        mock_load.side_effect = [
+            (
+                {
+                    'name': 'Base',
+                    'agents': ['base.md'],
+                    'merge-keys': ['agents'],
+                },
+                '/path/base.yaml',
+            ),
+            ({'name': 'Middle', 'agents': ['middle.md']}, '/path/middle.yaml'),
+        ]
+
+        child: dict[str, Any] = {
+            'inherit': ['base.yaml', 'middle.yaml'],
+            'name': 'Leaf',
+        }
+
+        result, _chain = setup_environment.resolve_config_inheritance(child, '/path/leaf.yaml')
+
+        # Base's merge-keys is consumed during its own resolution (it has no parent),
+        # so inter-entry merge between base and middle uses REPLACE
+        assert result['agents'] == ['middle.md']
+
+    @patch('setup_environment.load_config_from_source')
+    def test_list_inherit_error_message_includes_index(self, mock_load: MagicMock) -> None:
+        """Error message includes list index when second entry fails to load."""
+        mock_load.side_effect = [
+            ({'name': 'Base'}, '/path/base.yaml'),
+            FileNotFoundError('not found'),
+        ]
+
+        child: dict[str, Any] = {'inherit': ['base.yaml', 'missing.yaml'], 'name': 'Leaf'}
+
+        with pytest.raises(FileNotFoundError):
+            setup_environment.resolve_config_inheritance(child, '/path/leaf.yaml')
+
+    @patch('setup_environment.load_config_from_source')
+    def test_list_inherit_chain_entries_accumulated(self, mock_load: MagicMock) -> None:
+        """InheritanceChainEntry list contains all resolved entries in order."""
+        mock_load.side_effect = [
+            ({'name': 'Alpha'}, '/path/alpha.yaml'),
+            ({'name': 'Beta'}, '/path/beta.yaml'),
+            ({'name': 'Gamma'}, '/path/gamma.yaml'),
+        ]
+
+        child: dict[str, Any] = {
+            'inherit': ['alpha.yaml', 'beta.yaml', 'gamma.yaml'],
+            'name': 'Leaf',
+        }
+
+        _result, chain = setup_environment.resolve_config_inheritance(child, '/path/leaf.yaml')
+
+        assert len(chain) == 3
+        assert chain[0].name == 'Alpha'
+        assert chain[1].name == 'Beta'
+        assert chain[2].name == 'Gamma'
 
 
 class TestVersionInheritance:


### PR DESCRIPTION
Allow the inherit configuration key to accept a list of sources in addition to a single string, enabling multi-source composition chains where configs are merged sequentially left-to-right. Each list entry is resolved recursively before participating in the chain, with inter-entry merges using replace semantics and only the leaf config merge-keys applying to the final merge.