### PR TITLE
Add post-upgrade version verification and recovery cascade

### DIFF
--- a/docs/installing-claude-code.md
+++ b/docs/installing-claude-code.md
@@ -111,6 +111,19 @@ The bootstrap scripts install `uv` (Astral's Python package manager) and Python 
 
 When Claude Code is already installed, the installer checks for updates against the npm registry and upgrades using the same method that was originally used (source-matching). Native installations are upgraded via the native installer, npm installations are upgraded via npm, winget installations try `winget upgrade` first with npm fallback, and unknown-source installations try native first with npm fallback.
 
+### Upgrade Version Verification
+
+After each upgrade attempt, the installer verifies that the binary was actually updated to the expected version. If a version mismatch is detected (the installer reported success but the binary remains at the old version), a recovery cascade activates:
+
+1. **Versions cache recovery** -- The Anthropic native installer downloads binaries to `~/.local/share/claude/versions/` before promotion. If the promotion step fails silently, the installer copies the correct binary from this cache to `~/.local/bin/`.
+2. **GCS direct download** -- Downloads the correct version directly from Google Cloud Storage, bypassing the native installer entirely.
+3. **npm fallback** (`auto` mode only) -- Installs the correct version via npm as a last resort. Skipped in `native` mode.
+4. **Graceful degradation** -- If all recovery methods fail, the installer continues with the current version and displays a warning. The installation is never blocked by an upgrade failure.
+
+The npm upgrade branch does not use the recovery cascade (versions cache and GCS are native-specific mechanisms). Instead, it verifies the version and logs a warning on mismatch.
+
+This verification addresses a known issue where the Anthropic native installer may report a successful upgrade but fail to replace the binary ([#14942](https://github.com/anthropics/claude-code/issues/14942)).
+
 ### Auto-Migration from npm to Native
 
 In `auto` mode, when an npm installation is detected, the installer automatically attempts to migrate to the native installer for better stability. On successful migration, the old npm installation is removed to prevent PATH conflicts. If npm removal fails (due to permission issues in non-interactive mode), the installer displays a prominent warning with manual removal instructions but does not block the native installation.
@@ -220,6 +233,14 @@ sudo rmdir /usr/lib/node_modules/@anthropic-ai 2>/dev/null || true
 The `.claude-code-*` glob pattern removes stale temporary directories that prevent npm from operating. After removal, restart your terminal.
 
 **Note:** The installer automatically attempts this direct removal when `npm uninstall` fails. This manual procedure is only needed if the automatic fallback also fails (e.g., in non-interactive environments without cached sudo credentials).
+
+### Upgrade Reports Wrong Version
+
+If the installer reports upgrading to a new version but `claude --version` still shows the old version, the post-upgrade verification should detect this automatically and attempt recovery. If automatic recovery also fails, the installer logs a warning with the expected and actual versions. To resolve manually:
+
+1. Set `CLAUDE_CODE_TOOLBOX_VERSION=<desired_version>` and re-run the installer to force a specific version
+2. Check if the correct binary exists in `~/.local/share/claude/versions/<version>/` -- if present, copy it manually to `~/.local/bin/claude` (or `claude.exe` on Windows)
+3. As a last resort, use `CLAUDE_CODE_TOOLBOX_INSTALL_METHOD=npm` to install via npm instead
 
 ### Claude Command Not Found After Install
 

--- a/scripts/install_claude.py
+++ b/scripts/install_claude.py
@@ -2816,6 +2816,8 @@ def _install_claude_native_windows_installer(version: str = 'latest') -> bool:
             # Verify installation with source detection
             is_installed, claude_path, source = verify_claude_installation()
             if is_installed and source == 'native':
+                post_version = get_claude_version(claude_path)
+                info(f'Post-install binary version: {post_version}')
                 success(f'Native installation verified at: {claude_path}')
                 _finalize_native_install()
                 return True
@@ -3289,6 +3291,118 @@ def install_claude_native_cross_platform(version: str | None = None) -> bool:
     return install_claude_native_linux(version)
 
 
+def _verify_upgrade_version(expected_version: str, method_label: str) -> tuple[bool, str | None]:
+    """Verify that the installed Claude Code binary matches the expected version.
+
+    Compares the actual installed version against the expected version using
+    >= semantics to handle race conditions where a newer version is installed
+    during the upgrade process.
+
+    Args:
+        expected_version: The version that should have been installed (e.g., "2.1.92").
+        method_label: Human-readable label for logging (e.g., "native installer",
+            "winget", "npm").
+
+    Returns:
+        Tuple of (version_matches, actual_version) where:
+        - version_matches: True if actual version >= expected version
+        - actual_version: Detected version string, or None if undetectable
+    """
+    actual_version = get_claude_version()
+    if not actual_version:
+        warning(f'Could not detect Claude Code version after {method_label} upgrade')
+        return (False, None)
+
+    if compare_versions(actual_version, expected_version):
+        return (True, actual_version)
+
+    warning(
+        f'Version mismatch after {method_label} upgrade: '
+        f'expected >= {expected_version}, got {actual_version}',
+    )
+    return (False, actual_version)
+
+
+def _recover_from_versions_directory(target_version: str) -> str | None:
+    """Promote an already-downloaded binary from the Anthropic versions cache.
+
+    The Anthropic native installer downloads binaries to
+    ~/.local/share/claude/versions/{version}/ before promotion. When the
+    installer's promotion step fails silently, the correct binary may still
+    be available in this cache directory.
+
+    Only promotes the EXACT target_version -- no "newest available" fallback.
+    Uses shutil.copy2 for cross-volume compatibility (the versions directory
+    and ~/.local/bin/ may be on different filesystems).
+
+    Args:
+        target_version: Exact version to look for (e.g., "2.1.92").
+
+    Returns:
+        Promoted version string on success, None on failure.
+    """
+    home = get_real_user_home()
+    versions_dir = home / '.local' / 'share' / 'claude' / 'versions' / target_version
+
+    # Determine correct binary name for current platform
+    binary_name = 'claude.exe' if sys.platform == 'win32' else 'claude'
+    version_binary = versions_dir / binary_name
+
+    if not version_binary.exists():
+        return None
+
+    # Validate file size (same check as verify_claude_installation)
+    if version_binary.stat().st_size <= 1000:
+        warning(f'Binary in versions cache too small: {version_binary}')
+        return None
+
+    info(f'Found cached binary for v{target_version} at: {version_binary}')
+
+    # Determine target path
+    native_target = home / '.local' / 'bin' / binary_name
+    native_target.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        shutil.copy2(str(version_binary), str(native_target))
+    except PermissionError:
+        if sys.platform == 'win32':
+            # Windows file locking: copy source to temp, then use rename strategy
+            info('Target binary is locked, attempting rename strategy...')
+            temp_path = native_target.with_suffix('.tmp')
+            try:
+                shutil.copy2(str(version_binary), str(temp_path))
+                file_size = temp_path.stat().st_size
+                return (
+                    target_version
+                    if _handle_windows_file_lock(temp_path, native_target, target_version, file_size)
+                    else None
+                )
+            except OSError as copy_err:
+                warning(f'Failed to copy cached binary to temp file: {copy_err}')
+                with contextlib.suppress(Exception):
+                    temp_path.unlink()
+                return None
+        # Non-Windows PermissionError
+        warning(f'Permission denied copying cached binary: {version_binary}')
+        return None
+    except OSError as e:
+        warning(f'Failed to promote cached binary: {e}')
+        return None
+
+    # Set executable permission on Unix
+    if sys.platform != 'win32':
+        native_target.chmod(native_target.stat().st_mode | 0o755)
+
+    # Verify the promoted binary
+    promoted_version = get_claude_version(str(native_target))
+    if promoted_version and compare_versions(promoted_version, target_version):
+        success(f'Promoted cached binary v{promoted_version} to {native_target}')
+        return promoted_version
+
+    warning(f'Promoted binary version mismatch: expected >= {target_version}, got {promoted_version}')
+    return None
+
+
 def ensure_claude() -> bool:
     """Ensure Claude Code is installed (native-first, npm fallback).
 
@@ -3469,9 +3583,28 @@ def ensure_claude() -> bool:
                 # Native-only mode - use native installer
                 info('Upgrading via native installer (method: native)...')
                 if install_claude_native_cross_platform(version=None):
-                    new_version = get_claude_version()
-                    if new_version:
-                        success(f'Claude Code upgraded to version {new_version} via native installer')
+                    version_ok, actual_version = _verify_upgrade_version(latest_version, 'native installer')
+                    if version_ok:
+                        success(f'Claude Code upgraded to version {actual_version} via native installer')
+                        return True
+                    # Recovery cascade (no npm in native-only mode)
+                    info('Attempting version recovery...')
+                    recovered = _recover_from_versions_directory(latest_version)
+                    if recovered:
+                        success(f'Claude Code upgraded to version {recovered} via versions cache recovery')
+                        return True
+                    binary_name = 'claude.exe' if sys.platform == 'win32' else 'claude'
+                    native_target = get_real_user_home() / '.local' / 'bin' / binary_name
+                    if _download_claude_direct_from_gcs(latest_version, native_target):
+                        gcs_version = get_claude_version()
+                        if gcs_version:
+                            success(f'Claude Code upgraded to version {gcs_version} via GCS recovery')
+                        return True
+                    # No npm fallback in native-only mode (Tier 3 skipped)
+                    warning(
+                        f'Upgrade verification failed: expected >= {latest_version}, '
+                        f'got {actual_version}. Continuing with current version.',
+                    )
                     return True
                 warning('Native upgrade failed, continuing with current version')
                 return True  # Don't fail the entire installation
@@ -3481,9 +3614,44 @@ def ensure_claude() -> bool:
                 info(f'Detected native installation at: {upgrade_claude_path}')
                 info(f'Upgrading to {latest_version} via native installer...')
                 if install_claude_native_cross_platform(version=None):
-                    new_version = get_claude_version()
-                    if new_version:
-                        success(f'Claude Code upgraded to version {new_version} via native installer')
+                    version_ok, actual_version = _verify_upgrade_version(
+                        latest_version, 'native installer',
+                    )
+                    if version_ok:
+                        success(
+                            f'Claude Code upgraded to version {actual_version} via native installer',
+                        )
+                        return True
+                    # Recovery cascade (full 4-tier in auto mode)
+                    info('Attempting version recovery...')
+                    recovered = _recover_from_versions_directory(latest_version)
+                    if recovered:
+                        success(
+                            f'Claude Code upgraded to version {recovered} '
+                            f'via versions cache recovery',
+                        )
+                        return True
+                    binary_name = 'claude.exe' if sys.platform == 'win32' else 'claude'
+                    native_target = get_real_user_home() / '.local' / 'bin' / binary_name
+                    if _download_claude_direct_from_gcs(latest_version, native_target):
+                        gcs_version = get_claude_version()
+                        if gcs_version:
+                            success(
+                                f'Claude Code upgraded to version {gcs_version} via GCS recovery',
+                            )
+                        return True
+                    if install_claude_npm(upgrade=True, version=latest_version):
+                        npm_version = get_claude_version()
+                        if npm_version:
+                            success(
+                                f'Claude Code upgraded to version {npm_version} via npm recovery',
+                            )
+                        update_install_method_config('npm')
+                        return True
+                    warning(
+                        f'Upgrade verification failed: expected >= {latest_version}, '
+                        f'got {actual_version}. Continuing with current version.',
+                    )
                     return True
                 # Native upgrade failed - fall back to npm in auto mode
                 warning('Native upgrade failed, falling back to npm...')
@@ -3502,9 +3670,45 @@ def ensure_claude() -> bool:
                 info(f'Detected unknown installation source at: {upgrade_claude_path}')
                 info(f'Trying native upgrade to {latest_version} first...')
                 if install_claude_native_cross_platform(version=None):
-                    new_version = get_claude_version()
-                    if new_version:
-                        success(f'Claude Code upgraded to version {new_version} via native installer')
+                    version_ok, actual_version = _verify_upgrade_version(
+                        latest_version, 'native installer',
+                    )
+                    if version_ok:
+                        success(
+                            f'Claude Code upgraded to version {actual_version} '
+                            f'via native installer',
+                        )
+                        return True
+                    # Recovery cascade (full 4-tier in auto mode)
+                    info('Attempting version recovery...')
+                    recovered = _recover_from_versions_directory(latest_version)
+                    if recovered:
+                        success(
+                            f'Claude Code upgraded to version {recovered} '
+                            f'via versions cache recovery',
+                        )
+                        return True
+                    binary_name = 'claude.exe' if sys.platform == 'win32' else 'claude'
+                    native_target = get_real_user_home() / '.local' / 'bin' / binary_name
+                    if _download_claude_direct_from_gcs(latest_version, native_target):
+                        gcs_version = get_claude_version()
+                        if gcs_version:
+                            success(
+                                f'Claude Code upgraded to version {gcs_version} via GCS recovery',
+                            )
+                        return True
+                    if install_claude_npm(upgrade=True, version=latest_version):
+                        npm_version = get_claude_version()
+                        if npm_version:
+                            success(
+                                f'Claude Code upgraded to version {npm_version} via npm recovery',
+                            )
+                        update_install_method_config('npm')
+                        return True
+                    warning(
+                        f'Upgrade verification failed: expected >= {latest_version}, '
+                        f'got {actual_version}. Continuing with current version.',
+                    )
                     return True
                 warning('Native upgrade failed for unknown source, falling back to npm...')
                 if install_claude_npm(upgrade=True, version=latest_version):
@@ -3535,9 +3739,44 @@ def ensure_claude() -> bool:
                 ]
                 upgrade_result = run_command(upgrade_cmd, capture_output=True)
                 if upgrade_result.returncode == 0 or upgrade_result.returncode == -1978335189:
-                    new_version = get_claude_version()
-                    if new_version:
-                        success(f'Claude Code upgraded to version {new_version} via winget')
+                    version_ok, actual_version = _verify_upgrade_version(
+                        latest_version, 'winget',
+                    )
+                    if version_ok:
+                        success(
+                            f'Claude Code upgraded to version {actual_version} via winget',
+                        )
+                        return True
+                    # Recovery cascade (full 4-tier in auto mode)
+                    info('Attempting version recovery...')
+                    recovered = _recover_from_versions_directory(latest_version)
+                    if recovered:
+                        success(
+                            f'Claude Code upgraded to version {recovered} '
+                            f'via versions cache recovery',
+                        )
+                        return True
+                    binary_name = 'claude.exe' if sys.platform == 'win32' else 'claude'
+                    native_target = get_real_user_home() / '.local' / 'bin' / binary_name
+                    if _download_claude_direct_from_gcs(latest_version, native_target):
+                        gcs_version = get_claude_version()
+                        if gcs_version:
+                            success(
+                                f'Claude Code upgraded to version {gcs_version} via GCS recovery',
+                            )
+                        return True
+                    if install_claude_npm(upgrade=True, version=latest_version):
+                        npm_version = get_claude_version()
+                        if npm_version:
+                            success(
+                                f'Claude Code upgraded to version {npm_version} via npm recovery',
+                            )
+                        update_install_method_config('npm')
+                        return True
+                    warning(
+                        f'Upgrade verification failed: expected >= {latest_version}, '
+                        f'got {actual_version}. Continuing with current version.',
+                    )
                     return True
                 # winget upgrade failed -- fall back to npm in auto mode
                 warning('winget upgrade failed, falling back to npm...')
@@ -3554,9 +3793,18 @@ def ensure_claude() -> bool:
                 info(f'Detected npm installation at: {upgrade_claude_path}')
                 info(f'Upgrading to {latest_version} via npm...')
                 if install_claude_npm(upgrade=True, version=latest_version):
-                    new_version = get_claude_version()
-                    if new_version:
-                        success(f'Claude Code upgraded to version {new_version}')
+                    version_ok, actual_version = _verify_upgrade_version(
+                        latest_version, 'npm',
+                    )
+                    if version_ok:
+                        success(f'Claude Code upgraded to version {actual_version}')
+                        return True
+                    # npm version mismatch is unusual but handle gracefully
+                    warning(
+                        f'npm upgrade reported success but version mismatch: '
+                        f'expected >= {latest_version}, got {actual_version}. '
+                        f'Continuing with current version.',
+                    )
                     return True
                 warning('Upgrade failed, continuing with current version')
                 return True  # Don't fail the entire installation

--- a/scripts/install_claude.py
+++ b/scripts/install_claude.py
@@ -1988,7 +1988,7 @@ def get_claude_version(claude_path: str | None = None) -> str | None:
     result = run_command([claude_path, '--version'])
     if result.returncode == 0:
         # Parse version from output like "claude, version 0.7.7" or "@anthropic-ai/claude-code/0.7.7"
-        output = result.stdout.strip()
+        output = (result.stdout or '').strip()
         # Try to extract version number
         match = re.search(r'(\d+\.\d+\.\d+)', output)
         if match:

--- a/tests/e2e/test_upgrade_source_detection.py
+++ b/tests/e2e/test_upgrade_source_detection.py
@@ -45,6 +45,10 @@ class TestSourceAwareUpgrade:
                 install_claude, 'install_claude_native_cross_platform', return_value=True,
             ) as mock_native,
             patch.object(install_claude, 'install_claude_npm') as mock_npm,
+            patch.object(
+                install_claude, '_verify_upgrade_version',
+                return_value=(True, '2.1.39'),
+            ),
             patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False),
         ):
             result = install_claude.ensure_claude()
@@ -294,6 +298,10 @@ class TestPathClassification:
                 install_claude, 'install_claude_native_cross_platform', return_value=True,
             ) as mock_native,
             patch.object(install_claude, 'install_claude_npm') as mock_npm,
+            patch.object(
+                install_claude, '_verify_upgrade_version',
+                return_value=(True, '2.1.39'),
+            ),
             patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False),
         ):
             result = install_claude.ensure_claude()

--- a/tests/test_install_claude.py
+++ b/tests/test_install_claude.py
@@ -928,6 +928,7 @@ class TestClaudeInstallation:
             assert sudo_cmd[0] == '/usr/bin/npm'
 
     @patch('platform.system', return_value='Windows')
+    @patch('install_claude.get_claude_version', return_value='2.1.39')
     @patch('install_claude.urlopen')
     @patch('tempfile.NamedTemporaryFile')
     @patch('install_claude.run_command')
@@ -942,12 +943,14 @@ class TestClaudeInstallation:
         mock_run,
         mock_temp,
         mock_urlopen,
+        mock_get_version,
         mock_system,
     ):
         """Test native Claude installer on Windows."""
         # Verify mock configuration
         assert mock_system.return_value == 'Windows'
         assert mock_update_config is not None
+        assert mock_get_version.return_value == '2.1.39'
         # Mock installer script download
         mock_response = MagicMock()
         mock_response.read.return_value = b'# PowerShell installer script'
@@ -1071,6 +1074,7 @@ class TestEnsureClaudeSourceAwareUpgrade:
     """
 
     @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude._verify_upgrade_version', return_value=(True, '2.1.39'))
     @patch('install_claude.install_claude_npm')
     @patch('install_claude.install_claude_native_cross_platform', return_value=True)
     @patch('install_claude.compare_versions', return_value=False)
@@ -1085,6 +1089,7 @@ class TestEnsureClaudeSourceAwareUpgrade:
         mock_compare,
         mock_native,
         mock_npm,
+        mock_verify_upgrade,
     ):
         """When source is native in auto mode, upgrade should use native installer."""
         mock_get_version.side_effect = ['2.0.76', '2.1.39']
@@ -1098,6 +1103,7 @@ class TestEnsureClaudeSourceAwareUpgrade:
         # Native should be used, npm should NOT
         mock_native.assert_called()
         mock_npm.assert_not_called()
+        mock_verify_upgrade.assert_called()
 
     @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'npm'}, clear=False)
     @patch('install_claude.install_claude_npm', return_value=True)
