### PR TITLE
Resolve cross-source relative file paths during config inheritance

### DIFF
--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -1555,6 +1555,26 @@ When a version is pinned, the setup installs the matching Claude Code extension 
 
 Installation is **non-fatal**: failures produce warnings but do not abort the setup.
 
+#### VSIX Auto-Update Behavior
+
+The three installation tiers have different auto-update implications for the installed extension:
+
+| Tier   | Method               | Auto-Update Status                             |
+|--------|----------------------|------------------------------------------------|
+| Tier 1 | Bundled VSIX         | **Disabled by default** (VS Code v1.92+)       |
+| Tier 2 | Downloaded VSIX      | **Disabled by default** (VS Code v1.92+)       |
+| Tier 3 | Marketplace @version | **Active** -- VS Code may update the extension |
+
+Since VS Code v1.92, extensions installed via VSIX files (Tiers 1 and 2) have auto-update disabled by default. This is the primary defense mechanism for version pinning -- the installed extension stays at the pinned version without any additional IDE-level configuration.
+
+Tier 3 (marketplace @version syntax) is a last-resort fallback that only triggers when both the bundled VSIX is unavailable and the marketplace CDN download fails. In this case, VS Code may auto-update the extension despite version pinning. When Tier 3 is used, the setup emits a warning with instructions to manually disable auto-update for the extension:
+
+> In VS Code's Extensions view, right-click the Claude Code extension and set "Auto Update" to off.
+
+This per-extension "Auto Update" toggle is the only targeted control available. There is no `settings.json` key for per-extension auto-update exceptions -- the only JSON setting (`extensions.autoUpdate: false`) disables auto-update for ALL extensions, which is too broad.
+
+**JetBrains IDEs:** JetBrains IDEs use their own plugin ecosystem and do not support VSIX extensions. The Claude Code JetBrains plugin is versioned independently from the CLI, and there is no external mechanism to control per-plugin auto-update from outside the IDE. The existing `autoInstallIdeExtension: false` control is the only applicable protection for JetBrains.
+
 #### VS Code Family IDE Detection
 
 IDEs are detected via `shutil.which()` for each CLI name: `code`, `code-insiders`, `cursor`, `windsurf`, `codium`. The extension is installed into all detected IDEs. If no IDEs are detected, the step is a silent no-op.

