### PR TITLE
Revert status-line file injection into hooks pipeline

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -91,8 +91,6 @@ FILE_REFERENCE_KEYS: frozenset[str] = frozenset({
     'files-to-download',             # list[dict] -- each dict has 'source' key
     'skills',                        # list[dict] -- each dict has 'base' key
     'command-defaults.system-prompt',  # str -- nested scalar under command-defaults
-    'status-line.file',              # str -- nested scalar under status-line
-    'status-line.config',            # str -- nested scalar under status-line
 })
 
 # Node.js installation constants (standalone -- no imports from install_claude.py)
@@ -3124,53 +3122,6 @@ def _collect_simple_list_files(
     return files
 
 
-def _inject_status_line_into_hooks_files(config: dict[str, Any]) -> None:
-    """Auto-inject status-line file references into hooks.files for validation and download.
-
-    Ensures status-line.file and status-line.config are included in hooks.files
-    so they are validated and downloaded by the existing pipeline.
-
-    Args:
-        config: The configuration dictionary (modified in place).
-    """
-    status_line = config.get('status-line')
-    if not status_line or not isinstance(status_line, dict):
-        return
-
-    # Collect file references from status-line
-    files_to_inject: list[str] = []
-    sl_file = status_line.get('file')
-    if sl_file and isinstance(sl_file, str):
-        files_to_inject.append(sl_file)
-    sl_config = status_line.get('config')
-    if sl_config and isinstance(sl_config, str):
-        files_to_inject.append(sl_config)
-
-    if not files_to_inject:
-        return
-
-    # Ensure hooks dict exists
-    hooks = config.get('hooks')
-    if hooks is None:
-        hooks = {}
-        config['hooks'] = hooks
-    elif not isinstance(hooks, dict):
-        return
-
-    # Ensure hooks.files list exists
-    hook_files = hooks.get('files')
-    if hook_files is None:
-        hook_files = []
-        hooks['files'] = hook_files
-    elif not isinstance(hook_files, list):
-        return
-
-    # Inject each file if not already present
-    for file_ref in files_to_inject:
-        if file_ref not in hook_files:
-            hook_files.append(file_ref)
-
-
 def validate_all_config_files(
     config: dict[str, Any],
     config_source: str,
@@ -3937,20 +3888,6 @@ def _resolve_config_file_paths(config: dict[str, Any], config_source: str) -> di
             resolved_path, _ = resolve_resource_path(sys_prompt, config_source, base_url)
             cmd_defaults['system-prompt'] = resolved_path
         result['command-defaults'] = cmd_defaults
-
-    # --- status-line.file and status-line.config ---
-    sl = result.get('status-line')
-    if isinstance(sl, dict):
-        sl = sl.copy()
-        sl_file = sl.get('file')
-        if isinstance(sl_file, str):
-            resolved_path, _ = resolve_resource_path(sl_file, config_source, base_url)
-            sl['file'] = resolved_path
-        sl_config = sl.get('config')
-        if isinstance(sl_config, str):
-            resolved_path, _ = resolve_resource_path(sl_config, config_source, base_url)
-            sl['config'] = resolved_path
-        result['status-line'] = sl
 
     return result
 
@@ -9661,9 +9598,6 @@ def main() -> None:
 
         # Extract status_line configuration
         status_line = config.get('status-line')
-
-        # Auto-inject status-line files into hooks.files for validation and download
-        _inject_status_line_into_hooks_files(config)
 
         # Extract and validate effort_level configuration
         effort_level = config.get('effort-level')

--- a/tests/scripts/models/test_file_reference_keys_parity.py
+++ b/tests/scripts/models/test_file_reference_keys_parity.py
@@ -34,7 +34,6 @@ def _get_keys_resolved_by_function() -> frozenset[str]:
         'files-to-download': [{'source': sentinel_value, 'destination': '/tmp/test'}],
         'skills': [{'base': sentinel_value, 'files': ['SKILL.md']}],
         'command-defaults': {'system-prompt': sentinel_value, 'mode': 'replace'},
-        'status-line': {'file': sentinel_value, 'config': sentinel_value, 'interval': 10},
     }
 
     result = _resolve_config_file_paths(config, url_source)
@@ -70,16 +69,6 @@ def _get_keys_resolved_by_function() -> frozenset[str]:
     cd_original = config['command-defaults']
     if cd_result.get('system-prompt') != cd_original.get('system-prompt'):
         resolved_keys.add('command-defaults.system-prompt')
-
-    # Check status-line.file
-    sl_result = result.get('status-line', {})
-    sl_original = config['status-line']
-    if sl_result.get('file') != sl_original.get('file'):
-        resolved_keys.add('status-line.file')
-
-    # Check status-line.config
-    if sl_result.get('config') != sl_original.get('config'):
-        resolved_keys.add('status-line.config')
 
     return frozenset(resolved_keys)
 

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -1415,90 +1415,6 @@ class TestLoadConfig:
         assert 'agents/my-agent.md' in resolved
 
 
-class TestInjectStatusLineIntoHooksFiles:
-    """Tests for _inject_status_line_into_hooks_files() function."""
-
-    def test_inject_creates_hooks_files(self):
-        """Auto-inject creates hooks.files when hooks key is missing."""
-        config = {
-            'status-line': {
-                'file': 'hooks/status.py',
-                'config': 'configs/status-config.yaml',
-            },
-        }
-        setup_environment._inject_status_line_into_hooks_files(config)
-        assert config['hooks']['files'] == ['hooks/status.py', 'configs/status-config.yaml']
-
-    def test_inject_no_duplicates(self):
-        """Auto-inject does not create duplicates when files already present."""
-        config = {
-            'status-line': {
-                'file': 'hooks/status.py',
-                'config': 'configs/status-config.yaml',
-            },
-            'hooks': {
-                'files': ['hooks/status.py', 'hooks/other.py'],
-            },
-        }
-        setup_environment._inject_status_line_into_hooks_files(config)
-        assert config['hooks']['files'] == ['hooks/status.py', 'hooks/other.py', 'configs/status-config.yaml']
-
-    def test_inject_no_status_line(self):
-        """Auto-inject is a no-op when status-line is not configured."""
-        config = {'hooks': {'files': ['hooks/other.py']}}
-        setup_environment._inject_status_line_into_hooks_files(config)
-        assert config['hooks']['files'] == ['hooks/other.py']
-
-    def test_inject_file_only(self):
-        """Auto-inject handles status-line with file but no config."""
-        config = {
-            'status-line': {'file': 'hooks/status.py'},
-        }
-        setup_environment._inject_status_line_into_hooks_files(config)
-        assert config['hooks']['files'] == ['hooks/status.py']
-
-    def test_inject_config_only(self):
-        """Auto-inject handles status-line with config but no file."""
-        config = {
-            'status-line': {'config': 'configs/status-config.yaml'},
-        }
-        setup_environment._inject_status_line_into_hooks_files(config)
-        assert config['hooks']['files'] == ['configs/status-config.yaml']
-
-    def test_inject_invalid_status_line_type(self):
-        """Auto-inject handles status-line that is not a dict."""
-        config = {'status-line': 'invalid'}
-        setup_environment._inject_status_line_into_hooks_files(config)
-        assert 'hooks' not in config
-
-    def test_inject_invalid_hooks_type(self):
-        """Auto-inject handles hooks that is not a dict."""
-        config = {'status-line': {'file': 'x.py'}, 'hooks': 'invalid'}
-        setup_environment._inject_status_line_into_hooks_files(config)
-        assert config['hooks'] == 'invalid'
-
-    def test_inject_invalid_hooks_files_type(self):
-        """Auto-inject handles hooks.files that is not a list."""
-        config = {'status-line': {'file': 'x.py'}, 'hooks': {'files': 'invalid'}}
-        setup_environment._inject_status_line_into_hooks_files(config)
-        assert config['hooks']['files'] == 'invalid'
-
-    def test_inject_empty_strings(self):
-        """Auto-inject skips empty string values."""
-        config = {'status-line': {'file': '', 'config': ''}}
-        setup_environment._inject_status_line_into_hooks_files(config)
-        assert 'hooks' not in config
-
-    def test_inject_with_existing_empty_hooks_files(self):
-        """Auto-inject appends to an empty hooks.files list."""
-        config = {
-            'status-line': {'file': 'hooks/status.py'},
-            'hooks': {'files': []},
-        }
-        setup_environment._inject_status_line_into_hooks_files(config)
-        assert config['hooks']['files'] == ['hooks/status.py']
-
-
 class TestGetRealUserHome:
     """Tests for get_real_user_home() function."""
 
@@ -7454,21 +7370,6 @@ class TestResolveConfigFilePaths:
         assert 'raw.githubusercontent.com' in result['command-defaults']['system-prompt']
         assert 'prompts/my-prompt.md' in result['command-defaults']['system-prompt']
         assert result['command-defaults']['mode'] == 'replace'
-
-    def test_resolve_status_line_paths(self):
-        """status-line.file and status-line.config resolved using config_source."""
-        config = {
-            'status-line': {
-                'file': 'hooks/status.py',
-                'config': 'configs/status-config.yaml',
-                'interval': 10,
-            },
-        }
-        source = 'https://raw.githubusercontent.com/user/repo/main/config.yaml'
-        result = setup_environment._resolve_config_file_paths(config, source)
-        assert 'raw.githubusercontent.com' in result['status-line']['file']
-        assert 'raw.githubusercontent.com' in result['status-line']['config']
-        assert result['status-line']['interval'] == 10
 
     def test_resolve_with_base_url(self):
         """Config with base-url uses it for resolution of simple list keys."""


### PR DESCRIPTION
The _inject_status_line_into_hooks_files() function caused a regression where status-line files were not discoverable during config validation, breaking installation for configs using status-line references.

Remove the function, its call in main(), associated FILE_REFERENCE_KEYS entries, path resolution blocks, and all related tests.