@@ -1220,6 +1226,7 @@ class TestEnsureClaudeSourceAwareUpgrade:
         mock_native.assert_not_called()
 
     @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude._verify_upgrade_version', return_value=(True, '2.1.39'))
     @patch('install_claude.install_claude_npm')
     @patch('install_claude.install_claude_native_cross_platform', return_value=True)
     @patch('install_claude.compare_versions', return_value=False)
@@ -1234,6 +1241,7 @@ class TestEnsureClaudeSourceAwareUpgrade:
         mock_compare,
         mock_native,
         mock_npm,
+        mock_verify_upgrade,
     ):
         """When source is unknown in auto mode, try native first, then npm fallback."""
         mock_get_version.side_effect = ['2.0.76', '2.1.39']
@@ -1246,8 +1254,9 @@ class TestEnsureClaudeSourceAwareUpgrade:
         assert mock_compare.return_value is False
         # Native should be tried first for unknown source
         mock_native.assert_called()
-        # npm should NOT be called since native succeeded
+        # npm should NOT be called since native succeeded and version verified
         mock_npm.assert_not_called()
+        mock_verify_upgrade.assert_called()
 
     @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
     @patch('install_claude.install_claude_npm', return_value=True)
@@ -1283,6 +1292,7 @@ class TestEnsureClaudeSourceAwareUpgrade:
         mock_npm.assert_called()
 
     @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude._verify_upgrade_version', return_value=(True, '2.1.39'))
     @patch('install_claude.install_claude_native_cross_platform', return_value=True)
     @patch('install_claude.compare_versions', return_value=False)
     @patch('install_claude.get_latest_claude_version', return_value='2.1.39')
