### PR TITLE
Add per-entry merge-keys control for list-based inheritance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,13 +71,14 @@ The setup script requires explicit user confirmation before installing. CLI flag
 
 YAML configs define complete environments: dependencies, agents, MCP servers (auto-permission), slash commands, system prompts (append/replace modes), hooks, global config (`~/.claude.json` via deep merge), and selective inheritance via `merge-keys` directive.
 
-**List Inherit (`inherit: [list]`):** `inherit` accepts `str | list[str] | None`. Single-element lists normalize to string (recursive resolution -- the entry's own `inherit` IS resolved). Multi-element lists use flat left-to-right composition via `_resolve_list_inherit()`. Three mandatory rules:
+**List Inherit (`inherit: [list]`):** `inherit` accepts `str | list[str | InheritEntry] | None`. Single-element plain-string lists normalize to string (recursive resolution -- the entry's own `inherit` IS resolved). Single-element structured lists (`[{config: ..., merge-keys: [...]}]`) route to `_resolve_list_inherit()` (composition mode). Multi-element lists use flat left-to-right composition via `_resolve_list_inherit()`. Four mandatory rules:
 
-1. **Own inherit stripped (Rule 1):** Each listed file's own `inherit` key is completely ignored when the list has >1 entries. Users must explicitly include all configs in the desired order.
+1. **Own inherit stripped (Rule 1):** Each listed file's own `inherit` key is completely ignored in list composition mode. Users must explicitly include all configs in the desired order.
 2. **Separate-file equivalence (Rule 2):** `inherit: [A, B, C]` behaves identically to a virtual chain where C inherits B which inherits A. First entry = base (lowest priority), last entry overrides earlier ones, leaf overrides everything.
-3. **merge-keys per entry (Rule 3):** Each file's `merge-keys` applies normally at its composition step, as if it were a separate file with single-value inherit.
+3. **Own merge-keys stripped, per-entry from leaf (Rule 3):** Each listed file's own `merge-keys` key is stripped and ignored. Per-entry merge-keys are specified in the leaf config using structured `{config: ..., merge-keys: [...]}` entries. merge-keys are a property of the relationship between the leaf and each listed entry, not an intrinsic property of the listed config.
+4. **Leaf merge-keys for final step (Rule 4):** The leaf config's top-level `merge-keys` applies to the final composition step (leaf on top of accumulated base). Orthogonal to per-entry merge-keys.
 
-`_validate_merge_keys()` is a DRY helper extracted from the former inline validation, reused for both leaf and per-entry merge-keys validation. `_resolve_list_inherit()` threads `auth_param` through `load_config_from_source()` for each entry, extends the existing `visited` set for circular dependency detection, and builds `InheritanceChainEntry` entries for each loaded config.
+`_validate_merge_keys()` is a DRY helper extracted from the former inline validation, reused for both leaf and per-entry merge-keys validation. `InheritEntry` is a Pydantic model (`config: str`, `merge_keys: list[str] | None` with alias `merge-keys`, `extra='forbid'`) containing an inline `mergeable` frozenset (DRY violation covered by parity test `test_mergeable_config_keys_parity.py`). `_resolve_list_inherit()` threads `auth_param` through `load_config_from_source()` for each entry, extends the existing `visited` set for circular dependency detection, and builds `InheritanceChainEntry` entries for each loaded config.
 
 **Env Loader Files:** `generate_env_loader_files()` creates Rustup-style shell scripts containing ONLY `os-env-variables` (not `env-variables`). Per-command files: `~/.claude/{cmd}/env.sh`, `env.fish` (if Fish installed), `env.ps1` (Windows), `env.cmd` (Windows). Global files: `~/.claude/toolbox-env.sh`, `toolbox-env.fish`, `toolbox-env.ps1` (Windows), `toolbox-env.cmd` (Windows). `None`-valued (deletion) vars are excluded. `create_launcher_script()` injects guarded source lines in all 6 launcher variants so commands auto-load env vars.
 
@@ -125,7 +126,7 @@ Pydantic schema `EnvironmentConfig` in `scripts/models/environment_config.py` de
 
 **KNOWN_CONFIG_KEYS parity rule:** When adding new config keys to `setup_environment.py` (extending `KNOWN_CONFIG_KEYS`), the `EnvironmentConfig` model MUST be updated simultaneously (and vice versa). `tests/scripts/models/test_known_config_keys_parity.py` enforces STRICT BIDIRECTIONAL match with ZERO exceptions. Deprecated keys must be DELETED from both, not kept with backward compatibility shims.
 
-**Tests:** `tests/scripts/models/` -- `test_environment_config.py`, `test_mcp_server_scope.py`, `test_known_config_keys_parity.py`.
+**Tests:** `tests/scripts/models/` -- `test_environment_config.py`, `test_mcp_server_scope.py`, `test_known_config_keys_parity.py`, `test_mergeable_config_keys_parity.py`.
 
 **Sync & Runtime:** `.github/workflows/sync-to-repos.yml` syncs model changes to `alex-feel/claude-code-artifacts{,-public}` at `.github/environment_config.py`. The model is NOT imported at runtime -- `KNOWN_CONFIG_KEYS` is the active runtime mechanism.
 

--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -137,7 +137,7 @@ Quick-reference table of all configuration keys. Each key links to its detailed 
 | [`description`](#description)                         | `str`                  | No       | `None`  | Config description (shown in summary)                      |
 | [`post-install-notes`](#post-install-notes)           | `str`                  | No       | `None`  | Notes shown after successful installation                  |
 | [`version`](#version)                                 | `str`                  | No       | `None`  | Config version (semver)                                    |
-| [`inherit`](#inherit)                                 | `str \| list[str]`     | No       | `None`  | Parent config URL/path/name or list for composition chains |
+| [`inherit`](#inherit)                                 | `str \| list`          | No       | `None`  | Parent config URL/path/name or list for composition chains |
 | [`merge-keys`](#merge-keys)                           | `list[str]`            | No       | `None`  | Keys to merge instead of replace                           |
 | [`command-names`](#command-names)                     | `list[str]`            | No*      | `[]`    | Command names and aliases                                  |
 | [`base-url`](#base-url)                               | `str`                  | No       | `None`  | Base URL for relative resource paths                       |
@@ -271,13 +271,13 @@ Base URL for resolving relative resource paths (agents, commands, skills, hooks,
 
 #### `inherit`
 
-URL, local path, or repository config name to inherit from. Accepts a single string or a list of strings for composition chains.
+URL, local path, or repository config name to inherit from. Accepts a single string or a list of strings/structured objects for composition chains.
 
-- **Type:** `str | list[str] | None`
+- **Type:** `str | list[str | {config: str, merge-keys: list[str]}] | None`
 - **Default:** `None`
 - **Single string:** Standard recursive inheritance (child overrides parent). Use `merge-keys` to selectively merge.
-- **List of strings:** Flat composition chain (left-to-right). Each entry's own `inherit` is stripped. Each entry's `merge-keys` applies normally. See [List Inherit (Composition Chains)](#list-inherit-composition-chains).
-- **Validation:** Cannot be empty, no null bytes. Lists must be non-empty with all entries as non-empty, non-blank strings.
+- **List of strings/objects:** Flat composition chain (left-to-right). Each entry's own `inherit` and `merge-keys` are stripped. Per-entry merge-keys specified via structured `{config: ..., merge-keys: [...]}` entries in the leaf. See [List Inherit (Composition Chains)](#list-inherit-composition-chains).
+- **Validation:** Cannot be empty, no null bytes. Lists must be non-empty with all entries as non-empty strings or valid structured objects.
 - **Max depth:** 10 levels
 - **Circular dependency detection:** Automatic
 - **Inheritance:** Not applicable (structural meta-key consumed during resolution)
@@ -295,6 +295,14 @@ inherit: "base-config"  # fetched from artifacts-public repo
 inherit:
   - base.yaml
   - extensions.yaml
+
+# List with per-entry merge-keys (structured entries)
+inherit:
+  - base.yaml
+  - config: extensions.yaml
+    merge-keys:
+      - agents
+      - rules
 ```
 
 See [Configuration Inheritance](#configuration-inheritance) for details.
@@ -1140,7 +1148,7 @@ hooks:
 
 ### Configuration Inheritance
 
-The `inherit` key allows a configuration to extend a parent configuration. It accepts a single string for standard recursive inheritance or a list of strings for explicit composition chains (see [List Inherit (Composition Chains)](#list-inherit-composition-chains)).
+The `inherit` key allows a configuration to extend a parent configuration. It accepts a single string for standard recursive inheritance or a list of strings/structured objects for explicit composition chains (see [List Inherit (Composition Chains)](#list-inherit-composition-chains)).
 
 #### How Inheritance Works
 
@@ -1182,11 +1190,11 @@ effort-level: "high"          # Added (not in parent)
 
 ### List Inherit (Composition Chains)
 
-The `inherit` key also accepts a list of configuration paths for explicit composition chains. Three mandatory rules govern list inherit behavior:
+The `inherit` key also accepts a list of configuration paths for explicit composition chains. The list may contain plain strings (backward compatible) and structured objects with per-entry merge-keys. Four mandatory rules govern list inherit behavior:
 
 #### Rule 1: Own inherit stripped
 
-When `inherit` is a list with more than one entry, each listed file's own `inherit` key is **completely ignored**. It does not participate in chain resolution. The user explicitly specifies the full chain in one place -- if additional parent files are needed, they must be added to the list in the correct order.
+Each listed file's own `inherit` key is **completely ignored** in list composition mode. It does not participate in chain resolution. The user explicitly specifies the full chain in one place -- if additional parent files are needed, they must be added to the list in the correct order.
 
 #### Rule 2: Equivalent to separate-file chains
 
@@ -1197,9 +1205,63 @@ When `inherit` is a list with more than one entry, each listed file's own `inher
 
 Resolution order is left-to-right: the first entry is the base (lowest priority), subsequent entries override earlier ones, and the leaf config overrides everything.
 
-#### Rule 3: merge-keys per entry
+#### Rule 3: Own merge-keys stripped, per-entry from leaf
 
-Each file in the list can declare its own `merge-keys`, which applies normally at its composition step, as if it were a separate file with single-value inherit.
+Each listed file's own `merge-keys` key is **stripped and ignored**. Per-entry merge behavior is controlled by the leaf config using structured inherit entries: `{config: ..., merge-keys: [...]}`.
+
+This design reflects the principle that **merge-keys are a property of the relationship between the leaf and each listed entry**, not an intrinsic property of the listed config. A config file's own `merge-keys` may have been written for a different inheritance context and should not leak into an unrelated composition chain.
+
+Without structured entries, all composition steps use replace semantics (no merging between entries). To merge specific keys at a composition step, use a structured entry with `merge-keys`.
+
+#### Rule 4: Leaf merge-keys for final step
+
+The leaf config's top-level `merge-keys` applies to the **final composition step** (leaf on top of the accumulated base). This is orthogonal to per-entry merge-keys -- Rule 3 controls how listed entries compose with each other, while Rule 4 controls how the leaf merges on top.
+
+#### Structured Inherit Entries
+
+The inherit list accepts mixed entries: plain strings and structured objects.
+
+**Plain string entry** (replace semantics at that step):
+
+```yaml
+inherit:
+  - base.yaml
+  - extensions.yaml
+```
+
+**Structured entry** (per-entry merge-keys at that step):
+
+```yaml
+inherit:
+  - base.yaml
+  - config: extensions.yaml
+    merge-keys:
+      - agents
+      - rules
+```
+
+Structured entries have the following fields:
+
+| Field        | Type         | Required | Description                                               |
+|--------------|--------------|----------|-----------------------------------------------------------|
+| `config`     | `str`        | Yes      | Configuration source (URL, path, or repo name)            |
+| `merge-keys` | `list[str]`  | No       | Keys to merge instead of replace at this composition step |
+
+The `merge-keys` in a structured entry accepts the same values as the top-level `merge-keys` directive: `dependencies`, `agents`, `slash-commands`, `rules`, `skills`, `files-to-download`, `hooks`, `mcp-servers`, `global-config`, `user-settings`, `env-variables`, `os-env-variables`.
+
+Plain strings and structured entries can be mixed in the same list:
+
+```yaml
+inherit:
+  - base.yaml                    # Plain string (replace semantics)
+  - config: extensions.yaml      # Structured (merge agents and rules)
+    merge-keys:
+      - agents
+      - rules
+  - overrides.yaml               # Plain string (replace semantics)
+```
+
+> **Note:** Per-entry merge-keys on the **first** entry in the list is a no-op (there is no predecessor to merge with). The first entry always becomes the base.
 
 #### Virtual Chain Equivalence
 
@@ -1207,16 +1269,15 @@ Each file in the list can declare its own `merge-keys`, which applies normally a
 
 ```text
 A (base, no inherit)
-B_virtual (inherits A, own inherit stripped, B's merge-keys applied)
-C_virtual (inherits B_virtual, own inherit stripped, C's merge-keys applied)
-leaf (inherits C_virtual, leaf's merge-keys applied)
+B_virtual (inherits A, own inherit + merge-keys stripped, per-entry merge-keys from leaf applied)
+C_virtual (inherits B_virtual, own inherit + merge-keys stripped, per-entry merge-keys from leaf applied)
+leaf (inherits C_virtual, leaf's top-level merge-keys applied)
 ```
-
-Each file's `merge-keys` determines whether its keys merge with or replace the accumulated values at that step.
 
 #### Single-Element List
 
-`inherit: ["x"]` is normalized to `inherit: "x"` and uses the standard recursive single-string path. The file `x.yaml`'s own `inherit` **is** recursively resolved. Rule 1 only applies when the list has more than one entry.
+- `inherit: ["x"]` (plain string) is normalized to `inherit: "x"` and uses the standard recursive single-string path. The file `x.yaml`'s own `inherit` **is** recursively resolved.
+- `inherit: [{config: "x", merge-keys: [agents]}]` (structured entry) routes to composition mode. The file's own `inherit` and `merge-keys` are stripped per Rules 1 and 3.
 
 #### Example
 
@@ -1232,10 +1293,10 @@ env-variables:
   SHARED_VAR: "from_base"
   BASE_VAR: "base_val"
 
-# extensions.yaml (has own inherit that will be ignored when used in a list)
+# extensions.yaml (has own inherit and merge-keys that will be ignored in list mode)
 name: "Extensions"
-inherit: "some-parent.yaml"  # IGNORED when this file is part of a multi-element list
-merge-keys:
+inherit: "some-parent.yaml"  # IGNORED (Rule 1)
+merge-keys:                  # IGNORED (Rule 3)
   - agents
   - rules
 agents:
@@ -1246,11 +1307,16 @@ env-variables:
   SHARED_VAR: "from_extensions"
   EXT_VAR: "ext_val"
 
-# leaf.yaml
+# leaf.yaml -- per-entry merge-keys specified in the leaf
 inherit:
   - base.yaml
-  - extensions.yaml
+  - config: extensions.yaml
+    merge-keys:
+      - agents
+      - rules
 name: "My Environment"
+merge-keys:
+  - os-env-variables
 model: "opus"
 env-variables:
   LEAF_VAR: "leaf_val"
@@ -1258,12 +1324,13 @@ env-variables:
 
 Result:
 
-- `agents`: `["agents/core-agent.md", "agents/extra-agent.md"]` -- merged by extensions.yaml's `merge-keys`
-- `rules`: `["rules/base-rule.md", "rules/extra-rule.md"]` -- merged by extensions.yaml's `merge-keys`
+- `agents`: `["agents/core-agent.md", "agents/extra-agent.md"]` -- merged by the structured entry's `merge-keys` (Rule 3)
+- `rules`: `["rules/base-rule.md", "rules/extra-rule.md"]` -- merged by the structured entry's `merge-keys` (Rule 3)
 - `model`: `"opus"` -- leaf overrides
 - `name`: `"My Environment"` -- leaf overrides
-- `env-variables`: `{"LEAF_VAR": "leaf_val"}` -- extensions replaces base's env-variables entirely (not in `merge-keys`), then leaf replaces again (no `merge-keys`)
-- `some-parent.yaml` referenced in extensions.yaml's own inherit is **never loaded**
+- `env-variables`: `{"LEAF_VAR": "leaf_val"}` -- extensions replaces base's env-variables (not in per-entry merge-keys), then leaf replaces again
+- `some-parent.yaml` referenced in extensions.yaml's own inherit is **never loaded** (Rule 1)
+- extensions.yaml's own `merge-keys: [agents, rules]` is **ignored** (Rule 3)
 
 ### Selective Merge (`merge-keys`)
 

--- a/scripts/models/environment_config.py
+++ b/scripts/models/environment_config.py
@@ -634,6 +634,57 @@ class CommandDefaults(BaseModel):
         return v
 
 
+class InheritEntry(BaseModel):
+    """Structured entry for list-based inheritance with per-entry merge control.
+
+    Specifies a configuration source and optional per-entry merge-keys that
+    control how that entry's values compose with the accumulated base.
+    merge-keys are a property of the relationship between the leaf config
+    and the listed entry, not an intrinsic property of the listed config.
+
+    Attributes:
+        config: Configuration source (URL, file path, or repo name).
+        merge_keys: Optional list of top-level keys to merge (extend) instead
+            of replace when composing this entry with the accumulated base.
+    """
+
+    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+
+    config: str
+    merge_keys: list[str] | None = Field(None, alias='merge-keys')
+
+    @field_validator('config')
+    @classmethod
+    def validate_config(cls, v: str) -> str:
+        """Validate config source is non-empty and contains no null bytes."""
+        if not v or not v.strip():
+            raise ValueError('config cannot be empty or whitespace-only')
+        if '\x00' in v:
+            raise ValueError('config cannot contain null bytes')
+        return v
+
+    @field_validator('merge_keys')
+    @classmethod
+    def validate_merge_keys(cls, v: list[str] | None) -> list[str] | None:
+        """Validate merge-keys against the set of mergeable configuration keys."""
+        if v is None:
+            return v
+
+        # Inline definition avoids circular import from setup_environment.py
+        mergeable: frozenset[str] = frozenset({
+            'dependencies', 'agents', 'slash-commands', 'rules', 'skills',
+            'files-to-download', 'hooks', 'mcp-servers',
+            'global-config', 'user-settings', 'env-variables', 'os-env-variables',
+        })
+        invalid = [k for k in v if k not in mergeable]
+        if invalid:
+            raise ValueError(
+                f'Invalid merge-keys: {invalid}. '
+                f'Valid mergeable keys: {sorted(mergeable)}',
+            )
+        return v
+
+
 class EnvironmentConfig(BaseModel):
     """Complete environment configuration model."""
 
@@ -743,13 +794,14 @@ class EnvironmentConfig(BaseModel):
         'Semantic versioning string (e.g., "1.0.0"). Optional; configs without '
         'this field skip all version checking.',
     )
-    inherit: str | list[str] | None = Field(
+    inherit: str | list[str | InheritEntry] | None = Field(
         None,
         description='Parent configuration(s) to inherit from. '
-        'Accepts a single string (URL, path, or repo name) or a list of strings '
-        'for composition chains. When a list with >1 entries: entries are composed '
-        "left-to-right, each entry's own inherit key is ignored, merge-keys "
-        'apply per-entry. Single-element list is normalized to string.',
+        'Accepts a single string (URL, path, or repo name), a list of strings '
+        'for composition chains, or a list mixing strings and structured entries '
+        '{config: str, merge-keys: list[str]} for per-entry merge control. '
+        'Single-element plain-string list normalizes to string for recursive resolution. '
+        'Single-element structured list routes to composition mode.',
     )
     merge_keys: list[str] | None = Field(
         None,
@@ -921,24 +973,25 @@ class EnvironmentConfig(BaseModel):
             )
         return v
 
-    @field_validator('inherit')
+    @field_validator('inherit', mode='before')
     @classmethod
-    def validate_inherit(cls, v: str | list[str] | None) -> str | list[str] | None:
-        """Validate inherit value: string, list of strings, or None.
+    def validate_inherit(
+        cls, v: str | list[str | dict[str, Any] | InheritEntry] | None,
+    ) -> str | list[str | InheritEntry] | None:
+        """Validate inherit value: string, list of strings/structured entries, or None.
 
         When a list is provided:
         - Must be non-empty
-        - All elements must be non-empty, non-blank strings
-        - No null bytes allowed in any element
-
-        A single-element list is valid at the model level; normalization to string
-        happens at runtime in resolve_config_inheritance().
+        - Elements can be strings (plain inherit) or dicts (structured with per-entry merge-keys)
+        - Dict entries are coerced to InheritEntry via model_validate()
+        - All string entries must be non-empty, non-blank
+        - No null bytes allowed
 
         Args:
-            v: Inherit path/URL string, list of strings, or None.
+            v: Inherit path/URL string, list of strings/dicts, or None.
 
         Returns:
-            The validated inherit value.
+            The validated inherit value with dicts coerced to InheritEntry.
 
         Raises:
             ValueError: If inherit value is invalid.
@@ -956,20 +1009,30 @@ class EnvironmentConfig(BaseModel):
         if isinstance(v, list):
             if not v:
                 raise ValueError('inherit list cannot be empty')
+            result: list[str | InheritEntry] = []
             for i, entry in enumerate(v):
-                if not isinstance(entry, str):
+                if isinstance(entry, str):
+                    if not entry or not entry.strip():
+                        raise ValueError(f'inherit[{i}] cannot be empty or whitespace-only')
+                    if '\x00' in entry:
+                        raise ValueError(f'inherit[{i}] cannot contain null bytes')
+                    result.append(entry)
+                elif isinstance(entry, dict):
+                    try:
+                        result.append(InheritEntry.model_validate(entry))
+                    except Exception as e:
+                        raise ValueError(f'inherit[{i}]: {e}') from e
+                elif isinstance(entry, InheritEntry):
+                    result.append(entry)
+                else:
                     raise ValueError(
-                        f'inherit[{i}] must be a string, '
+                        f'inherit[{i}] must be a string or {{config: ..., merge-keys: [...]}} object, '
                         f'got {type(entry).__name__}',
                     )
-                if not entry or not entry.strip():
-                    raise ValueError(f'inherit[{i}] cannot be empty or whitespace-only')
-                if '\x00' in entry:
-                    raise ValueError(f'inherit[{i}] cannot contain null bytes')
-            return v
+            return result
 
         raise ValueError(
-            f"The 'inherit' key must be a string or list of strings, "
+            f"The 'inherit' key must be a string or list of strings/objects, "
             f"got {type(v).__name__}: {v!r}",
         )
 

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -4267,7 +4267,7 @@ def _validate_merge_keys(
 
 def _resolve_list_inherit(
     config: dict[str, Any],
-    inherit_list: list[str],
+    inherit_list: list[str | dict[str, Any]],
     source: str,
     auth_param: str | None,
     visited: set[str],
@@ -4275,17 +4275,14 @@ def _resolve_list_inherit(
 ) -> tuple[dict[str, Any], list[InheritanceChainEntry]]:
     """Resolve list-based inheritance via flat left-to-right composition.
 
-    When inherit is a list with >1 entries, each entry is loaded raw,
-    its own 'inherit' key is stripped, its 'merge-keys' is captured and
-    validated, and entries are composed left-to-right.
-
-    This is equivalent to creating a virtual chain where:
-    inherit: [A, B, C] behaves identically to C inherits B inherits A,
-    with each entry's own inherit ignored.
+    When inherit is a list, each entry is loaded raw, its own 'inherit' and
+    'merge-keys' keys are stripped (Rules 1 and 3), and entries are composed
+    left-to-right using per-entry merge-keys specified in the leaf config's
+    structured inherit entries.
 
     Args:
         config: The leaf configuration (contains the list inherit).
-        inherit_list: List of inherit values (already validated, len > 1).
+        inherit_list: List of inherit entries (strings or structured dicts/InheritEntry).
         source: Source path/URL of the leaf config.
         auth_param: Optional authentication parameter for private repositories.
         visited: Set of already-visited sources for circular dependency detection.
@@ -4300,8 +4297,18 @@ def _resolve_list_inherit(
     """
     accumulated: dict[str, Any] | None = None
 
-    for i, entry_value in enumerate(inherit_list):
-        entry_value = entry_value.strip()
+    for i, entry_raw in enumerate(inherit_list):
+        # Extract entry_value (config source) and override_merge_keys from entry
+        if isinstance(entry_raw, str):
+            entry_value = entry_raw.strip()
+            override_merge_keys: list[str] | None = None
+        elif isinstance(entry_raw, dict):
+            entry_value = str(entry_raw.get('config', '')).strip()
+            override_merge_keys = entry_raw.get('merge-keys')
+        else:
+            # InheritEntry object (from model validation)
+            entry_value = entry_raw.config.strip()
+            override_merge_keys = entry_raw.merge_keys
 
         # Resolve path relative to leaf source
         entry_source = _resolve_inherit_path(entry_value, source)
@@ -4338,9 +4345,15 @@ def _resolve_list_inherit(
         if own_inherit is not None:
             info(f"inherit[{i}]: own 'inherit' key stripped (list composition mode)")
 
-        # Rule 3: Capture and validate entry's merge-keys
-        entry_merge_keys = _validate_merge_keys(
-            entry_config.get(MERGE_KEYS_KEY),
+        # Rule 3 (per-entry from leaf): Strip and IGNORE entry's own merge-keys.
+        # Per-entry merge behavior comes from the leaf's structured entries.
+        own_merge_keys = entry_config.get(MERGE_KEYS_KEY)
+        if own_merge_keys is not None:
+            info(f"inherit[{i}]: own 'merge-keys' stripped (leaf controls merge semantics)")
+
+        # Validate override merge-keys from the structured entry (if provided)
+        validated_override = _validate_merge_keys(
+            override_merge_keys,
             context=f'inherit[{i}]',
         )
 
@@ -4352,21 +4365,22 @@ def _resolve_list_inherit(
         ))
 
         if accumulated is None:
-            # First entry becomes the base (its merge-keys are moot: no predecessor)
+            # First entry becomes the base; merge-keys are moot (no predecessor).
+            # Defense-in-depth: strip meta-keys here even though _merge_configs also
+            # strips them, because first entry bypasses _merge_configs entirely.
             accumulated = {
                 k: v for k, v in entry_config.items()
                 if k not in (INHERIT_KEY, MERGE_KEYS_KEY)
             }
-            if entry_merge_keys is not None:
-                debug_log(f'inherit[{i}]: merge-keys ignored (first entry, no predecessor)')
+            if validated_override is not None:
+                debug_log(f'inherit[{i}]: per-entry merge-keys ignored (first entry, no predecessor)')
         else:
-            # Subsequent entries: compose with accumulated using entry's merge-keys
-            accumulated = _merge_configs(accumulated, entry_config, merge_keys=entry_merge_keys)
+            # Subsequent entries: compose with accumulated using leaf-specified per-entry merge-keys
+            accumulated = _merge_configs(accumulated, entry_config, merge_keys=validated_override)
 
         success(f'Loaded inherit[{i}]: {entry_value}')
 
-    # Final: merge leaf config on top of accumulated base
-    # accumulated is guaranteed non-None: inherit_list has >1 entries (validated by caller)
+    # Final: merge leaf config on top of accumulated base (Rule 4)
     assert accumulated is not None
     leaf_merge_keys = _validate_merge_keys(config.get(MERGE_KEYS_KEY))
     merged = _merge_configs(accumulated, config, merge_keys=leaf_merge_keys)
@@ -4390,8 +4404,9 @@ def resolve_config_inheritance(
 
     Supports two modes of inheritance:
     - Single string: recursive chain resolution (child -> parent -> grandparent)
-    - List of strings: flat left-to-right composition where each entry's own
-      'inherit' key is stripped and merge-keys apply per-entry
+    - List of strings/objects: flat left-to-right composition where each entry's
+      own 'inherit' and 'merge-keys' keys are stripped, and per-entry merge-keys
+      are specified via structured {config: ..., merge-keys: [...]} entries
 
     Args:
         config: The configuration dictionary to resolve inheritance for.
@@ -4463,25 +4478,49 @@ def resolve_config_inheritance(
             error("Empty 'inherit' list in configuration")
             raise ValueError("The 'inherit' list cannot be empty")
 
-        # Validate all entries are non-empty strings
+        # Validate all entries are strings or structured dicts
         for i, entry in enumerate(inherit_value):
-            if not isinstance(entry, str):
-                error(f'Invalid inherit[{i}]: expected string, got {type(entry).__name__}')
+            if isinstance(entry, str):
+                stripped = entry.strip()
+                if not stripped:
+                    error(f'Empty string in inherit[{i}]')
+                    raise ValueError(f'inherit[{i}] cannot be empty or whitespace-only')
+            elif isinstance(entry, dict):
+                if 'config' not in entry:
+                    error(f'inherit[{i}]: structured entry missing required "config" key')
+                    raise ValueError(
+                        f'inherit[{i}] structured entry must have a "config" key',
+                    )
+            elif hasattr(entry, 'config'):
+                # InheritEntry object from model validation
+                pass
+            else:
+                error(f'Invalid inherit[{i}]: expected string or {{config: ...}}, got {type(entry).__name__}')
                 raise ValueError(
-                    f'inherit[{i}] must be a string, '
+                    f'inherit[{i}] must be a string or {{config: ..., merge-keys: [...]}} object, '
                     f'got {type(entry).__name__}: {entry!r}',
                 )
-            stripped = entry.strip()
-            if not stripped:
-                error(f'Empty string in inherit[{i}]')
-                raise ValueError(f'inherit[{i}] cannot be empty or whitespace-only')
 
-        # Single-element list: normalize to string, use existing recursive path
+        # Single-element list handling
         if len(inherit_value) == 1:
-            inherit_value = inherit_value[0].strip()
-            # Fall through to the string path below
+            single = inherit_value[0]
+            if isinstance(single, str):
+                # Plain string: normalize to string, use recursive chain
+                inherit_value = single.strip()
+                # Fall through to the string path below
+            else:
+                # Structured entry: route to _resolve_list_inherit (composition mode).
+                # Preserves per-entry merge-keys and strips loaded config's own merge-keys.
+                return _resolve_list_inherit(
+                    config=config,
+                    inherit_list=inherit_value,
+                    source=source,
+                    auth_param=auth_param,
+                    visited=visited,
+                    chain=chain,
+                )
         else:
-            # Multi-element list: flat composition (Rule 1, 2, 3)
+            # Multi-element list: flat composition (Rules 1, 2, 3, 4)
             return _resolve_list_inherit(
                 config=config,
                 inherit_list=inherit_value,
@@ -4493,7 +4532,7 @@ def resolve_config_inheritance(
     elif not isinstance(inherit_value, str):
         error(f"Invalid 'inherit' value: expected string or list, got {type(inherit_value).__name__}")
         raise ValueError(
-            f"The 'inherit' key must be a string or list of strings, "
+            f"The 'inherit' key must be a string or list of strings/objects, "
             f"got {type(inherit_value).__name__}: {inherit_value!r}",
         )
 

--- a/tests/e2e/fixtures/list_inherit_single_structured.yaml
+++ b/tests/e2e/fixtures/list_inherit_single_structured.yaml
@@ -1,0 +1,8 @@
+name: "Single Structured"
+inherit:
+  - config: list_inherit_base.yaml
+    merge-keys:
+      - agents
+agents:
+  - "agents/single-structured-agent.md"
+model: "opus"

--- a/tests/e2e/fixtures/list_inherit_structured_leaf.yaml
+++ b/tests/e2e/fixtures/list_inherit_structured_leaf.yaml
@@ -1,0 +1,9 @@
+name: "Structured Leaf"
+inherit:
+  - list_inherit_base.yaml
+  - config: list_inherit_middle.yaml
+    merge-keys:
+      - agents
+      - rules
+agents:
+  - "agents/structured-leaf-agent.md"

--- a/tests/e2e/test_list_inherit.py
+++ b/tests/e2e/test_list_inherit.py
@@ -1,9 +1,11 @@
 """E2E tests for inherit: [list] composition chains.
 
-Tests verify that list-based inheritance follows the 3 mandatory rules:
+Tests verify that list-based inheritance follows the 4 mandatory rules:
 1. Own inherit in ALL list entries is completely ignored
 2. List behaves identically to separate-file chains (left-to-right)
-3. merge-keys in each entry applies normally
+3. Own merge-keys in ALL list entries is stripped and ignored;
+   per-entry merge-keys come from structured entries in the leaf
+4. Leaf's top-level merge-keys applies to the final composition step
 
 Each test class focuses on a specific scenario. All tests use real YAML
 fixture files loaded from disk, not mocked configs.
@@ -49,13 +51,12 @@ class TestBasicListComposition:
         assert resolved['name'] == 'List Inherit Leaf'
 
     def test_left_to_right_priority_mcp_servers(self, fixtures_dir):
-        """Middle (right) replaces base (left) MCP servers (no merge-keys for mcp-servers)."""
+        """Middle (right) replaces base (left) MCP servers (no per-entry merge-keys for mcp-servers)."""
         path = fixtures_dir / 'list_inherit_leaf.yaml'
         config = _load_yaml(path)
         resolved, _ = _resolve(config, str(path))
-        # Middle has merge-keys: [agents, rules] but NOT mcp-servers
-        # So middle's mcp-servers replace base's at the accumulated level
-        # Then leaf has no mcp-servers, so accumulated mcp-servers survive
+        # Middle's own merge-keys are STRIPPED (Rule 3), so middle replaces base entirely
+        # Middle's mcp-servers replace base's at the accumulated level
         server_names = [s['name'] for s in resolved.get('mcp-servers', [])]
         assert 'middle-server' in server_names
         assert 'base-server' not in server_names
@@ -131,51 +132,67 @@ class TestOwnInheritStripping:
 
 
 class TestMergeKeysPerEntry:
-    """Test Rule 3: merge-keys in each entry applies normally."""
+    """Test Rules 3+4: Entry's own merge-keys stripped; per-entry from leaf structured entries."""
 
-    def test_middle_merge_keys_merge_agents_visible_via_leaf_merge(self, fixtures_dir):
-        """Middle's merge-keys verified via leaf that also merges agents."""
-        # list_inherit_merge_keys_leaf.yaml has merge-keys: [agents, rules]
-        # so the merge chain is: base agents + middle agents + leaf agents
-        path = fixtures_dir / 'list_inherit_merge_keys_leaf.yaml'
+    def test_entry_own_merge_keys_stripped(self, fixtures_dir):
+        """Middle's own merge-keys are stripped: agents NOT merged with plain string entries."""
+        # list_inherit_leaf.yaml uses plain string entries (no per-entry merge-keys)
+        # Middle.yaml has merge-keys: [agents, rules] but these are STRIPPED (Rule 3)
+        # So middle's agents REPLACE base's agents (no merge)
+        path = fixtures_dir / 'list_inherit_leaf.yaml'
+        config = _load_yaml(path)
+        resolved, _ = _resolve(config, str(path))
+        # Accumulated: middle replaced base (no merge), then leaf replaced accumulated
+        agents = resolved.get('agents', [])
+        assert agents == ['agents/leaf-agent.md']
+
+    def test_leaf_structured_entry_merge_keys_applied(self, fixtures_dir):
+        """Structured entry with merge-keys merges agents from base and middle."""
+        path = fixtures_dir / 'list_inherit_structured_leaf.yaml'
         config = _load_yaml(path)
         resolved, _ = _resolve(config, str(path))
         agents = resolved.get('agents', [])
-        # Middle merge-keys merges with base, then leaf merge-keys merges again
-        assert 'agents/base-agent.md' in agents
-        assert 'agents/middle-agent.md' in agents
-        assert 'agents/mk-leaf-agent.md' in agents
+        # Base agents + middle agents (merged via structured per-entry merge-keys) + leaf agents
+        # Leaf has no top-level merge-keys, so leaf REPLACES accumulated agents
+        # Actually: base is first (no merge), middle merges agents via structured entry,
+        # then leaf replaces (no top-level merge-keys for agents)
+        assert 'agents/structured-leaf-agent.md' in agents
 
-    def test_middle_merge_keys_merge_rules_visible_via_leaf_merge(self, fixtures_dir):
-        """Middle's merge-keys for rules verified via leaf that also merges."""
-        path = fixtures_dir / 'list_inherit_merge_keys_leaf.yaml'
+    def test_structured_entry_merges_rules(self, fixtures_dir):
+        """Structured entry merges rules between base and middle."""
+        path = fixtures_dir / 'list_inherit_structured_leaf.yaml'
         config = _load_yaml(path)
         resolved, _ = _resolve(config, str(path))
         rules = resolved.get('rules', [])
+        # Structured entry merge-keys: [agents, rules] -- middle merges with base
         assert 'rules/base-rule.md' in rules
         assert 'rules/middle-rule.md' in rules
-        assert 'rules/mk-leaf-rule.md' in rules
 
     def test_leaf_merge_keys_applied(self, fixtures_dir):
-        """Leaf's own merge-keys applies on top of accumulated."""
+        """Leaf's own merge-keys applies on top of accumulated (Rule 4)."""
         path = fixtures_dir / 'list_inherit_merge_keys_leaf.yaml'
         config = _load_yaml(path)
         resolved, _ = _resolve(config, str(path))
+        # Middle's own merge-keys are STRIPPED, so middle REPLACES base agents
+        # But leaf has merge-keys: [agents, rules], so leaf MERGES with accumulated
         agents = resolved.get('agents', [])
-        # All three levels' agents should be present
-        assert 'agents/base-agent.md' in agents
+        # Middle replaced base (no per-entry merge-keys), then leaf merges
         assert 'agents/middle-agent.md' in agents
         assert 'agents/mk-leaf-agent.md' in agents
+        # Base agents were replaced by middle (not merged), so base NOT present
+        assert 'agents/base-agent.md' not in agents
 
     def test_leaf_merge_keys_merge_rules(self, fixtures_dir):
-        """Leaf's merge-keys merges rules from all levels."""
+        """Leaf's merge-keys merges rules from accumulated + leaf."""
         path = fixtures_dir / 'list_inherit_merge_keys_leaf.yaml'
         config = _load_yaml(path)
         resolved, _ = _resolve(config, str(path))
         rules = resolved.get('rules', [])
-        assert 'rules/base-rule.md' in rules
+        # Middle replaced base rules (no per-entry merge-keys), then leaf merges
         assert 'rules/middle-rule.md' in rules
         assert 'rules/mk-leaf-rule.md' in rules
+        # Base rules replaced by middle
+        assert 'rules/base-rule.md' not in rules
 
     def test_leaf_without_merge_keys_replaces_agents(self, fixtures_dir):
         """Leaf without merge-keys replaces accumulated agents."""
@@ -188,12 +205,22 @@ class TestMergeKeysPerEntry:
         assert 'agents/base-agent.md' not in agents
         assert 'agents/middle-agent.md' not in agents
 
+    def test_mixed_plain_and_structured_entries(self, fixtures_dir):
+        """List with plain string first, structured second composes correctly."""
+        path = fixtures_dir / 'list_inherit_structured_leaf.yaml'
+        config = _load_yaml(path)
+        resolved, chain = _resolve(config, str(path))
+        # Base is plain string (first entry), middle is structured with merge-keys
+        assert len(chain) == 2
+        assert 'inherit' not in resolved
+        assert 'merge-keys' not in resolved
+
 
 class TestSingleElementListNormalization:
-    """Test: inherit: ['x'] normalized to string path."""
+    """Test: inherit: ['x'] normalized to string path; [{config: 'x'}] uses composition."""
 
     def test_single_element_resolves_recursively(self, fixtures_dir):
-        """Single-element list uses existing recursive string path."""
+        """Single-element plain-string list uses existing recursive string path."""
         path = fixtures_dir / 'list_inherit_single.yaml'
         config = _load_yaml(path)
         resolved, chain = _resolve(config, str(path))
@@ -210,37 +237,71 @@ class TestSingleElementListNormalization:
         assert 'agents/single-agent.md' in resolved['agents']
 
     def test_single_element_chain_has_one_entry(self, fixtures_dir):
-        """Single-element list produces chain with 1 entry."""
+        """Single-element plain-string list produces chain with 1 entry."""
         path = fixtures_dir / 'list_inherit_single.yaml'
         config = _load_yaml(path)
         _, chain = _resolve(config, str(path))
         assert len(chain) == 1
 
+    def test_single_structured_entry_routes_to_list_path(self, fixtures_dir):
+        """Single structured entry uses composition mode, NOT recursive."""
+        path = fixtures_dir / 'list_inherit_single_structured.yaml'
+        config = _load_yaml(path)
+        resolved, chain = _resolve(config, str(path))
+        # Composition mode: chain has 1 entry (base)
+        assert len(chain) == 1
+        assert resolved['name'] == 'Single Structured'
+        assert resolved['model'] == 'opus'
+
+    def test_single_structured_merges_agents(self, fixtures_dir):
+        """Single structured entry's merge-keys merges agents with base."""
+        path = fixtures_dir / 'list_inherit_single_structured.yaml'
+        config = _load_yaml(path)
+        resolved, _ = _resolve(config, str(path))
+        # The structured entry has merge-keys: [agents], BUT this is the first entry
+        # (no predecessor), so merge-keys is ignored for the first entry.
+        # Leaf replaces agents (no top-level merge-keys).
+        agents = resolved.get('agents', [])
+        assert 'agents/single-structured-agent.md' in agents
+
+    def test_single_structured_strips_own_merge_keys(self, fixtures_dir):
+        """Loaded config's own merge-keys ignored even for single structured entry."""
+        # list_inherit_base.yaml has NO merge-keys, so nothing to strip.
+        # But verify the mechanism works: result has no merge-keys key
+        path = fixtures_dir / 'list_inherit_single_structured.yaml'
+        config = _load_yaml(path)
+        resolved, _ = _resolve(config, str(path))
+        assert 'merge-keys' not in resolved
+        assert 'inherit' not in resolved
+
 
 class TestEquivalenceToSeparateFiles:
-    """Test Rule 2: list must behave IDENTICALLY to separate-file chains."""
+    """Test Rule 2: list must behave IDENTICALLY to separate-file chains.
+
+    With the new Rule 3, each entry's own merge-keys is stripped. So the
+    equivalence is: inherit: [base, middle] == middle replaces base entirely
+    (since merge-keys are stripped), then leaf applied on top.
+    """
 
     def test_equivalence_two_files(self, fixtures_dir):
-        """inherit: [base, middle] == middle inherits base (separate files)."""
+        """inherit: [base, middle] == middle replaces base (merge-keys stripped)."""
         # Method 1: List inherit
         leaf_path = fixtures_dir / 'list_inherit_leaf.yaml'
         leaf_config = _load_yaml(leaf_path)
         list_result, _ = _resolve(leaf_config, str(leaf_path))
 
-        # Method 2: Simulate separate-file chain
+        # Method 2: Manual simulation of new Rule 3 behavior
         base_config = _load_yaml(fixtures_dir / 'list_inherit_base.yaml')
         middle_config = _load_yaml(fixtures_dir / 'list_inherit_middle.yaml')
 
-        # Manually build the chain: base -> middle -> leaf
-        # Step 1: strip middle's own inherit, apply merge-keys
-        middle_mk = middle_config.get('merge-keys')
-        middle_validated_mk = frozenset(middle_mk) if middle_mk else None
+        # Step 1: Strip middle's own merge-keys (Rule 3), compose with REPLACE semantics
         base_stripped = {
             k: v for k, v in base_config.items()
             if k not in ('inherit', 'merge-keys')
         }
+        # With Rule 3, middle's own merge-keys is stripped, so merge_keys=None (REPLACE)
         step1 = setup_environment._merge_configs(
-            base_stripped, middle_config, merge_keys=middle_validated_mk,
+            base_stripped, middle_config, merge_keys=None,
         )
 
         # Step 2: apply leaf on top (leaf has no merge-keys)
@@ -266,8 +327,8 @@ class TestEdgeCases:
         with pytest.raises(ValueError, match='cannot be empty'):
             _resolve(config, 'test.yaml')
 
-    def test_list_with_non_string_raises(self):
-        """List with non-string entry raises ValueError."""
+    def test_list_with_non_string_non_dict_raises(self):
+        """List with non-string, non-dict entry raises ValueError."""
         config = {'inherit': ['a.yaml', 123], 'name': 'Test'}
         with pytest.raises(ValueError, match='must be a string'):
             _resolve(config, 'test.yaml')
@@ -297,7 +358,7 @@ class TestEdgeCases:
             _resolve(config, str(fixtures_dir / 'test.yaml'))
 
     def test_dict_inherit_raises(self):
-        """Dict inherit value raises ValueError."""
+        """Dict inherit value (not in list) raises ValueError."""
         config = {'inherit': {'source': 'base.yaml'}, 'name': 'Test'}
         with pytest.raises(ValueError, match='must be a string or list'):
             _resolve(config, 'test.yaml')
@@ -307,6 +368,28 @@ class TestEdgeCases:
         config = {'inherit': 42, 'name': 'Test'}
         with pytest.raises(ValueError, match='must be a string or list'):
             _resolve(config, 'test.yaml')
+
+    def test_structured_entry_missing_config_raises(self):
+        """Structured entry without config key raises ValueError."""
+        config = {
+            'inherit': [{'merge-keys': ['agents']}],
+            'name': 'Test',
+        }
+        with pytest.raises(ValueError, match='must have a "config" key'):
+            _resolve(config, 'test.yaml')
+
+    def test_dict_entry_in_list_accepted(self, fixtures_dir):
+        """Dict entry in list is accepted (structured entry)."""
+        config = {
+            'inherit': [
+                {'config': 'list_inherit_base.yaml'},
+                'list_inherit_middle.yaml',
+            ],
+            'name': 'Test',
+        }
+        resolved, chain = _resolve(config, str(fixtures_dir / 'test.yaml'))
+        assert len(chain) == 2
+        assert resolved['name'] == 'Test'
 
 
 class TestChainOrdering:
@@ -350,15 +433,13 @@ class TestEnvVariableComposition:
         env_vars = resolved['env-variables']
         assert env_vars == {'LEAF_VAR': 'leaf_val'}
 
-    def test_env_vars_merged_when_merge_keys_used(self, fixtures_dir):
-        """Env-variables merge when merge-keys includes env-variables."""
+    def test_env_vars_from_middle_when_no_leaf_env_vars(self, fixtures_dir):
+        """Middle's env-variables survives when leaf has no env-variables key."""
         path = fixtures_dir / 'list_inherit_merge_keys_leaf.yaml'
         config = _load_yaml(path)
         resolved, _ = _resolve(config, str(path))
-        # merge_keys_leaf has merge-keys: [agents, rules] but NOT env-variables
-        # Middle has env-variables which replaces base's env-variables
+        # Middle's own merge-keys is STRIPPED, so middle REPLACES base env-variables
         # Leaf has NO env-variables key, so accumulated env-variables survive
         env_vars = resolved.get('env-variables', {})
-        # Middle's env-variables replaced base's (no merge-keys for env-variables in middle)
         assert env_vars.get('MIDDLE_VAR') == 'middle_val'
         assert env_vars.get('SHARED_VAR') == 'from_middle'

--- a/tests/scripts/models/test_environment_config.py
+++ b/tests/scripts/models/test_environment_config.py
@@ -15,6 +15,66 @@ import pytest
 from pydantic import ValidationError
 
 from scripts.models.environment_config import EnvironmentConfig
+from scripts.models.environment_config import InheritEntry
+
+
+class TestInheritEntryModel:
+    """Tests for the InheritEntry Pydantic model."""
+
+    def test_inherit_entry_basic_valid(self):
+        """Basic InheritEntry with only config succeeds."""
+        entry = InheritEntry(config='base.yaml')
+        assert entry.config == 'base.yaml'
+        assert entry.merge_keys is None
+
+    def test_inherit_entry_with_merge_keys(self):
+        """InheritEntry with merge-keys via model_validate succeeds."""
+        entry = InheritEntry.model_validate({'config': 'x.yaml', 'merge-keys': ['agents']})
+        assert entry.config == 'x.yaml'
+        assert entry.merge_keys == ['agents']
+
+    def test_inherit_entry_empty_config_rejected(self):
+        """Empty config string raises ValueError."""
+        with pytest.raises(Exception, match='config cannot be empty'):
+            InheritEntry(config='')
+
+    def test_inherit_entry_blank_config_rejected(self):
+        """Whitespace-only config raises ValueError."""
+        with pytest.raises(Exception, match='config cannot be empty'):
+            InheritEntry(config='   ')
+
+    def test_inherit_entry_null_bytes_rejected(self):
+        """Config with null bytes raises ValueError."""
+        with pytest.raises(Exception, match='config cannot contain null bytes'):
+            InheritEntry(config='base\x00.yaml')
+
+    def test_inherit_entry_invalid_merge_key_rejected(self):
+        """Invalid merge-key raises ValueError."""
+        with pytest.raises(Exception, match='Invalid merge-keys'):
+            InheritEntry.model_validate({'config': 'x.yaml', 'merge-keys': ['invalid-key']})
+
+    def test_inherit_entry_extra_field_rejected(self):
+        """Extra field rejected by extra=forbid."""
+        with pytest.raises(ValidationError, match='extra'):
+            InheritEntry.model_validate({'config': 'x.yaml', 'extra': 'y'})
+
+    def test_inherit_entry_missing_config_rejected(self):
+        """Missing config field raises error."""
+        with pytest.raises(ValidationError, match='config'):
+            InheritEntry.model_validate({'merge-keys': ['agents']})
+
+    def test_inherit_entry_model_validate_alias(self):
+        """model_validate works with kebab-case alias."""
+        entry = InheritEntry.model_validate({'config': 'x.yaml', 'merge-keys': ['agents', 'rules']})
+        assert entry.merge_keys == ['agents', 'rules']
+
+    def test_inherit_entry_multiple_merge_keys(self):
+        """Multiple valid merge-keys accepted."""
+        entry = InheritEntry.model_validate({
+            'config': 'x.yaml',
+            'merge-keys': ['agents', 'rules', 'mcp-servers', 'env-variables'],
+        })
+        assert len(entry.merge_keys) == 4
 
 
 class TestHooksUnusedFiles:
@@ -1530,7 +1590,7 @@ class TestInheritValidation:
 
     def test_inherit_list_with_non_string_rejected(self) -> None:
         """List with non-string element raises ValidationError."""
-        with pytest.raises(ValidationError, match='Input should be a valid string'):
+        with pytest.raises(ValidationError, match=r'inherit\[0\] must be a string or'):
             EnvironmentConfig.model_validate({'name': 'Test', 'inherit': [123]})
 
     def test_inherit_list_with_null_bytes_rejected(self) -> None:
@@ -1539,8 +1599,8 @@ class TestInheritValidation:
             EnvironmentConfig.model_validate({'name': 'Test', 'inherit': ['base\x00.yaml']})
 
     def test_inherit_dict_rejected(self) -> None:
-        """Dict value raises ValidationError."""
-        with pytest.raises(ValidationError, match='Input should be a valid'):
+        """Dict value (not in list) raises ValidationError."""
+        with pytest.raises(ValidationError, match='must be a string or list'):
             EnvironmentConfig.model_validate({
                 'name': 'Test',
                 'inherit': {'source': 'base.yaml'},
@@ -1548,7 +1608,7 @@ class TestInheritValidation:
 
     def test_inherit_int_rejected(self) -> None:
         """Integer value raises ValidationError."""
-        with pytest.raises(ValidationError, match='Input should be a valid'):
+        with pytest.raises(ValidationError, match='must be a string or list'):
             EnvironmentConfig.model_validate({'name': 'Test', 'inherit': 42})
 
     def test_inherit_list_second_element_invalid(self) -> None:
@@ -1566,3 +1626,35 @@ class TestInheritValidation:
             'inherit': ['a.yaml', 'b.yaml', 'c.yaml'],
         })
         assert config.inherit == ['a.yaml', 'b.yaml', 'c.yaml']
+
+    def test_inherit_list_with_structured_entry_valid(self) -> None:
+        """List with structured entry (dict) is accepted."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'inherit': [{'config': 'x.yaml', 'merge-keys': ['agents']}, 'y.yaml'],
+        })
+        assert len(config.inherit) == 2
+
+    def test_inherit_list_mixed_entries_valid(self) -> None:
+        """Mixed strings and dicts in list accepted."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'inherit': ['a.yaml', {'config': 'b.yaml', 'merge-keys': ['rules']}, 'c.yaml'],
+        })
+        assert len(config.inherit) == 3
+
+    def test_inherit_list_structured_entry_missing_config(self) -> None:
+        """Dict without config key raises ValidationError."""
+        with pytest.raises(ValidationError, match=r'inherit\[0\]'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'inherit': [{'merge-keys': ['agents']}],
+            })
+
+    def test_inherit_single_structured_entry_valid(self) -> None:
+        """Single structured entry in list passes validation."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'inherit': [{'config': 'x.yaml', 'merge-keys': ['agents']}],
+        })
+        assert len(config.inherit) == 1

--- a/tests/scripts/models/test_mergeable_config_keys_parity.py
+++ b/tests/scripts/models/test_mergeable_config_keys_parity.py
@@ -1,0 +1,88 @@
+"""Parity test: InheritEntry's inline mergeable frozenset must match MERGEABLE_CONFIG_KEYS.
+
+The InheritEntry model in environment_config.py necessarily duplicates the
+MERGEABLE_CONFIG_KEYS frozenset from setup_environment.py (standalone script
+policy prevents cross-import). This test enforces strict parity.
+"""
+
+from __future__ import annotations
+
+from scripts.models.environment_config import InheritEntry
+from scripts.setup_environment import MERGEABLE_CONFIG_KEYS
+
+
+def _get_inherit_entry_mergeable_keys() -> frozenset[str]:
+    """Extract the set of keys accepted by InheritEntry's merge-keys validator.
+
+    Validates each key from MERGEABLE_CONFIG_KEYS individually against
+    InheritEntry to determine which keys the inline frozenset accepts.
+
+    Returns:
+        frozenset of key names that InheritEntry accepts as valid merge-keys.
+    """
+    valid_keys: set[str] = set()
+    for key in MERGEABLE_CONFIG_KEYS:
+        try:
+            entry = InheritEntry.model_validate({'config': 'test.yaml', 'merge-keys': [key]})
+            if entry.merge_keys:
+                valid_keys.update(entry.merge_keys)
+        except Exception:
+            pass  # Key rejected -- will be caught by assertion
+    return frozenset(valid_keys)
+
+
+def test_inherit_entry_accepts_all_mergeable_keys() -> None:
+    """InheritEntry must accept every key in MERGEABLE_CONFIG_KEYS."""
+    accepted = _get_inherit_entry_mergeable_keys()
+    missing = MERGEABLE_CONFIG_KEYS - accepted
+    assert not missing, (
+        f'InheritEntry rejects keys that are in MERGEABLE_CONFIG_KEYS: {sorted(missing)}. '
+        f'Update the inline mergeable frozenset in InheritEntry.validate_merge_keys().'
+    )
+
+
+def test_inherit_entry_rejects_non_mergeable_keys() -> None:
+    """InheritEntry must reject keys NOT in MERGEABLE_CONFIG_KEYS."""
+    fake_keys = ['nonexistent-key', 'fake-key', 'bogus']
+    for key in fake_keys:
+        try:
+            InheritEntry.model_validate({'config': 'test.yaml', 'merge-keys': [key]})
+            raise AssertionError(f'InheritEntry should reject non-mergeable key: {key}')
+        except AssertionError:
+            raise
+        except Exception:
+            pass  # Expected rejection
+
+
+def test_environment_config_mergeable_matches_inherit_entry() -> None:
+    """EnvironmentConfig.validate_merge_keys inline set must match InheritEntry's."""
+    from scripts.models.environment_config import EnvironmentConfig
+
+    # Extract from EnvironmentConfig by attempting validation
+    ec_valid: set[str] = set()
+    for key in MERGEABLE_CONFIG_KEYS:
+        try:
+            EnvironmentConfig.model_validate({
+                'name': 'test',
+                'merge-keys': [key],
+            })
+            ec_valid.add(key)
+        except Exception:
+            pass
+
+    ie_valid = _get_inherit_entry_mergeable_keys()
+    assert ec_valid == ie_valid, (
+        f'EnvironmentConfig and InheritEntry have different mergeable key sets.\n'
+        f'Only in EnvironmentConfig: {sorted(ec_valid - ie_valid)}\n'
+        f'Only in InheritEntry: {sorted(ie_valid - ec_valid)}'
+    )
+
+
+def test_mergeable_keys_match_runtime_constant() -> None:
+    """Both inline frozensets must exactly match MERGEABLE_CONFIG_KEYS."""
+    ie_valid = _get_inherit_entry_mergeable_keys()
+    assert ie_valid == MERGEABLE_CONFIG_KEYS, (
+        f'InheritEntry mergeable keys differ from MERGEABLE_CONFIG_KEYS.\n'
+        f'Only in MERGEABLE_CONFIG_KEYS: {sorted(MERGEABLE_CONFIG_KEYS - ie_valid)}\n'
+        f'Only in InheritEntry: {sorted(ie_valid - MERGEABLE_CONFIG_KEYS)}'
+    )

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -7330,7 +7330,7 @@ class TestListInherit:
         assert result['model'] == 'opus'
 
     def test_list_merge_keys_per_entry(self, mock_load):
-        """Each entry's merge-keys applies normally (Rule 3)."""
+        """Entry's own merge-keys stripped; per-entry from leaf structured entries (Rule 3)."""
         def load_side_effect(src, _auth_param=None):
             if 'base' in src:
                 return ({
@@ -7345,9 +7345,11 @@ class TestListInherit:
                 }, 'ext.yaml')
             return ({}, src)
         mock_load.side_effect = load_side_effect
+        # Plain string entries: ext's own merge-keys is STRIPPED, so ext REPLACES base
         child = {'inherit': ['base.yaml', 'ext.yaml'], 'name': 'Leaf'}
         result, chain = setup_environment.resolve_config_inheritance(child, 'leaf.yaml')
-        assert 'base-agent.md' in result['agents']
+        # ext replaced base agents (no per-entry merge-keys from leaf)
+        assert 'base-agent.md' not in result['agents']
         assert 'ext-agent.md' in result['agents']
 
     def test_list_empty_raises(self):
@@ -7433,7 +7435,7 @@ class TestListInherit:
         assert 'merge-keys' not in result
 
     def test_leaf_merge_keys_applied(self, mock_load):
-        """Leaf's own merge-keys applies on top of accumulated."""
+        """Leaf's own merge-keys applies on top of accumulated (Rule 4)."""
         def load_side_effect(src, _auth_param=None):
             if 'base' in src:
                 return ({'name': 'Base', 'agents': ['base-agent.md']}, 'base.yaml')
@@ -7452,7 +7454,9 @@ class TestListInherit:
             'name': 'Leaf',
         }
         result, _ = setup_environment.resolve_config_inheritance(child, 'leaf.yaml')
-        assert 'base-agent.md' in result['agents']
+        # ext's own merge-keys is STRIPPED (Rule 3), so ext REPLACES base agents
+        # Leaf merge-keys: [agents] merges leaf agents with accumulated (ext's agents)
+        assert 'base-agent.md' not in result['agents']
         assert 'ext-agent.md' in result['agents']
         assert 'leaf-agent.md' in result['agents']
 


### PR DESCRIPTION
Strip and ignore each listed config's own merge-keys during list composition, allowing the leaf config to specify per-entry merge behavior via structured inherit entries {config, merge-keys}. Add InheritEntry Pydantic model with validation against mergeable keys, update inherit field type to accept mixed string and structured entries, and route single-element structured lists to composition mode while preserving recursive resolution for plain strings.