--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -266,7 +266,7 @@ Base URL for resolving relative resource paths (agents, commands, skills, hooks,
 - **Type:** `str | None`
 - **Default:** `None`
 - **Validation:** Must start with `http://` or `https://`
-- **Inheritance:** Standard override (child replaces parent). Each level's `base-url` applies to that level's own resource paths.
+- **Inheritance:** Standard override (child replaces parent). Each level's `base-url` applies to that level's own resource paths during inheritance resolution. A child `base-url` does **not** retroactively affect parent resource paths -- see [Resource Path Resolution in Inheritance](#resource-path-resolution-in-inheritance).
 - **Example:** `base-url: "https://raw.githubusercontent.com/org/repo/main"`
 
 #### `inherit`
@@ -1158,6 +1158,41 @@ The `inherit` key allows a configuration to extend a parent configuration. It ac
 - Circular dependencies are detected automatically
 - The `version` key is extracted from the root config **before** inheritance resolution
 - Both `inherit` and `merge-keys` are stripped from the final merged configuration
+
+#### Resource Path Resolution in Inheritance
+
+When configurations are inherited across different sources (e.g., a GitHub-hosted parent and a local child), relative file paths in each config are resolved using that config's own source location and `base-url`. This ensures that files referenced by a parent config are found at the correct location regardless of where the child config is stored.
+
+**How it works:**
+
+- Each parent config's relative resource paths (agents, rules, slash-commands, hooks files, files-to-download sources, skill bases, system prompts, and status-line files) are resolved to absolute URLs or paths **before** merging with child values
+- The resolution uses the parent config's own `config_source` (where it was loaded from) and `base-url`
+- Child (leaf) config paths continue to be resolved at validation time using the leaf's own source
+
+**Example:** A GitHub-hosted parent with a local child:
+
+```yaml
+# Parent (hosted at https://raw.githubusercontent.com/org/repo/main/parent.yaml)
+agents:
+  - "agents/shared-agent.md"       # Resolved to https://raw.githubusercontent.com/org/repo/main/agents/shared-agent.md
+rules:
+  - "rules/coding-standards.md"    # Resolved to https://raw.githubusercontent.com/org/repo/main/rules/coding-standards.md
+```
+
+```yaml
+# Child (local file: ~/my-project/config.yaml)
+inherit: "https://raw.githubusercontent.com/org/repo/main/parent.yaml"
+agents:
+  - "agents/local-agent.md"        # Resolved locally from ~/my-project/ at validation time
+```
+
+After inheritance resolution, the merged config contains both the GitHub-resolved parent paths and the local child paths. Each is resolved from the correct source.
+
+**Key points:**
+
+- A child `base-url` does **not** affect parent resource paths. Each config level's `base-url` governs only its own resources.
+- Skills `base` paths ignore `base-url` by design -- they are resolved directly from the config source.
+- Already-absolute paths and full URLs pass through resolution unchanged.
 
 #### Inheritance Path Resolution
 

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -2303,7 +2303,10 @@ def install_ide_extensions(
                 use_marketplace_syntax = True
                 warning(
                     'Using marketplace @version syntax. '
-                    'VS Code may auto-update this extension.',
+                    'VS Code may auto-update this extension. '
+                    'To prevent auto-updates: in VS Code Extensions view, '
+                    'right-click the Claude Code extension and set '
+                    '"Auto Update" to off.',
                 )
 
         # Install into each detected IDE

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -75,6 +75,26 @@ MERGEABLE_CONFIG_KEYS: frozenset[str] = frozenset({
     'os-env-variables',
 })
 
+# Config keys containing file references (paths or URLs) that require
+# resolution and validation. Used as a single source of truth for maintenance.
+# Dot notation indicates nested keys (e.g., 'hooks.files' = hooks['files']).
+#
+# Access patterns differ per key type (simple list, dict-nested list,
+# dict-nested scalar), so this constant serves as a registry, not a
+# dispatch mechanism. validate_all_config_files() and
+# _resolve_config_file_paths() handle type-specific extraction logic.
+FILE_REFERENCE_KEYS: frozenset[str] = frozenset({
+    'agents',                        # list[str] -- simple string list
+    'slash-commands',                 # list[str] -- simple string list
+    'rules',                         # list[str] -- simple string list
+    'hooks.files',                   # list[str] -- nested under hooks dict
+    'files-to-download',             # list[dict] -- each dict has 'source' key
+    'skills',                        # list[dict] -- each dict has 'base' key
+    'command-defaults.system-prompt',  # str -- nested scalar under command-defaults
+    'status-line.file',              # str -- nested scalar under status-line
+    'status-line.config',            # str -- nested scalar under status-line
+})
+
 # Node.js installation constants (standalone -- no imports from install_claude.py)
 MIN_NODE_VERSION = '18.0.0'
 NODE_LTS_API = 'https://nodejs.org/dist/index.json'
@@ -3104,6 +3124,53 @@ def _collect_simple_list_files(
     return files
 
 
+def _inject_status_line_into_hooks_files(config: dict[str, Any]) -> None:
+    """Auto-inject status-line file references into hooks.files for validation and download.
+
+    Ensures status-line.file and status-line.config are included in hooks.files
+    so they are validated and downloaded by the existing pipeline.
+
+    Args:
+        config: The configuration dictionary (modified in place).
+    """
+    status_line = config.get('status-line')
+    if not status_line or not isinstance(status_line, dict):
+        return
+
+    # Collect file references from status-line
+    files_to_inject: list[str] = []
+    sl_file = status_line.get('file')
+    if sl_file and isinstance(sl_file, str):
+        files_to_inject.append(sl_file)
+    sl_config = status_line.get('config')
+    if sl_config and isinstance(sl_config, str):
+        files_to_inject.append(sl_config)
+
+    if not files_to_inject:
+        return
+
+    # Ensure hooks dict exists
+    hooks = config.get('hooks')
+    if hooks is None:
+        hooks = {}
+        config['hooks'] = hooks
+    elif not isinstance(hooks, dict):
+        return
+
+    # Ensure hooks.files list exists
+    hook_files = hooks.get('files')
+    if hook_files is None:
+        hook_files = []
+        hooks['files'] = hook_files
+    elif not isinstance(hook_files, list):
+        return
+
+    # Inject each file if not already present
+    for file_ref in files_to_inject:
+        if file_ref not in hook_files:
+            hook_files.append(file_ref)
+
+
 def validate_all_config_files(
     config: dict[str, Any],
     config_source: str,
@@ -3111,6 +3178,9 @@ def validate_all_config_files(
     auth_cache: 'AuthHeaderCache | None' = None,
 ) -> tuple[bool, list[tuple[str, str, bool, str]]]:
     """Validate all files in the configuration (both remote and local).
+
+    Validates accessibility of all file references across config keys defined
+    in FILE_REFERENCE_KEYS.
 
     Args:
         config: Environment configuration dictionary
@@ -3778,6 +3848,113 @@ def resolve_resource_path(resource_path: str, config_source: str, base_url: str 
     return str(resource_full_path), False
 
 
+def _resolve_config_file_paths(config: dict[str, Any], config_source: str) -> dict[str, Any]:
+    """Resolve all relative file paths in a config dict using its own source.
+
+    Converts relative file paths to absolute URLs or paths so that after merging,
+    each file reference is self-contained and does not depend on the leaf config's
+    source for resolution.
+
+    Only resolves paths that are RELATIVE. Absolute paths and full URLs are
+    left unchanged (resolve_resource_path passes them through).
+
+    See FILE_REFERENCE_KEYS for the complete list of config keys containing
+    file references.
+
+    Args:
+        config: Configuration dictionary containing file references.
+        config_source: The source URL or path where this config was loaded from.
+
+    Returns:
+        A new config dict with file paths resolved. The original dict is not modified.
+    """
+    result = config.copy()
+    base_url = config.get('base-url')
+
+    # --- Simple list keys: agents, slash-commands, rules ---
+    for key in ('agents', 'slash-commands', 'rules'):
+        items = result.get(key)
+        if isinstance(items, list):
+            resolved_items = []
+            for item in items:
+                if isinstance(item, str):
+                    resolved_path, _ = resolve_resource_path(item, config_source, base_url)
+                    resolved_items.append(resolved_path)
+                else:
+                    resolved_items.append(item)
+            result[key] = resolved_items
+
+    # --- hooks.files ---
+    hooks = result.get('hooks')
+    if isinstance(hooks, dict):
+        hooks = hooks.copy()
+        hook_files = hooks.get('files')
+        if isinstance(hook_files, list):
+            resolved_files = []
+            for item in hook_files:
+                if isinstance(item, str):
+                    resolved_path, _ = resolve_resource_path(item, config_source, base_url)
+                    resolved_files.append(resolved_path)
+                else:
+                    resolved_files.append(item)
+            hooks['files'] = resolved_files
+        result['hooks'] = hooks
+
+    # --- files-to-download[].source ---
+    ftd = result.get('files-to-download')
+    if isinstance(ftd, list):
+        resolved_ftd = []
+        for item in ftd:
+            if isinstance(item, dict):
+                item = item.copy()
+                source = item.get('source')
+                if isinstance(source, str):
+                    resolved_path, _ = resolve_resource_path(source, config_source, base_url)
+                    item['source'] = resolved_path
+            resolved_ftd.append(item)
+        result['files-to-download'] = resolved_ftd
+
+    # --- skills[].base (uses None for base_url to match validate_all_config_files behavior) ---
+    skills = result.get('skills')
+    if isinstance(skills, list):
+        resolved_skills = []
+        for item in skills:
+            if isinstance(item, dict):
+                item = item.copy()
+                skill_base = item.get('base')
+                if isinstance(skill_base, str):
+                    resolved_path, _ = resolve_resource_path(skill_base, config_source, None)
+                    item['base'] = resolved_path
+            resolved_skills.append(item)
+        result['skills'] = resolved_skills
+
+    # --- command-defaults.system-prompt ---
+    cmd_defaults = result.get('command-defaults')
+    if isinstance(cmd_defaults, dict):
+        cmd_defaults = cmd_defaults.copy()
+        sys_prompt = cmd_defaults.get('system-prompt')
+        if isinstance(sys_prompt, str):
+            resolved_path, _ = resolve_resource_path(sys_prompt, config_source, base_url)
+            cmd_defaults['system-prompt'] = resolved_path
+        result['command-defaults'] = cmd_defaults
+
+    # --- status-line.file and status-line.config ---
+    sl = result.get('status-line')
+    if isinstance(sl, dict):
+        sl = sl.copy()
+        sl_file = sl.get('file')
+        if isinstance(sl_file, str):
+            resolved_path, _ = resolve_resource_path(sl_file, config_source, base_url)
+            sl['file'] = resolved_path
+        sl_config = sl.get('config')
+        if isinstance(sl_config, str):
+            resolved_path, _ = resolve_resource_path(sl_config, config_source, base_url)
+            sl['config'] = resolved_path
+        result['status-line'] = sl
+
+    return result
+
+
 def load_config_from_source(config_spec: str, auth_param: str | None = None) -> tuple[dict[str, Any], str]:
     """Load configuration from URL, local path, or repository.
 
@@ -3859,7 +4036,7 @@ def load_config_from_source(config_spec: str, auth_param: str | None = None) -> 
         content = fetch_url_with_auth(config_url, auth_param=auth_param)
         config = yaml.safe_load(content)
         success(f"Configuration loaded: {config.get('name', config_spec)}")
-        return config, config_spec
+        return config, config_url
     except urllib.error.HTTPError as e:
         if e.code == 404:
             error(f'Configuration not found in repository: {config_spec}')
@@ -4343,6 +4520,9 @@ def _resolve_list_inherit(
             error(f'Error: {e}')
             raise
 
+        # Resolve entry's file paths using its own source before composition
+        entry_config = _resolve_config_file_paths(entry_config, actual_source)
+
         # Rule 1: Strip own inherit from entry (completely ignored)
         own_inherit = entry_config.get(INHERIT_KEY)
         if own_inherit is not None:
@@ -4592,6 +4772,9 @@ def resolve_config_inheritance(
         depth=depth + 1,
         chain=chain,
     )
+
+    # Resolve parent's file paths using parent's own source before merging
+    resolved_parent = _resolve_config_file_paths(resolved_parent, actual_parent_source)
 
     # Append the parent entry to the chain after recursion resolves deeper ancestors
     chain.append(InheritanceChainEntry(
@@ -9478,6 +9661,9 @@ def main() -> None:
 
         # Extract status_line configuration
         status_line = config.get('status-line')
+
+        # Auto-inject status-line files into hooks.files for validation and download
+        _inject_status_line_into_hooks_files(config)
 
         # Extract and validate effort_level configuration
         effort_level = config.get('effort-level')

--- a/tests/e2e/test_list_inherit.py
+++ b/tests/e2e/test_list_inherit.py
@@ -40,6 +40,24 @@ def _resolve(
     return setup_environment.resolve_config_inheritance(config, source)
 
 
+def _contains_path(items: list[str], suffix: str) -> bool:
+    """Check if any item in the list ends with the given path suffix.
+
+    Parent paths are resolved to absolute paths during inheritance, so exact
+    string comparison fails. This helper normalizes by checking path suffixes.
+
+    Returns:
+        True if any item matches the suffix.
+    """
+    import os
+
+    normalized_suffix = suffix.replace('/', os.sep)
+    return any(
+        item == suffix or item.endswith((os.sep + normalized_suffix, '/' + suffix))
+        for item in items
+    )
+
+
 class TestBasicListComposition:
     """Test basic two-element list composition (Rule 2)."""
 
@@ -165,8 +183,8 @@ class TestMergeKeysPerEntry:
         resolved, _ = _resolve(config, str(path))
         rules = resolved.get('rules', [])
         # Structured entry merge-keys: [agents, rules] -- middle merges with base
-        assert 'rules/base-rule.md' in rules
-        assert 'rules/middle-rule.md' in rules
+        assert _contains_path(rules, 'rules/base-rule.md')
+        assert _contains_path(rules, 'rules/middle-rule.md')
 
     def test_leaf_merge_keys_applied(self, fixtures_dir):
         """Leaf's own merge-keys applies on top of accumulated (Rule 4)."""
@@ -177,10 +195,10 @@ class TestMergeKeysPerEntry:
         # But leaf has merge-keys: [agents, rules], so leaf MERGES with accumulated
         agents = resolved.get('agents', [])
         # Middle replaced base (no per-entry merge-keys), then leaf merges
-        assert 'agents/middle-agent.md' in agents
-        assert 'agents/mk-leaf-agent.md' in agents
+        assert _contains_path(agents, 'agents/middle-agent.md')
+        assert _contains_path(agents, 'agents/mk-leaf-agent.md')
         # Base agents were replaced by middle (not merged), so base NOT present
-        assert 'agents/base-agent.md' not in agents
+        assert not _contains_path(agents, 'agents/base-agent.md')
 
     def test_leaf_merge_keys_merge_rules(self, fixtures_dir):
         """Leaf's merge-keys merges rules from accumulated + leaf."""
@@ -189,10 +207,10 @@ class TestMergeKeysPerEntry:
         resolved, _ = _resolve(config, str(path))
         rules = resolved.get('rules', [])
         # Middle replaced base rules (no per-entry merge-keys), then leaf merges
-        assert 'rules/middle-rule.md' in rules
-        assert 'rules/mk-leaf-rule.md' in rules
+        assert _contains_path(rules, 'rules/middle-rule.md')
+        assert _contains_path(rules, 'rules/mk-leaf-rule.md')
         # Base rules replaced by middle
-        assert 'rules/base-rule.md' not in rules
+        assert not _contains_path(rules, 'rules/base-rule.md')
 
     def test_leaf_without_merge_keys_replaces_agents(self, fixtures_dir):
         """Leaf without merge-keys replaces accumulated agents."""
@@ -291,17 +309,27 @@ class TestEquivalenceToSeparateFiles:
         list_result, _ = _resolve(leaf_config, str(leaf_path))
 
         # Method 2: Manual simulation of new Rule 3 behavior
-        base_config = _load_yaml(fixtures_dir / 'list_inherit_base.yaml')
-        middle_config = _load_yaml(fixtures_dir / 'list_inherit_middle.yaml')
+        base_path = fixtures_dir / 'list_inherit_base.yaml'
+        middle_path = fixtures_dir / 'list_inherit_middle.yaml'
+        base_config = _load_yaml(base_path)
+        middle_config = _load_yaml(middle_path)
+
+        # Resolve file paths using each entry's own source (matching real behavior)
+        base_resolved = setup_environment._resolve_config_file_paths(
+            base_config, str(base_path),
+        )
+        middle_resolved = setup_environment._resolve_config_file_paths(
+            middle_config, str(middle_path),
+        )
 
         # Step 1: Strip middle's own merge-keys (Rule 3), compose with REPLACE semantics
         base_stripped = {
-            k: v for k, v in base_config.items()
+            k: v for k, v in base_resolved.items()
             if k not in ('inherit', 'merge-keys')
         }
         # With Rule 3, middle's own merge-keys is stripped, so merge_keys=None (REPLACE)
         step1 = setup_environment._merge_configs(
-            base_stripped, middle_config, merge_keys=None,
+            base_stripped, middle_resolved, merge_keys=None,
         )
 
         # Step 2: apply leaf on top (leaf has no merge-keys)

--- a/tests/e2e/test_merge_keys.py
+++ b/tests/e2e/test_merge_keys.py
@@ -4,6 +4,7 @@ Tests verify that configuration inheritance with merge-keys correctly merges
 specified keys using type-aware strategies while replacing non-listed keys.
 """
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -33,6 +34,22 @@ def _resolve(
     return setup_environment.resolve_config_inheritance(config, source)
 
 
+def _contains_path(items: list[str], suffix: str) -> bool:
+    """Check if any item in the list ends with the given path suffix.
+
+    Parent paths are resolved to absolute paths during inheritance, so exact
+    string comparison fails. This helper normalizes by checking path suffixes.
+
+    Returns:
+        True if any item matches the suffix.
+    """
+    normalized_suffix = suffix.replace('/', os.sep)
+    return any(
+        item == suffix or item.endswith((os.sep + normalized_suffix, '/' + suffix))
+        for item in items
+    )
+
+
 class TestTwoLevelMerge:
     """Test two-level parent-child inheritance with merge-keys."""
 
@@ -41,16 +58,16 @@ class TestTwoLevelMerge:
         child_path = fixtures_dir / 'merge_child.yaml'
         config = _load_yaml(child_path)
         resolved, _ = _resolve(config, str(child_path))
-        assert 'agents/parent-agent.md' in resolved['agents']
-        assert 'agents/child-agent.md' in resolved['agents']
+        assert _contains_path(resolved['agents'], 'agents/parent-agent.md')
+        assert _contains_path(resolved['agents'], 'agents/child-agent.md')
 
     def test_rules_merged(self, fixtures_dir):
         """Rules from parent and child are concatenated."""
         child_path = fixtures_dir / 'merge_child.yaml'
         config = _load_yaml(child_path)
         resolved, _ = _resolve(config, str(child_path))
-        assert 'rules/parent-rule.md' in resolved['rules']
-        assert 'rules/child-rule.md' in resolved['rules']
+        assert _contains_path(resolved['rules'], 'rules/parent-rule.md')
+        assert _contains_path(resolved['rules'], 'rules/child-rule.md')
 
     def test_mcp_servers_in_position_replacement(self, fixtures_dir):
         """MCP server with same name replaced in-position; new server appended."""
@@ -82,8 +99,8 @@ class TestTwoLevelMerge:
         config = _load_yaml(child_path)
         resolved, _ = _resolve(config, str(child_path))
         hooks = resolved['hooks']
-        assert 'hooks/parent-hook.py' in hooks['files']
-        assert 'hooks/child-hook.py' in hooks['files']
+        assert _contains_path(hooks['files'], 'hooks/parent-hook.py')
+        assert _contains_path(hooks['files'], 'hooks/child-hook.py')
         assert len(hooks['events']) == 2
 
     def test_global_config_deep_merge(self, fixtures_dir):
@@ -176,11 +193,11 @@ class TestFourLevelChain:
         agents = resolved['agents']
         # L3 replaces everything from L1+L2 with ['agents/l3-agent.md']
         # L4 merges with L3, adding ['agents/l4-agent.md']
-        assert 'agents/l3-agent.md' in agents
-        assert 'agents/l4-agent.md' in agents
+        assert _contains_path(agents, 'agents/l3-agent.md')
+        assert _contains_path(agents, 'agents/l4-agent.md')
         # L1 and L2 agents should NOT be present (L3 replaced)
-        assert 'agents/l1-agent.md' not in agents
-        assert 'agents/l2-agent.md' not in agents
+        assert not _contains_path(agents, 'agents/l1-agent.md')
+        assert not _contains_path(agents, 'agents/l2-agent.md')
 
     def test_mcp_servers_chain(self, fixtures_dir):
         """MCP servers follow same merge-replace-merge pattern."""
@@ -201,10 +218,10 @@ class TestFourLevelChain:
         resolved, _ = _resolve(config, str(l4_path))
 
         rules = resolved['rules']
-        assert 'rules/l3-rule.md' in rules
-        assert 'rules/l4-rule.md' in rules
-        assert 'rules/l1-rule.md' not in rules
-        assert 'rules/l2-rule.md' not in rules
+        assert _contains_path(rules, 'rules/l3-rule.md')
+        assert _contains_path(rules, 'rules/l4-rule.md')
+        assert not _contains_path(rules, 'rules/l1-rule.md')
+        assert not _contains_path(rules, 'rules/l2-rule.md')
 
     def test_chain_length(self, fixtures_dir):
         """Inheritance chain has 3 entries (L1, L2, L3 as ancestors of L4)."""
@@ -232,7 +249,8 @@ class TestTwoLevelReplace:
 
         # L3 has no merge-keys, so it replaces L2's (merged) agents
         agents = resolved['agents']
-        assert agents == ['agents/l3-agent.md']
+        assert len(agents) == 1
+        assert _contains_path(agents, 'agents/l3-agent.md')
 
 
 class TestMergeKeysWithoutInherit:

--- a/tests/scripts/models/test_file_reference_keys_parity.py
+++ b/tests/scripts/models/test_file_reference_keys_parity.py
@@ -1,0 +1,109 @@
+"""Parity test: FILE_REFERENCE_KEYS must match keys processed by _resolve_config_file_paths().
+
+Ensures the registry constant stays synchronized with the actual resolution logic.
+If this test fails, a file-reference key was added to or removed from
+_resolve_config_file_paths() without updating FILE_REFERENCE_KEYS (or vice versa).
+
+Fix: Update BOTH FILE_REFERENCE_KEYS and _resolve_config_file_paths() simultaneously.
+"""
+
+from __future__ import annotations
+
+from scripts.setup_environment import FILE_REFERENCE_KEYS
+from scripts.setup_environment import _resolve_config_file_paths
+
+
+def _get_keys_resolved_by_function() -> frozenset[str]:
+    """Determine which file-reference keys _resolve_config_file_paths actually resolves.
+
+    Feeds a config with sentinel values for all possible file-reference keys
+    and checks which ones are transformed by the function.
+
+    Returns:
+        frozenset of dot-path key identifiers that the function resolves.
+    """
+    sentinel_value = 'sentinel-relative-path.txt'
+    url_source = 'https://raw.githubusercontent.com/test/repo/main/config.yaml'
+
+    # Config with all possible file-reference key types populated
+    config: dict = {
+        'agents': [sentinel_value],
+        'slash-commands': [sentinel_value],
+        'rules': [sentinel_value],
+        'hooks': {'files': [sentinel_value], 'events': []},
+        'files-to-download': [{'source': sentinel_value, 'destination': '/tmp/test'}],
+        'skills': [{'base': sentinel_value, 'files': ['SKILL.md']}],
+        'command-defaults': {'system-prompt': sentinel_value, 'mode': 'replace'},
+        'status-line': {'file': sentinel_value, 'config': sentinel_value, 'interval': 10},
+    }
+
+    result = _resolve_config_file_paths(config, url_source)
+
+    resolved_keys: set[str] = set()
+
+    # Check simple list keys
+    for key in ('agents', 'slash-commands', 'rules'):
+        if result.get(key) and result[key] != config[key]:
+            resolved_keys.add(key)
+
+    # Check hooks.files
+    if (
+        result.get('hooks', {}).get('files')
+        and result['hooks']['files'] != config['hooks']['files']
+    ):
+        resolved_keys.add('hooks.files')
+
+    # Check files-to-download
+    ftd_result = result.get('files-to-download', [])
+    ftd_original = config['files-to-download']
+    if ftd_result and ftd_result[0].get('source') != ftd_original[0].get('source'):
+        resolved_keys.add('files-to-download')
+
+    # Check skills
+    skills_result = result.get('skills', [])
+    skills_original = config['skills']
+    if skills_result and skills_result[0].get('base') != skills_original[0].get('base'):
+        resolved_keys.add('skills')
+
+    # Check command-defaults.system-prompt
+    cd_result = result.get('command-defaults', {})
+    cd_original = config['command-defaults']
+    if cd_result.get('system-prompt') != cd_original.get('system-prompt'):
+        resolved_keys.add('command-defaults.system-prompt')
+
+    # Check status-line.file
+    sl_result = result.get('status-line', {})
+    sl_original = config['status-line']
+    if sl_result.get('file') != sl_original.get('file'):
+        resolved_keys.add('status-line.file')
+
+    # Check status-line.config
+    if sl_result.get('config') != sl_original.get('config'):
+        resolved_keys.add('status-line.config')
+
+    return frozenset(resolved_keys)
+
+
+def test_file_reference_keys_match_resolve_function() -> None:
+    """FILE_REFERENCE_KEYS must match keys resolved by _resolve_config_file_paths."""
+    resolved_keys = _get_keys_resolved_by_function()
+    assert resolved_keys == FILE_REFERENCE_KEYS, (
+        f'FILE_REFERENCE_KEYS and _resolve_config_file_paths are out of sync.\n'
+        f'In FILE_REFERENCE_KEYS only: {sorted(FILE_REFERENCE_KEYS - resolved_keys)}\n'
+        f'Resolved by function only: {sorted(resolved_keys - FILE_REFERENCE_KEYS)}'
+    )
+
+
+def test_file_reference_keys_is_subset_of_known_keys() -> None:
+    """All top-level keys in FILE_REFERENCE_KEYS must appear in KNOWN_CONFIG_KEYS.
+
+    Dot-path keys (e.g., 'hooks.files') are checked by their top-level prefix.
+    """
+    from scripts.setup_environment import KNOWN_CONFIG_KEYS
+
+    for key in FILE_REFERENCE_KEYS:
+        top_level = key.split('.')[0]
+        assert top_level in KNOWN_CONFIG_KEYS, (
+            f'FILE_REFERENCE_KEYS contains "{key}" whose top-level key "{top_level}" '
+            f'is not in KNOWN_CONFIG_KEYS.'
+        )

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -11485,6 +11485,24 @@ class TestInstallIdeExtensions:
         assert result is True
         assert 'anthropic.claude-code@2.1.85' in commands_run[0]
 
+    def test_marketplace_fallback_warning_text(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setattr(shutil, 'which', lambda name: '/usr/bin/code' if name == 'code' else None)
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+
+        def mock_fetch_fail(_url: str, **_kw: object) -> bytes:
+            raise Exception('download failed')
+
+        monkeypatch.setattr(setup_environment, 'fetch_url_bytes_with_auth', mock_fetch_fail)
+        monkeypatch.setattr(setup_environment, 'run_command', lambda _cmd, **_kw: MagicMock(returncode=0))
+
+        setup_environment.install_ide_extensions('2.1.85')
+
+        captured = capsys.readouterr()
+        assert 'right-click' in captured.out
+        assert 'Auto Update' in captured.out
+
     def test_multiple_ides_installed(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         def mock_which(name: str) -> str | None:
             return f'/usr/bin/{name}' if name in ('code', 'cursor') else None

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -1383,8 +1383,120 @@ class TestLoadConfig:
 
         config, source = setup_environment.load_config_from_source('python')
         assert config['name'] == 'Repo Config'
-        assert source == 'python.yaml'
+        assert source == 'https://raw.githubusercontent.com/alex-feel/claude-code-artifacts-public/main/python.yaml'
         mock_fetch.assert_called_once()
+
+    @pytest.mark.parametrize(
+        ('input_spec', 'expected_url_suffix'),
+        [
+            ('python', 'python.yaml'),
+            ('python.yaml', 'python.yaml'),
+            ('my-config', 'my-config.yaml'),
+            ('my-config.yaml', 'my-config.yaml'),
+        ],
+    )
+    @patch('setup_environment.fetch_url_with_auth')
+    def test_load_config_from_repository_returns_url(self, mock_fetch, input_spec, expected_url_suffix):
+        """Source 3 returns the full GitHub raw URL for proper path resolution."""
+        mock_fetch.return_value = 'name: Test Config'
+        config, source = setup_environment.load_config_from_source(input_spec)
+        expected_url = f'https://raw.githubusercontent.com/alex-feel/claude-code-artifacts-public/main/{expected_url_suffix}'
+        assert source == expected_url
+        assert config['name'] == 'Test Config'
+
+    @patch('setup_environment.fetch_url_with_auth')
+    def test_source_3_url_enables_path_resolution(self, mock_fetch):
+        """Source 3 URL enables resolve_resource_path to derive correct base URL."""
+        mock_fetch.return_value = 'name: Test'
+        _, source = setup_environment.load_config_from_source('python')
+        assert source.startswith('https://')
+        resolved, is_remote = setup_environment.resolve_resource_path('agents/my-agent.md', source, None)
+        assert is_remote is True
+        assert 'agents/my-agent.md' in resolved
+
+
+class TestInjectStatusLineIntoHooksFiles:
+    """Tests for _inject_status_line_into_hooks_files() function."""
+
+    def test_inject_creates_hooks_files(self):
+        """Auto-inject creates hooks.files when hooks key is missing."""
+        config = {
+            'status-line': {
+                'file': 'hooks/status.py',
+                'config': 'configs/status-config.yaml',
+            },
+        }
+        setup_environment._inject_status_line_into_hooks_files(config)
+        assert config['hooks']['files'] == ['hooks/status.py', 'configs/status-config.yaml']
+
+    def test_inject_no_duplicates(self):
+        """Auto-inject does not create duplicates when files already present."""
+        config = {
+            'status-line': {
+                'file': 'hooks/status.py',
+                'config': 'configs/status-config.yaml',
+            },
+            'hooks': {
+                'files': ['hooks/status.py', 'hooks/other.py'],
+            },
+        }
+        setup_environment._inject_status_line_into_hooks_files(config)
+        assert config['hooks']['files'] == ['hooks/status.py', 'hooks/other.py', 'configs/status-config.yaml']
+
+    def test_inject_no_status_line(self):
+        """Auto-inject is a no-op when status-line is not configured."""
+        config = {'hooks': {'files': ['hooks/other.py']}}
+        setup_environment._inject_status_line_into_hooks_files(config)
+        assert config['hooks']['files'] == ['hooks/other.py']
+
+    def test_inject_file_only(self):
+        """Auto-inject handles status-line with file but no config."""
+        config = {
+            'status-line': {'file': 'hooks/status.py'},
+        }
+        setup_environment._inject_status_line_into_hooks_files(config)
+        assert config['hooks']['files'] == ['hooks/status.py']
+
+    def test_inject_config_only(self):
+        """Auto-inject handles status-line with config but no file."""
+        config = {
+            'status-line': {'config': 'configs/status-config.yaml'},
+        }
+        setup_environment._inject_status_line_into_hooks_files(config)
+        assert config['hooks']['files'] == ['configs/status-config.yaml']
+
+    def test_inject_invalid_status_line_type(self):
+        """Auto-inject handles status-line that is not a dict."""
+        config = {'status-line': 'invalid'}
+        setup_environment._inject_status_line_into_hooks_files(config)
+        assert 'hooks' not in config
+
+    def test_inject_invalid_hooks_type(self):
+        """Auto-inject handles hooks that is not a dict."""
+        config = {'status-line': {'file': 'x.py'}, 'hooks': 'invalid'}
+        setup_environment._inject_status_line_into_hooks_files(config)
+        assert config['hooks'] == 'invalid'
+
+    def test_inject_invalid_hooks_files_type(self):
+        """Auto-inject handles hooks.files that is not a list."""
+        config = {'status-line': {'file': 'x.py'}, 'hooks': {'files': 'invalid'}}
+        setup_environment._inject_status_line_into_hooks_files(config)
+        assert config['hooks']['files'] == 'invalid'
+
+    def test_inject_empty_strings(self):
+        """Auto-inject skips empty string values."""
+        config = {'status-line': {'file': '', 'config': ''}}
+        setup_environment._inject_status_line_into_hooks_files(config)
+        assert 'hooks' not in config
+
+    def test_inject_with_existing_empty_hooks_files(self):
+        """Auto-inject appends to an empty hooks.files list."""
+        config = {
+            'status-line': {'file': 'hooks/status.py'},
+            'hooks': {'files': []},
+        }
+        setup_environment._inject_status_line_into_hooks_files(config)
+        assert config['hooks']['files'] == ['hooks/status.py']
 
 
 class TestGetRealUserHome:
@@ -7243,6 +7355,262 @@ agents:
             assert 'inherit' not in resolved
 
 
+class TestResolveConfigFilePaths:
+    """Unit tests for _resolve_config_file_paths() helper."""
+
+    def test_resolve_agents_with_url_source(self):
+        """Relative agent paths resolved to full URLs using URL config_source."""
+        config = {'agents': ['agents/my-agent.md', 'agents/helper.md']}
+        source = 'https://raw.githubusercontent.com/user/repo/main/config.yaml'
+        result = setup_environment._resolve_config_file_paths(config, source)
+        assert result['agents'][0] == 'https://raw.githubusercontent.com/user/repo/main/agents/my-agent.md'
+        assert result['agents'][1] == 'https://raw.githubusercontent.com/user/repo/main/agents/helper.md'
+
+    def test_resolve_agents_with_local_source(self, tmp_path):
+        """Relative agent paths resolved to absolute local paths."""
+        config_file = tmp_path / 'config.yaml'
+        config_file.touch()
+        config = {'agents': ['agents/my-agent.md']}
+        result = setup_environment._resolve_config_file_paths(config, str(config_file))
+        expected = str((tmp_path / 'agents' / 'my-agent.md').resolve())
+        assert result['agents'][0] == expected
+
+    def test_resolve_url_paths_unchanged(self):
+        """Full URL paths in config pass through without modification."""
+        url = 'https://example.com/agents/my-agent.md'
+        config = {
+            'agents': [url],
+            'slash-commands': [url],
+            'rules': [url],
+        }
+        result = setup_environment._resolve_config_file_paths(config, 'some-source.yaml')
+        assert result['agents'][0] == url
+        assert result['slash-commands'][0] == url
+        assert result['rules'][0] == url
+
+    def test_resolve_absolute_paths_unchanged(self):
+        """Absolute local paths pass through without modification."""
+        if sys.platform == 'win32':
+            abs_path = r'C:\Users\test\agents\agent.md'
+        else:
+            abs_path = '/home/user/agents/agent.md'
+        config = {'agents': [abs_path]}
+        result = setup_environment._resolve_config_file_paths(config, 'some-source.yaml')
+        assert Path(result['agents'][0]).is_absolute()
+
+    def test_resolve_hooks_files(self):
+        """hooks.files paths resolved using config_source."""
+        config = {
+            'hooks': {
+                'files': ['hooks/linter.py', 'hooks/formatter.sh'],
+                'events': [{'event': 'PostToolUse'}],
+            },
+        }
+        source = 'https://raw.githubusercontent.com/user/repo/main/config.yaml'
+        result = setup_environment._resolve_config_file_paths(config, source)
+        assert 'raw.githubusercontent.com' in result['hooks']['files'][0]
+        assert 'hooks/linter.py' in result['hooks']['files'][0]
+        assert result['hooks']['events'] == config['hooks']['events']
+
+    def test_resolve_files_to_download_source(self):
+        """files-to-download source paths resolved using config_source."""
+        config = {
+            'files-to-download': [
+                {'source': 'scripts/tool.sh', 'destination': '~/.local/bin/tool.sh'},
+                {'source': 'https://example.com/file.txt', 'destination': '/tmp/file.txt'},
+            ],
+        }
+        source = 'https://raw.githubusercontent.com/user/repo/main/config.yaml'
+        result = setup_environment._resolve_config_file_paths(config, source)
+        assert 'raw.githubusercontent.com' in result['files-to-download'][0]['source']
+        assert result['files-to-download'][1]['source'] == 'https://example.com/file.txt'
+        assert result['files-to-download'][0]['destination'] == '~/.local/bin/tool.sh'
+
+    def test_resolve_skills_base_without_base_url(self):
+        """skills[].base resolved with None base_url (matching validation behavior)."""
+        config = {
+            'base-url': 'https://custom-base.com/{path}',
+            'skills': [
+                {'base': 'skills/my-skill', 'files': ['SKILL.md', 'prompt.md']},
+            ],
+        }
+        source = 'https://raw.githubusercontent.com/user/repo/main/config.yaml'
+        result = setup_environment._resolve_config_file_paths(config, source)
+        resolved_base = result['skills'][0]['base']
+        assert 'custom-base.com' not in resolved_base
+        assert 'raw.githubusercontent.com' in resolved_base
+        assert result['skills'][0]['files'] == ['SKILL.md', 'prompt.md']
+
+    def test_resolve_command_defaults_system_prompt(self):
+        """command-defaults.system-prompt resolved using config_source."""
+        config = {
+            'command-defaults': {
+                'system-prompt': 'prompts/my-prompt.md',
+                'mode': 'replace',
+            },
+        }
+        source = 'https://raw.githubusercontent.com/user/repo/main/config.yaml'
+        result = setup_environment._resolve_config_file_paths(config, source)
+        assert 'raw.githubusercontent.com' in result['command-defaults']['system-prompt']
+        assert 'prompts/my-prompt.md' in result['command-defaults']['system-prompt']
+        assert result['command-defaults']['mode'] == 'replace'
+
+    def test_resolve_status_line_paths(self):
+        """status-line.file and status-line.config resolved using config_source."""
+        config = {
+            'status-line': {
+                'file': 'hooks/status.py',
+                'config': 'configs/status-config.yaml',
+                'interval': 10,
+            },
+        }
+        source = 'https://raw.githubusercontent.com/user/repo/main/config.yaml'
+        result = setup_environment._resolve_config_file_paths(config, source)
+        assert 'raw.githubusercontent.com' in result['status-line']['file']
+        assert 'raw.githubusercontent.com' in result['status-line']['config']
+        assert result['status-line']['interval'] == 10
+
+    def test_resolve_with_base_url(self):
+        """Config with base-url uses it for resolution of simple list keys."""
+        config = {
+            'base-url': 'https://custom-cdn.com/files/{path}',
+            'agents': ['agents/my-agent.md'],
+        }
+        source = 'https://raw.githubusercontent.com/user/repo/main/config.yaml'
+        result = setup_environment._resolve_config_file_paths(config, source)
+        assert result['agents'][0] == 'https://custom-cdn.com/files/agents/my-agent.md'
+
+    def test_resolve_empty_config(self):
+        """Config with no file-bearing keys produces no errors."""
+        config = {'name': 'Test', 'model': 'opus'}
+        result = setup_environment._resolve_config_file_paths(config, 'test.yaml')
+        assert result == config
+
+    def test_resolve_does_not_modify_original(self):
+        """_resolve_config_file_paths returns a new dict without modifying original."""
+        config = {
+            'agents': ['agents/my-agent.md'],
+            'hooks': {'files': ['hooks/linter.py']},
+        }
+        source = 'https://raw.githubusercontent.com/user/repo/main/config.yaml'
+        original_agents = config['agents'].copy()
+        original_hooks_files = config['hooks']['files'].copy()
+        setup_environment._resolve_config_file_paths(config, source)
+        assert config['agents'] == original_agents
+        assert config['hooks']['files'] == original_hooks_files
+
+    def test_resolve_tilde_paths(self):
+        """Tilde paths expanded to absolute local paths."""
+        config = {'agents': ['~/.claude/agents/my-agent.md']}
+        result = setup_environment._resolve_config_file_paths(config, 'test.yaml')
+        assert Path(result['agents'][0]).is_absolute()
+        assert '~' not in result['agents'][0]
+
+
+class TestResolveConfigFilePathsIntegration:
+    """Integration tests for _resolve_config_file_paths with inheritance."""
+
+    @patch.object(setup_environment, 'load_config_from_source')
+    def test_string_inherit_resolves_parent_paths(self, mock_load):
+        """Parent at URL with relative paths: paths resolved to parent's URL after inheritance."""
+        parent_url = 'https://raw.githubusercontent.com/user/repo/main/parent.yaml'
+
+        def load_side_effect(src, _auth_param=None):
+            if 'parent' in src:
+                return (
+                    {'name': 'Parent', 'agents': ['agents/parent-agent.md']},
+                    parent_url,
+                )
+            raise FileNotFoundError(f'Not found: {src}')
+
+        mock_load.side_effect = load_side_effect
+        child = {'inherit': 'parent.yaml', 'name': 'Child'}
+        result, _chain = setup_environment.resolve_config_inheritance(child, 'child.yaml')
+
+        assert result['agents'][0].startswith('https://raw.githubusercontent.com/')
+        assert 'agents/parent-agent.md' in result['agents'][0]
+
+    @patch.object(setup_environment, 'load_config_from_source')
+    def test_list_inherit_resolves_each_entry_paths(self, mock_load):
+        """Each list entry's paths resolved using its own source."""
+        base_url = 'https://raw.githubusercontent.com/user/repo/main/base.yaml'
+        ext_url = 'https://raw.githubusercontent.com/user/ext-repo/main/ext.yaml'
+
+        def load_side_effect(src, _auth_param=None):
+            if 'base' in src:
+                return (
+                    {'name': 'Base', 'agents': ['agents/base-agent.md']},
+                    base_url,
+                )
+            if 'ext' in src:
+                return (
+                    {'name': 'Ext', 'rules': ['rules/ext-rule.md']},
+                    ext_url,
+                )
+            return ({}, src)
+
+        mock_load.side_effect = load_side_effect
+        child = {
+            'inherit': ['base.yaml', 'ext.yaml'],
+            'name': 'Leaf',
+        }
+        result, _chain = setup_environment.resolve_config_inheritance(child, 'leaf.yaml')
+
+        assert 'user/repo' in result['agents'][0]
+        assert 'user/ext-repo' in result['rules'][0]
+
+    @patch.object(setup_environment, 'load_config_from_source')
+    def test_multi_level_resolves_at_each_level(self, mock_load):
+        """Each level's paths resolved using its own source in deep inheritance."""
+        gp_url = 'https://raw.githubusercontent.com/org/base/main/grandparent.yaml'
+        parent_url = 'https://raw.githubusercontent.com/org/ext/main/parent.yaml'
+
+        def load_side_effect(src, _auth_param=None):
+            if 'grandparent' in src:
+                return (
+                    {'name': 'GP', 'agents': ['agents/gp-agent.md']},
+                    gp_url,
+                )
+            if 'parent' in src:
+                return (
+                    {
+                        'inherit': 'grandparent.yaml',
+                        'name': 'Parent',
+                        'rules': ['rules/parent-rule.md'],
+                    },
+                    parent_url,
+                )
+            raise FileNotFoundError(f'Not found: {src}')
+
+        mock_load.side_effect = load_side_effect
+        child = {'inherit': 'parent.yaml', 'name': 'Child'}
+        result, _chain = setup_environment.resolve_config_inheritance(child, 'child.yaml')
+
+        assert 'org/base' in result['agents'][0]
+        assert 'org/ext' in result['rules'][0]
+
+    def test_no_inherit_behavior_unchanged(self):
+        """Config without inherit does not undergo path resolution."""
+        config = {'name': 'Test', 'agents': ['agents/my-agent.md']}
+        result, _chain = setup_environment.resolve_config_inheritance(config, 'test.yaml')
+        assert result['agents'] == ['agents/my-agent.md']
+
+    @patch.object(setup_environment, 'load_config_from_source')
+    def test_absolute_paths_in_parent_unchanged(self, mock_load):
+        """Parent with absolute/URL paths: paths pass through resolution unchanged."""
+        parent_url = 'https://raw.githubusercontent.com/user/repo/main/parent.yaml'
+        mock_load.return_value = (
+            {
+                'name': 'Parent',
+                'agents': ['https://example.com/agents/remote-agent.md'],
+            },
+            parent_url,
+        )
+        child = {'inherit': 'parent.yaml', 'name': 'Child'}
+        result, _chain = setup_environment.resolve_config_inheritance(child, 'child.yaml')
+        assert result['agents'][0] == 'https://example.com/agents/remote-agent.md'
+
+
 class TestValidateMergeKeysHelper:
     """Tests for the extracted _validate_merge_keys() function."""
 
@@ -7303,16 +7671,24 @@ class TestListInherit:
         """inherit: [base, ext] -> base is lowest priority, ext overrides base."""
         def load_side_effect(src, _auth_param=None):
             if 'base' in src:
-                return ({'name': 'Base', 'model': 'sonnet', 'agents': ['a.md']}, 'base.yaml')
+                return (
+                    {'name': 'Base', 'model': 'sonnet', 'agents': ['a.md']},
+                    'https://raw.githubusercontent.com/user/repo/main/base.yaml',
+                )
             if 'ext' in src:
-                return ({'name': 'Ext', 'model': 'opus'}, 'ext.yaml')
+                return (
+                    {'name': 'Ext', 'model': 'opus'},
+                    'https://raw.githubusercontent.com/user/repo/main/ext.yaml',
+                )
             return ({}, src)
         mock_load.side_effect = load_side_effect
         child = {'inherit': ['base.yaml', 'ext.yaml'], 'name': 'Leaf'}
         result, chain = setup_environment.resolve_config_inheritance(child, 'leaf.yaml')
         assert result['name'] == 'Leaf'
         assert result['model'] == 'opus'
-        assert result['agents'] == ['a.md']
+        # Path resolved to full URL from base's source
+        assert len(result['agents']) == 1
+        assert 'a.md' in result['agents'][0]
 
     def test_list_strips_own_inherit(self, mock_load):
         """Own inherit in list entries is completely ignored (Rule 1)."""
@@ -7336,21 +7712,21 @@ class TestListInherit:
                 return ({
                     'name': 'Base',
                     'agents': ['base-agent.md'],
-                }, 'base.yaml')
+                }, 'https://raw.githubusercontent.com/user/repo/main/base.yaml')
             if 'ext' in src:
                 return ({
                     'name': 'Ext',
                     'merge-keys': ['agents'],
                     'agents': ['ext-agent.md'],
-                }, 'ext.yaml')
+                }, 'https://raw.githubusercontent.com/user/repo/main/ext.yaml')
             return ({}, src)
         mock_load.side_effect = load_side_effect
         # Plain string entries: ext's own merge-keys is STRIPPED, so ext REPLACES base
         child = {'inherit': ['base.yaml', 'ext.yaml'], 'name': 'Leaf'}
         result, chain = setup_environment.resolve_config_inheritance(child, 'leaf.yaml')
         # ext replaced base agents (no per-entry merge-keys from leaf)
-        assert 'base-agent.md' not in result['agents']
-        assert 'ext-agent.md' in result['agents']
+        assert not any('base-agent.md' in a for a in result['agents'])
+        assert any('ext-agent.md' in a for a in result['agents'])
 
     def test_list_empty_raises(self):
         """inherit: [] raises ValueError."""
@@ -7438,13 +7814,16 @@ class TestListInherit:
         """Leaf's own merge-keys applies on top of accumulated (Rule 4)."""
         def load_side_effect(src, _auth_param=None):
             if 'base' in src:
-                return ({'name': 'Base', 'agents': ['base-agent.md']}, 'base.yaml')
+                return (
+                    {'name': 'Base', 'agents': ['base-agent.md']},
+                    'https://raw.githubusercontent.com/user/repo/main/base.yaml',
+                )
             if 'ext' in src:
                 return ({
                     'name': 'Ext',
                     'merge-keys': ['agents'],
                     'agents': ['ext-agent.md'],
-                }, 'ext.yaml')
+                }, 'https://raw.githubusercontent.com/user/repo/main/ext.yaml')
             return ({}, src)
         mock_load.side_effect = load_side_effect
         child = {
@@ -7456,8 +7835,8 @@ class TestListInherit:
         result, _ = setup_environment.resolve_config_inheritance(child, 'leaf.yaml')
         # ext's own merge-keys is STRIPPED (Rule 3), so ext REPLACES base agents
         # Leaf merge-keys: [agents] merges leaf agents with accumulated (ext's agents)
-        assert 'base-agent.md' not in result['agents']
-        assert 'ext-agent.md' in result['agents']
+        assert not any('base-agent.md' in a for a in result['agents'])
+        assert any('ext-agent.md' in a for a in result['agents'])
         assert 'leaf-agent.md' in result['agents']
 
     def test_list_file_not_found_raises(self, mock_load):


### PR DESCRIPTION
Parent config file references (agents, rules, hooks files, skills, system prompts, status-line files, files-to-download sources) were resolved using the leaf config's source instead of the parent's own source location.
This caused broken paths when inheriting across different sources (e.g., GitHub-hosted parent with local child).

Add _resolve_config_file_paths() to convert relative paths to absolute URLs or paths using each config's own source before merging.

Integrate at both inheritance call sites (resolve_config_inheritance and _resolve_list_inherit).

Add FILE_REFERENCE_KEYS registry constant with parity test.

Fix Source 3 (load_config_from_source) to return config_url instead of spec name, enabling proper path resolution.

Add _inject_status_line_into_hooks_files() to ensure status-line file references are validated and downloaded.

Update E2E tests to use path suffix matching for resolved absolute paths.