@@ -1295,8 +1305,9 @@ class TestEnsureClaudeSourceAwareUpgrade:
         mock_get_latest,
         mock_compare,
         mock_native,
+        mock_verify_upgrade,
     ):
-        """After native upgrade, get_claude_version() should be called to report version."""
+        """After native upgrade, _verify_upgrade_version() should be called to verify."""
         mock_get_version.side_effect = ['2.0.76', '2.1.39']
         mock_verify.return_value = (True, '/home/user/.local/bin/claude', 'native')
 
@@ -1306,9 +1317,8 @@ class TestEnsureClaudeSourceAwareUpgrade:
         assert mock_get_latest.return_value == '2.1.39'
         assert mock_compare.return_value is False
         mock_native.assert_called()
-        # get_claude_version should be called at least twice:
-        # once for initial version check, once after upgrade
-        assert mock_get_version.call_count >= 2
+        # _verify_upgrade_version should be called after successful upgrade
+        mock_verify_upgrade.assert_called_once()
 
 
 class TestMainFunction:
@@ -4849,6 +4859,7 @@ class TestInstallClaudeNativeLinuxGcsFallback:
 class TestEnsureClaudeWingetUpgrade:
     """Tests for winget-source upgrade routing in ensure_claude()."""
 
+    @patch('install_claude._verify_upgrade_version', return_value=(True, '2.1.39'))
     @patch('install_claude.run_command')
     @patch('install_claude.update_install_method_config')
     @patch('install_claude.install_claude_npm')
@@ -4858,7 +4869,7 @@ class TestEnsureClaudeWingetUpgrade:
     @patch('install_claude.verify_claude_installation')
     def test_winget_source_tries_winget_upgrade(
         self, mock_verify, mock_get_version, mock_get_latest,
-        mock_compare, mock_npm, mock_config, mock_run,
+        mock_compare, mock_npm, mock_config, mock_run, mock_verify_upgrade,
     ):
         """Winget source tries winget upgrade before npm."""
         assert mock_get_latest.return_value == '2.1.39'
@@ -4881,6 +4892,7 @@ class TestEnsureClaudeWingetUpgrade:
         call_args = mock_run.call_args[0][0]
         assert call_args[0] == 'winget'
         assert call_args[1] == 'upgrade'
+        mock_verify_upgrade.assert_called()
 
     @patch('install_claude.run_command')
     @patch('install_claude.update_install_method_config')
@@ -4940,3 +4952,486 @@ class TestFinalizeNativeInstallMethodParam:
         install_claude._finalize_native_install(method='custom')
         mock_check.assert_called_once()
         mock_config.assert_called_once_with('custom')
+
+
+class TestVerifyUpgradeVersion:
+    """Tests for _verify_upgrade_version() post-upgrade version check."""
+
+    @patch('install_claude.get_claude_version', return_value='2.1.92')
+    @patch('install_claude.compare_versions', return_value=True)
+    def test_version_matches(self, mock_compare, mock_get_version):
+        """Returns (True, actual_version) when version >= expected."""
+        assert mock_get_version.return_value  # Ensure mock is active
+        result = install_claude._verify_upgrade_version('2.1.92', 'native installer')
+        assert result == (True, '2.1.92')
+        mock_compare.assert_called_once_with('2.1.92', '2.1.92')
+
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch('install_claude.compare_versions', return_value=False)
+    def test_version_mismatch(self, mock_compare, mock_get_version):
+        """Returns (False, actual_version) when version < expected."""
+        assert mock_get_version.return_value  # Ensure mock is active
+        result = install_claude._verify_upgrade_version('2.1.92', 'native installer')
+        assert result == (False, '2.1.89')
+        mock_compare.assert_called_once_with('2.1.89', '2.1.92')
+
+    @patch('install_claude.get_claude_version', return_value=None)
+    def test_version_undetectable(self, mock_get_version):
+        """Returns (False, None) when version cannot be detected."""
+        mock_get_version.assert_not_called()  # Not called yet
+        result = install_claude._verify_upgrade_version('2.1.92', 'native installer')
+        assert result == (False, None)
+        mock_get_version.assert_called_once()
+
+    @patch('install_claude.get_claude_version', return_value='2.1.93')
+    @patch('install_claude.compare_versions', return_value=True)
+    def test_newer_version_accepted(self, mock_compare, mock_get_version):
+        """Accepts a version newer than expected (race condition handling)."""
+        assert mock_get_version.return_value  # Ensure mock is active
+        result = install_claude._verify_upgrade_version('2.1.92', 'native installer')
+        assert result == (True, '2.1.93')
+        mock_compare.assert_called_once_with('2.1.93', '2.1.92')
+
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch('install_claude.compare_versions', return_value=False)
+    def test_method_label_in_warning(self, mock_compare, mock_get_version, capsys):
+        """Method label appears in the warning message."""
+        assert mock_get_version.return_value  # Ensure mock is active
+        install_claude._verify_upgrade_version('2.1.92', 'winget')
+        captured = capsys.readouterr()
+        assert 'winget' in captured.out
+        mock_compare.assert_called_once()
+
+
+class TestRecoverFromVersionsDirectory:
+    """Tests for _recover_from_versions_directory() cache promotion."""
+
+    def test_binary_not_found(self, tmp_path, monkeypatch):
+        """Returns None when versions directory does not exist."""
+        monkeypatch.setattr('install_claude.get_real_user_home', lambda: tmp_path)
+        result = install_claude._recover_from_versions_directory('2.1.92')
+        assert result is None
+
+    def test_binary_too_small(self, tmp_path, monkeypatch):
+        """Returns None when cached binary is too small (corrupt)."""
+        monkeypatch.setattr('install_claude.get_real_user_home', lambda: tmp_path)
+        versions_dir = tmp_path / '.local' / 'share' / 'claude' / 'versions' / '2.1.92'
+        versions_dir.mkdir(parents=True)
+        binary_name = 'claude.exe' if sys.platform == 'win32' else 'claude'
+        (versions_dir / binary_name).write_bytes(b'x' * 500)
+        result = install_claude._recover_from_versions_directory('2.1.92')
+        assert result is None
+
+    @patch('install_claude.get_claude_version', return_value='2.1.92')
+    @patch('install_claude.compare_versions', return_value=True)
+    def test_successful_promotion(self, mock_compare, mock_get_version, tmp_path, monkeypatch):
+        """Promotes cached binary and returns version string."""
+        monkeypatch.setattr('install_claude.get_real_user_home', lambda: tmp_path)
+        versions_dir = tmp_path / '.local' / 'share' / 'claude' / 'versions' / '2.1.92'
+        versions_dir.mkdir(parents=True)
+        binary_name = 'claude.exe' if sys.platform == 'win32' else 'claude'
+        (versions_dir / binary_name).write_bytes(b'x' * 2000)
+        (tmp_path / '.local' / 'bin').mkdir(parents=True, exist_ok=True)
+        result = install_claude._recover_from_versions_directory('2.1.92')
+        assert result == '2.1.92'
+        assert (tmp_path / '.local' / 'bin' / binary_name).exists()
+        mock_get_version.assert_called_once()
+        mock_compare.assert_called_once()
+
+    def test_different_version_not_promoted(self, tmp_path, monkeypatch):
+        """Only promotes exact target_version, not other versions in cache."""
+        monkeypatch.setattr('install_claude.get_real_user_home', lambda: tmp_path)
+        # Create version 2.1.91 but request 2.1.92
+        versions_dir = tmp_path / '.local' / 'share' / 'claude' / 'versions' / '2.1.91'
+        versions_dir.mkdir(parents=True)
+        binary_name = 'claude.exe' if sys.platform == 'win32' else 'claude'
+        (versions_dir / binary_name).write_bytes(b'x' * 2000)
+        result = install_claude._recover_from_versions_directory('2.1.92')
+        assert result is None
+
+    @patch('install_claude.get_claude_version', return_value='2.1.90')
+    @patch('install_claude.compare_versions', return_value=False)
+    def test_promoted_binary_version_mismatch(
+        self, mock_compare, mock_get_version, tmp_path, monkeypatch,
+    ):
+        """Returns None when promoted binary reports wrong version."""
+        monkeypatch.setattr('install_claude.get_real_user_home', lambda: tmp_path)
+        versions_dir = tmp_path / '.local' / 'share' / 'claude' / 'versions' / '2.1.92'
+        versions_dir.mkdir(parents=True)
+        binary_name = 'claude.exe' if sys.platform == 'win32' else 'claude'
+        (versions_dir / binary_name).write_bytes(b'x' * 2000)
+        (tmp_path / '.local' / 'bin').mkdir(parents=True, exist_ok=True)
+        result = install_claude._recover_from_versions_directory('2.1.92')
+        assert result is None
+        mock_get_version.assert_called_once()
+        mock_compare.assert_called_once()
+
+    def test_creates_target_directory(self, tmp_path, monkeypatch):
+        """Creates ~/.local/bin/ if it does not exist."""
+        monkeypatch.setattr('install_claude.get_real_user_home', lambda: tmp_path)
+        monkeypatch.setattr(
+            'install_claude.get_claude_version', lambda *_args: '2.1.92',
+        )
+        monkeypatch.setattr(
+            'install_claude.compare_versions', lambda *_args: True,
+        )
+        versions_dir = tmp_path / '.local' / 'share' / 'claude' / 'versions' / '2.1.92'
+        versions_dir.mkdir(parents=True)
+        binary_name = 'claude.exe' if sys.platform == 'win32' else 'claude'
+        (versions_dir / binary_name).write_bytes(b'x' * 2000)
+        # Do NOT create .local/bin -- function should create it
+        assert not (tmp_path / '.local' / 'bin').exists()
+        result = install_claude._recover_from_versions_directory('2.1.92')
+        assert result == '2.1.92'
+        assert (tmp_path / '.local' / 'bin').exists()
+
+    def test_oserror_on_copy(self, tmp_path, monkeypatch):
+        """Returns None on general OSError during copy."""
+        monkeypatch.setattr('install_claude.get_real_user_home', lambda: tmp_path)
+        versions_dir = tmp_path / '.local' / 'share' / 'claude' / 'versions' / '2.1.92'
+        versions_dir.mkdir(parents=True)
+        binary_name = 'claude.exe' if sys.platform == 'win32' else 'claude'
+        (versions_dir / binary_name).write_bytes(b'x' * 2000)
+        (tmp_path / '.local' / 'bin').mkdir(parents=True, exist_ok=True)
+        with patch('shutil.copy2', side_effect=OSError('disk full')):
+            result = install_claude._recover_from_versions_directory('2.1.92')
+        assert result is None
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    def test_windows_permission_error_delegates_to_file_lock(self, tmp_path, monkeypatch):
+        """On Windows PermissionError, copies to temp then delegates to file lock handler."""
+        monkeypatch.setattr('install_claude.get_real_user_home', lambda: tmp_path)
+        versions_dir = tmp_path / '.local' / 'share' / 'claude' / 'versions' / '2.1.92'
+        versions_dir.mkdir(parents=True)
+        (versions_dir / 'claude.exe').write_bytes(b'x' * 2000)
+        (tmp_path / '.local' / 'bin').mkdir(parents=True, exist_ok=True)
+        # First copy2 call raises PermissionError (to target); second succeeds (to temp)
+        copy_calls = []
+
+        def mock_copy2(src, dst):  # noqa: ARG001
+            copy_calls.append(dst)
+            if len(copy_calls) == 1:
+                raise PermissionError('Access is denied')
+            # Second call (to .tmp) succeeds -- create the file
+            Path(dst).write_bytes(b'x' * 2000)
+
+        with (
+            patch('shutil.copy2', side_effect=mock_copy2),
+            patch(
+                'install_claude._handle_windows_file_lock', return_value=True,
+            ) as mock_file_lock,
+        ):
+            result = install_claude._recover_from_versions_directory('2.1.92')
+        assert result == '2.1.92'
+        mock_file_lock.assert_called_once()
+
+    @pytest.mark.skipif(sys.platform == 'win32', reason='Unix-only test')
+    def test_unix_permission_error_returns_none(self, tmp_path, monkeypatch):
+        """On Unix PermissionError, returns None without file lock handling."""
+        monkeypatch.setattr('install_claude.get_real_user_home', lambda: tmp_path)
+        versions_dir = tmp_path / '.local' / 'share' / 'claude' / 'versions' / '2.1.92'
+        versions_dir.mkdir(parents=True)
+        binary_name = 'claude'
+        (versions_dir / binary_name).write_bytes(b'x' * 2000)
+        (tmp_path / '.local' / 'bin').mkdir(parents=True, exist_ok=True)
+        with patch('shutil.copy2', side_effect=PermissionError('Permission denied')):
+            result = install_claude._recover_from_versions_directory('2.1.92')
+        assert result is None
+
+
+class TestUpgradeVersionVerification:
+    """Tests for post-upgrade version verification in ensure_claude() upgrade branches."""
+
+    @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude._recover_from_versions_directory', return_value='2.1.92')
+    @patch('install_claude._verify_upgrade_version', return_value=(False, '2.1.89'))
+    @patch('install_claude.install_claude_native_cross_platform', return_value=True)
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.92')
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch('install_claude.verify_claude_installation')
+    def test_native_source_mismatch_recovers_from_versions_dir(
+        self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
+        mock_native, mock_verify_upgrade, mock_recover,
+    ):
+        """When native upgrade has version mismatch, Tier 1 recovery from versions dir."""
+        mock_verify.return_value = (True, '/home/user/.local/bin/claude', 'native')
+        result = install_claude.ensure_claude()
+        assert result is True
+        mock_recover.assert_called_once_with('2.1.92')
+        assert mock_get_version.return_value == '2.1.89'
+        assert mock_get_latest.return_value == '2.1.92'
+        assert mock_compare.return_value is False
+        mock_native.assert_called()
+        mock_verify_upgrade.assert_called()
+
+    @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude._download_claude_direct_from_gcs', return_value=True)
+    @patch('install_claude._recover_from_versions_directory', return_value=None)
+    @patch('install_claude._verify_upgrade_version', return_value=(False, '2.1.89'))
+    @patch('install_claude.install_claude_native_cross_platform', return_value=True)
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.92')
+    @patch('install_claude.get_claude_version')
+    @patch('install_claude.verify_claude_installation')
+    def test_native_source_mismatch_gcs_fallback(
+        self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
+        mock_native, mock_verify_upgrade, mock_recover, mock_gcs,
+    ):
+        """When versions dir recovery fails, Tier 2 GCS download."""
+        mock_get_version.return_value = '2.1.89'
+        mock_verify.return_value = (True, '/home/user/.local/bin/claude', 'native')
+        result = install_claude.ensure_claude()
+        assert result is True
+        mock_recover.assert_called_once()
+        mock_gcs.assert_called_once()
+        assert mock_get_latest.return_value == '2.1.92'
+        assert mock_compare.return_value is False
+        mock_native.assert_called()
+        mock_verify_upgrade.assert_called()
+
+    @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude.install_claude_npm', return_value=True)
+    @patch('install_claude._download_claude_direct_from_gcs', return_value=False)
+    @patch('install_claude._recover_from_versions_directory', return_value=None)
+    @patch('install_claude._verify_upgrade_version', return_value=(False, '2.1.89'))
+    @patch('install_claude.install_claude_native_cross_platform', return_value=True)
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.92')
+    @patch('install_claude.get_claude_version')
+    @patch('install_claude.verify_claude_installation')
+    def test_native_source_mismatch_npm_last_resort(
+        self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
+        mock_native, mock_verify_upgrade, mock_recover, mock_gcs, mock_npm,
+        mock_update_config,
+    ):
+        """When GCS also fails, Tier 3 npm fallback in auto mode."""
+        mock_get_version.return_value = '2.1.89'
+        mock_verify.return_value = (True, '/home/user/.local/bin/claude', 'native')
+        result = install_claude.ensure_claude()
+        assert result is True
+        mock_npm.assert_called_once()
+        mock_update_config.assert_called_with('npm')
+        assert mock_get_latest.return_value == '2.1.92'
+        assert mock_compare.return_value is False
+        mock_native.assert_called()
+        mock_verify_upgrade.assert_called()
+        mock_recover.assert_called_once()
+        mock_gcs.assert_called_once()
+
+    @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'native'}, clear=False)
+    @patch('install_claude.install_claude_npm')
+    @patch('install_claude._download_claude_direct_from_gcs', return_value=False)
+    @patch('install_claude._recover_from_versions_directory', return_value=None)
+    @patch('install_claude._verify_upgrade_version', return_value=(False, '2.1.89'))
+    @patch('install_claude.install_claude_native_cross_platform', return_value=True)
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.92')
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch('install_claude.verify_claude_installation')
+    def test_native_mode_no_npm_in_recovery(
+        self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
+        mock_native, mock_verify_upgrade, mock_recover, mock_gcs, mock_npm,
+    ):
+        """Native-only mode skips npm in recovery cascade (Tier 3 omitted)."""
+        mock_verify.return_value = (True, '/home/user/.local/bin/claude', 'native')
+        result = install_claude.ensure_claude()
+        assert result is True
+        mock_npm.assert_not_called()
+        assert mock_get_version.return_value == '2.1.89'
+        assert mock_get_latest.return_value == '2.1.92'
+        assert mock_compare.return_value is False
+        mock_native.assert_called()
+        mock_verify_upgrade.assert_called()
+        mock_recover.assert_called_once()
+        mock_gcs.assert_called_once()
+
+    @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude._verify_upgrade_version', return_value=(True, '2.1.92'))
+    @patch('install_claude.install_claude_native_cross_platform', return_value=True)
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.92')
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch('install_claude.verify_claude_installation')
+    def test_native_source_version_matches_no_recovery(
+        self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
+        mock_native, mock_verify_upgrade,
+    ):
+        """When version matches after upgrade, no recovery cascade triggered."""
+        mock_verify.return_value = (True, '/home/user/.local/bin/claude', 'native')
+        result = install_claude.ensure_claude()
+        assert result is True
+        assert mock_get_version.return_value == '2.1.89'
+        assert mock_get_latest.return_value == '2.1.92'
+        assert mock_compare.return_value is False
+        mock_native.assert_called()
+        mock_verify_upgrade.assert_called()
+
+    @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude._recover_from_versions_directory', return_value='2.1.92')
+    @patch('install_claude._verify_upgrade_version', return_value=(False, '2.1.89'))
+    @patch('install_claude.install_claude_native_cross_platform', return_value=True)
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.92')
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch('install_claude.verify_claude_installation')
+    def test_unknown_source_mismatch_recovers_from_versions_dir(
+        self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
+        mock_native, mock_verify_upgrade, mock_recover,
+    ):
+        """Unknown source upgrade with mismatch triggers versions dir recovery."""
+        mock_verify.return_value = (True, '/usr/local/bin/claude', 'unknown')
+        result = install_claude.ensure_claude()
+        assert result is True
+        mock_recover.assert_called_once_with('2.1.92')
+        assert mock_get_version.return_value == '2.1.89'
+        assert mock_get_latest.return_value == '2.1.92'
+        assert mock_compare.return_value is False
+        mock_native.assert_called()
+        mock_verify_upgrade.assert_called()
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude._recover_from_versions_directory', return_value='2.1.92')
+    @patch('install_claude._verify_upgrade_version', return_value=(False, '2.1.89'))
+    @patch('install_claude.run_command')
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.92')
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch('install_claude.verify_claude_installation')
+    def test_winget_source_mismatch_recovers_from_versions_dir(
+        self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
+        mock_run, mock_verify_upgrade, mock_recover,
+    ):
+        """Winget upgrade with mismatch triggers versions dir recovery."""
+        mock_verify.return_value = (
+            True,
+            r'C:\Users\test\AppData\Local\Programs\claude\claude.exe',
+            'winget',
+        )
+        mock_run.return_value = MagicMock(returncode=0)
+        result = install_claude.ensure_claude()
+        assert result is True
+        mock_recover.assert_called_once_with('2.1.92')
+        assert mock_get_version.return_value == '2.1.89'
+        assert mock_get_latest.return_value == '2.1.92'
+        assert mock_compare.return_value is False
+        mock_verify_upgrade.assert_called()
+
+    @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude._verify_upgrade_version', return_value=(False, '2.1.89'))
+    @patch('install_claude.install_claude_npm', return_value=True)
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.92')
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch('install_claude.verify_claude_installation')
+    def test_npm_source_mismatch_graceful_degradation(
+        self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
+        mock_npm, mock_verify_upgrade,
+    ):
+        """npm upgrade with mismatch degrades gracefully (no recovery cascade)."""
+        # First call: migration check (return non-npm to skip migration)
+        # Second call: upgrade source detection (return npm)
+        mock_verify.side_effect = [
+            (True, '/home/user/.local/bin/claude', 'native'),
+            (True, '/home/user/.npm-global/bin/claude', 'npm'),
+        ]
+        result = install_claude.ensure_claude()
+        assert result is True
+        assert mock_get_version.return_value == '2.1.89'
+        assert mock_get_latest.return_value == '2.1.92'
+        assert mock_compare.return_value is False
+        mock_npm.assert_called()
+        mock_verify_upgrade.assert_called()
+
+    @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude._verify_upgrade_version', return_value=(True, '2.1.92'))
+    @patch('install_claude.install_claude_npm', return_value=True)
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.92')
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch('install_claude.verify_claude_installation')
+    def test_npm_source_version_matches(
+        self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
+        mock_npm, mock_verify_upgrade,
+    ):
+        """npm upgrade with version match succeeds normally."""
+        # First call: migration check (return non-npm to skip migration)
+        # Second call: upgrade source detection (return npm)
+        mock_verify.side_effect = [
+            (True, '/home/user/.local/bin/claude', 'native'),
+            (True, '/home/user/.npm-global/bin/claude', 'npm'),
+        ]
+        result = install_claude.ensure_claude()
+        assert result is True
+        assert mock_get_version.return_value == '2.1.89'
+        assert mock_get_latest.return_value == '2.1.92'
+        assert mock_compare.return_value is False
+        mock_npm.assert_called()
+        mock_verify_upgrade.assert_called()
+
+    @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude.install_claude_npm')
+    @patch('install_claude._download_claude_direct_from_gcs', return_value=False)
+    @patch('install_claude._recover_from_versions_directory', return_value=None)
+    @patch('install_claude._verify_upgrade_version', return_value=(False, '2.1.89'))
+    @patch('install_claude.install_claude_native_cross_platform', return_value=True)
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.92')
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch('install_claude.verify_claude_installation')
+    def test_all_recovery_tiers_fail_graceful_degradation(
+        self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
+        mock_native, mock_verify_upgrade, mock_recover, mock_gcs, mock_npm,
+    ):
+        """When all recovery tiers fail, graceful degradation with warning."""
+        mock_verify.return_value = (True, '/home/user/.local/bin/claude', 'native')
+        mock_npm.return_value = False
+        result = install_claude.ensure_claude()
+        assert result is True  # Graceful degradation -- never blocks installation
+        assert mock_get_version.return_value == '2.1.89'
+        assert mock_get_latest.return_value == '2.1.92'
+        assert mock_compare.return_value is False
+        mock_native.assert_called()
+        mock_verify_upgrade.assert_called()
+        mock_recover.assert_called_once()
+        mock_gcs.assert_called_once()
+
+
+class TestDiagnosticLogging:
+    """Tests for diagnostic version logging in _install_claude_native_windows_installer."""
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch('install_claude._finalize_native_install')
+    @patch('install_claude.get_claude_version', return_value='2.1.92')
+    @patch(
+        'install_claude.verify_claude_installation',
+        return_value=(True, r'C:\Users\test\.local\bin\claude.exe', 'native'),
+    )
+    @patch('install_claude.ensure_local_bin_in_path_windows')
+    @patch('install_claude.run_command')
+    @patch('install_claude.urlopen')
+    def test_logs_post_install_version(
+        self, mock_urlopen, mock_run, mock_path, mock_verify,
+        mock_get_version, mock_finalize, capsys,
+    ):
+        """Diagnostic info line is printed after successful native install."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'echo "test"'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout='Installed 2.1.92', stderr='',
+        )
+
+        install_claude._install_claude_native_windows_installer()
+
+        # Verify all mocks participated correctly
+        mock_get_version.assert_called()
+        mock_verify.assert_called()
+        mock_path.assert_called()
+        mock_finalize.assert_called()
+        captured = capsys.readouterr()
+        assert 'Post-install binary version: 2.1.92' in captured.out

--- a/tests/test_install_claude_additional.py
+++ b/tests/test_install_claude_additional.py
@@ -817,6 +817,7 @@ class TestNativeWindowsInstallerFunction:
     """Test the internal native Windows installer function."""
 
     @patch('platform.system', return_value='Windows')
+    @patch('install_claude.get_claude_version', return_value='2.1.39')
     @patch('install_claude.urlopen')
     @patch('install_claude.run_command')
     @patch('install_claude.verify_claude_installation')
@@ -839,12 +840,14 @@ class TestNativeWindowsInstallerFunction:
         mock_verify,
         mock_run,
         mock_urlopen,
+        mock_get_version,
         mock_system,
     ):
         """Test successful native installer execution."""
         del mock_check_npm
         # Verify mock configuration
         assert mock_system.return_value == 'Windows'
+        assert mock_get_version.return_value == '2.1.39'
 
         # Mock installer script download
         mock_response = MagicMock()

--- a/tests/test_install_claude_critical.py
+++ b/tests/test_install_claude_critical.py
@@ -149,14 +149,21 @@ class TestSSLErrorHandling:
 
     @patch('scripts.install_claude.ssl.create_default_context')
     @patch('scripts.install_claude.urlopen')
+    @patch('scripts.install_claude.get_claude_version', return_value='2.1.39')
     @patch('scripts.install_claude.verify_claude_installation')
     @patch('scripts.install_claude.ensure_local_bin_in_path_windows')
     @patch('scripts.install_claude.update_install_method_config')
+    @patch('scripts.install_claude._cleanup_old_claude_files')
+    @patch('scripts.install_claude.time.sleep')
     def test_install_claude_native_ssl_error(
-        self, mock_update_config, mock_ensure_path, mock_verify, mock_urlopen, mock_ssl_context,
+        self, mock_sleep, mock_cleanup, mock_update_config, mock_ensure_path,
+        mock_verify, mock_get_version, mock_urlopen, mock_ssl_context,
     ):
         """Test Claude native installer with SSL certificate error."""
         assert mock_update_config is not None
+        assert mock_get_version is not None
+        assert mock_sleep is not None
+        assert mock_cleanup is not None
         with patch('scripts.install_claude.platform.system', return_value='Windows'):
             # First urlopen raises SSL error
             ssl_error = urllib.error.URLError('CERTIFICATE_VERIFY_FAILED')


### PR DESCRIPTION
The native installer can silently report success while failing to promote the downloaded binary from the versions cache to ~/.local/bin/, leaving the old version in place. Add _verify_upgrade_version() to compare the actual binary version against the expected version after every upgrade path in ensure_claude(). On mismatch, a tiered recovery cascade attempts: versions directory promotion via _recover_from_versions_directory(), GCS direct download, and npm fallback (auto mode only), with graceful degradation if all recovery tiers are exhausted.

Refs: anthropics/claude-code#14942