### PR TITLE
Add dual hooks routing to settings.json when command-names is absent

### DIFF
--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -250,7 +250,7 @@ Creates global shell commands that launch Claude Code with this environment conf
   - Must be alphanumeric, hyphens, and underscores only
 - **Co-dependency:** If specified, `command-defaults` must also be specified (and vice versa)
 - **Inheritance:** Standard override (child replaces parent)
-- **Note:** If empty or not specified, setup steps for hooks download, settings, manifest, launcher, and command registration are skipped. The setup still processes other resources (agents, MCP servers, dependencies, and so on) but does not create a launchable command.
+- **Note:** If empty or not specified, hooks are written to `~/.claude/settings.json` (global scope) instead of a per-environment `config.json`. Manifest, launcher, and command registration steps are skipped. The setup still processes other resources (agents, MCP servers, dependencies, and so on) but does not create a launchable command.
 - **Example:**
 
 ```yaml
@@ -798,7 +798,7 @@ Free-form settings merged into `~/.claude/settings.json`. Uses deep merge with a
 
 - **Type:** `UserSettings | None`
 - **Default:** `None`
-- **Excluded keys:** `hooks` and `statusLine` (these are profile-specific and must be configured at the root level of the YAML configuration)
+- **Excluded keys:** `hooks` and `statusLine` (these require dedicated write logic with path resolution and type processing, and must be configured at the root level of the YAML configuration)
 - **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: deep recursive merge using `deep_merge_settings()` with `DEFAULT_ARRAY_UNION_KEYS` (`permissions.allow`, `permissions.deny`, `permissions.ask` arrays are unioned with deduplication). Child keys override matching parent keys; `null` values delete keys.
 - **Example:**
 
@@ -1143,6 +1143,24 @@ hooks:
       if: "Bash(rm *)"
       once: true
 ```
+
+#### Hooks Routing
+
+Hooks are routed to different target files based on whether `command-names` is specified:
+
+| Scenario                | Target File                    | Write Mechanism                              | Hook Files Directory     |
+|-------------------------|--------------------------------|----------------------------------------------|--------------------------|
+| `command-names` present | `~/.claude/{cmd}/config.json`  | `create_profile_config()` (atomic overwrite) | `~/.claude/{cmd}/hooks/` |
+| `command-names` absent  | `~/.claude/settings.json`      | `write_hooks_to_settings()` (key-replace)    | `~/.claude/hooks/`       |
+
+When `command-names` is absent, the setup writes hooks to the global `~/.claude/settings.json` using read-pop-replace-write semantics: the existing file is read, the `hooks` key is replaced entirely (removing stale events from prior runs), and all other keys are preserved. This avoids deep merge, which would retain stale hook event keys across re-runs.
+
+**Re-run behavior:** The toolbox owns the `hooks` key in `settings.json`. Re-running the setup overwrites any manually-added hooks in `settings.json`. To configure hooks, define them in the YAML configuration rather than editing `settings.json` directly.
+
+The installation summary distinguishes between the two routing targets:
+
+- With `command-names`: `Hooks: N configured (in config.json)`
+- Without `command-names`: `Hooks: N configured (in settings.json)`
 
 ## Advanced Topics
 
@@ -1659,13 +1677,13 @@ Here is a conceptual overview of what the setup script does when you run it with
 14. **Write user settings** -- Merges `user-settings` into `~/.claude/settings.json`.
 15. **Write global config** -- Merges `global-config` into `~/.claude.json`.
 16. **Cleanup stale controls** -- Sweeps all filesystem locations for stale auto-update and IDE extension artifacts from prior configurations.
-17. **Download hooks** -- Downloads hook script files. (Only if `command-names` is specified.)
-18. **Configure profile** -- Creates the profile configuration file for the command.
-19. **Write manifest** -- Creates an installation tracking manifest.
-20. **Create launcher** -- Creates the launcher script for the command.
-21. **Register commands** -- Creates global command wrappers.
+17. **Download hooks** -- Downloads hook script files to `~/.claude/{cmd}/hooks/` (with `command-names`) or `~/.claude/hooks/` (without).
+18. **Write hooks** -- With `command-names`: writes hooks to `config.json` via `create_profile_config()`. Without `command-names`: writes hooks to `~/.claude/settings.json` via `write_hooks_to_settings()`.
+19. **Write manifest** -- Creates an installation tracking manifest. (Only if `command-names` is specified.)
+20. **Create launcher** -- Creates the launcher script for the command. (Only if `command-names` is specified.)
+21. **Register commands** -- Creates global command wrappers. (Only if `command-names` is specified.)
 
-Steps 17 through 21 are skipped if `command-names` is not specified.
+Steps 17-18 are skipped if no hooks are configured. Steps 19-21 are skipped if `command-names` is not specified.
 
 ## Complete Annotated Example
 

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -175,7 +175,7 @@ TILDE_EXPANSION_KEYS: set[str] = {
 # Keys that are NOT allowed in the user-settings section
 # These keys have path resolution issues or are inherently profile-specific
 USER_SETTINGS_EXCLUDED_KEYS: set[str] = {
-    'hooks',       # Path resolution issues; profile-specific event handlers
+    'hooks',       # Hooks require dedicated write logic with path resolution and type processing
     'statusLine',  # Path resolution issues; profile-specific display config
 }
 
@@ -8135,6 +8135,262 @@ def _apply_common_hook_fields(
         hook_config['timeout'] = hook['timeout']
 
 
+def _build_hooks_json(
+    hooks: dict[str, Any],
+    hooks_dir: Path,
+) -> dict[str, Any]:
+    """Build hooks JSON structure from YAML configuration.
+
+    Converts YAML hook event definitions into Claude Code's JSON hooks format.
+    Generates absolute POSIX paths for hook file references. Supports all four
+    hook types: command, http, prompt, agent.
+
+    Used by both create_profile_config() (per-environment config.json) and
+    write_hooks_to_settings() (global settings.json).
+
+    Args:
+        hooks: Hooks configuration dictionary with optional 'events' key.
+        hooks_dir: Directory containing downloaded hook files.
+
+    Returns:
+        Dictionary with hook event names as keys and matcher/hooks arrays
+        as values. Empty dict if no hook events defined.
+    """
+    result: dict[str, Any] = {}
+
+    hook_events = hooks.get('events', [])
+    if not hook_events:
+        return result
+
+    for hook in hook_events:
+        event = hook.get('event')
+        matcher = hook.get('matcher', '')
+        hook_type = hook.get('type', 'command')
+        command = hook.get('command')
+        config = hook.get('config')  # Optional config file reference
+
+        if not event:
+            warning('Invalid hook configuration: missing event, skipping')
+            continue
+
+        # Validate required fields per hook type
+        if hook_type == 'command' and not command:
+            warning('Invalid command hook: missing command, skipping')
+            continue
+        if hook_type == 'http' and not hook.get('url'):
+            warning('Invalid http hook: missing url, skipping')
+            continue
+        if hook_type in ('prompt', 'agent') and not hook.get('prompt'):
+            warning(f'Invalid {hook_type} hook: missing prompt, skipping')
+            continue
+
+        # Add to result
+        if event not in result:
+            result[event] = []
+
+        # Find or create matcher group
+        matcher_group: dict[str, Any] | None = None
+        hooks_list_raw = result[event]
+        if isinstance(hooks_list_raw, list):
+            hooks_list: list[dict[str, Any]] = cast(list[dict[str, Any]], hooks_list_raw)
+            for group_item in hooks_list:
+                if group_item.get('matcher') == matcher:
+                    matcher_group = group_item
+                    break
+
+        if not matcher_group:
+            matcher_group = {
+                'matcher': matcher,
+                'hooks': [],
+            }
+            hooks_event_list_raw = result[event]
+            if isinstance(hooks_event_list_raw, list):
+                hooks_event_list: list[dict[str, Any]] = cast(list[dict[str, Any]], hooks_event_list_raw)
+                hooks_event_list.append(matcher_group)
+
+        # Build hook configuration based on hook type
+        hook_config: dict[str, Any]
+
+        if hook_type == 'command':
+            # Command hooks require file path processing
+            assert command is not None
+
+            # Build the proper command based on file type
+            # Strip query parameters from command if present
+            clean_command = command.split('?')[0] if '?' in command else command
+
+            # Check if this looks like a file reference or a direct command
+            # File references typically don't contain spaces (just the filename)
+            # Direct commands like 'echo "test"' contain spaces
+            is_file_reference = ' ' not in clean_command
+
+            if is_file_reference:
+                # Determine if this is a Python script (case-insensitive check)
+                is_python_script = clean_command.lower().endswith(('.py', '.pyw'))
+
+                # Determine if this is a JavaScript/Node.js script (case-insensitive check)
+                is_javascript_script = clean_command.lower().endswith(('.js', '.mjs', '.cjs'))
+
+                if is_python_script:
+                    # Python script - use uv run for cross-platform execution
+                    hook_path = hooks_dir / Path(clean_command).name
+                    hook_path_str = hook_path.as_posix()
+                    full_command = f'uv run --no-project --python 3.12 {hook_path_str}'
+
+                    # Append config file path if specified
+                    if config:
+                        clean_config = config.split('?')[0] if '?' in config else config
+                        config_path = hooks_dir / Path(clean_config).name
+                        config_path_str = config_path.as_posix()
+                        full_command = f'{full_command} {config_path_str}'
+
+                elif is_javascript_script:
+                    # JavaScript script - use node for cross-platform execution
+                    hook_path = hooks_dir / Path(clean_command).name
+                    hook_path_str = hook_path.as_posix()
+                    full_command = f'node {hook_path_str}'
+
+                    # Append config file path if specified
+                    if config:
+                        clean_config = config.split('?')[0] if '?' in config else config
+                        config_path = hooks_dir / Path(clean_config).name
+                        config_path_str = config_path.as_posix()
+                        full_command = f'{full_command} {config_path_str}'
+
+                else:
+                    # Other file - build absolute path and use as-is
+                    hook_path = hooks_dir / Path(clean_command).name
+                    hook_path_str = hook_path.as_posix()
+                    full_command = hook_path_str
+
+                    # Append config file path if specified
+                    if config:
+                        clean_config = config.split('?')[0] if '?' in config else config
+                        config_path = hooks_dir / Path(clean_config).name
+                        config_path_str = config_path.as_posix()
+                        full_command = f'{full_command} {config_path_str}'
+            else:
+                # Direct command with spaces - use as-is
+                full_command = command
+
+            # Add hook configuration for command hook
+            hook_config = {
+                'type': hook_type,
+                'command': full_command,
+            }
+            # Pass through command-specific optional fields
+            if hook.get('async') is not None:
+                hook_config['async'] = hook['async']
+            if hook.get('shell') is not None:
+                hook_config['shell'] = hook['shell']
+
+        elif hook_type == 'http':
+            # HTTP hooks: pure pass-through, no file-path processing
+            hook_config = {
+                'type': hook_type,
+                'url': hook.get('url', ''),
+            }
+            if hook.get('headers') is not None:
+                hook_config['headers'] = hook['headers']
+            if hook.get('allowed-env-vars') is not None:
+                hook_config['allowedEnvVars'] = hook['allowed-env-vars']
+
+        elif hook_type == 'prompt':
+            # Prompt hooks: pass-through for prompt and model
+            hook_config = {
+                'type': hook_type,
+                'prompt': hook.get('prompt', ''),
+            }
+            if hook.get('model') is not None:
+                hook_config['model'] = hook['model']
+
+        elif hook_type == 'agent':
+            # Agent hooks: same structure as prompt but type is 'agent'
+            hook_config = {
+                'type': hook_type,
+                'prompt': hook.get('prompt', ''),
+            }
+            if hook.get('model') is not None:
+                hook_config['model'] = hook['model']
+
+        else:
+            warning(f'Unknown hook type: {hook_type}, skipping')
+            continue
+
+        # Apply common fields to ALL hook types
+        _apply_common_hook_fields(hook_config, hook)
+
+        if matcher_group and 'hooks' in matcher_group:
+            matcher_hooks_raw = matcher_group['hooks']
+            if isinstance(matcher_hooks_raw, list):
+                matcher_hooks_list = cast(list[object], matcher_hooks_raw)
+                matcher_hooks_list.append(hook_config)
+
+    return result
+
+
+def write_hooks_to_settings(
+    hooks: dict[str, Any],
+    hooks_dir: Path,
+    settings_dir: Path,
+) -> bool:
+    """Write hooks to settings.json with key-replace semantics.
+
+    Reads existing settings.json, replaces the 'hooks' key entirely (not
+    deep-merged), and preserves all other keys. This ensures stale hook
+    events from prior runs are removed.
+
+    Used when command-names is absent from the YAML configuration, routing
+    hooks to the global settings.json instead of a per-environment config.json.
+
+    Args:
+        hooks: Hooks configuration dictionary from YAML.
+        hooks_dir: Directory containing downloaded hook files.
+        settings_dir: Directory containing settings.json (typically ~/.claude/).
+
+    Returns:
+        True if hooks were written successfully, False on failure.
+    """
+    settings_file = settings_dir / 'settings.json'
+    info('Writing hooks to settings.json...')
+
+    # Build hooks JSON using shared helper
+    hooks_json = _build_hooks_json(hooks, hooks_dir)
+
+    # Read existing settings.json (or empty dict)
+    existing: dict[str, Any] = {}
+    if settings_file.exists():
+        try:
+            file_content = settings_file.read_text(encoding='utf-8')
+            if file_content.strip():
+                parsed = json.loads(file_content)
+                if isinstance(parsed, dict):
+                    existing = parsed
+                else:
+                    warning(f'Existing {settings_file} is not a dict, starting fresh')
+        except json.JSONDecodeError as e:
+            warning(f'Invalid JSON in {settings_file}: {e}, starting fresh')
+
+    # Replace the 'hooks' key entirely (not deep merge)
+    if hooks_json:
+        existing['hooks'] = hooks_json
+    else:
+        existing.pop('hooks', None)  # Remove hooks if config produces none
+
+    # Write back
+    try:
+        settings_dir.mkdir(parents=True, exist_ok=True)
+        settings_file.write_text(
+            json.dumps(existing, indent=2, ensure_ascii=False) + '\n',
+            encoding='utf-8',
+        )
+        success(f'Wrote hooks to {settings_file}')
+        return True
+    except OSError as e:
+        warning(f'Failed to write hooks to {settings_file}: {e}')
+        return False
+
+
 def create_profile_config(
     hooks: dict[str, Any],
     config_base_dir: Path,
@@ -8288,195 +8544,10 @@ def create_profile_config(
             info(f'Setting statusLine: {filename}')
 
     # Handle hooks if present
-    hook_events: list[dict[str, Any]] = []
-
     if hooks:
-        settings['hooks'] = {}
-        # Extract events from the hooks configuration (files are downloaded separately)
-        hook_events = hooks.get('events', [])
-
-    # Process each hook event
-    for hook in hook_events:
-        event = hook.get('event')
-        matcher = hook.get('matcher', '')
-        hook_type = hook.get('type', 'command')
-        command = hook.get('command')
-        config = hook.get('config')  # Optional config file reference
-
-        if not event:
-            warning('Invalid hook configuration: missing event, skipping')
-            continue
-
-        # Validate required fields per hook type
-        if hook_type == 'command' and not command:
-            warning('Invalid command hook: missing command, skipping')
-            continue
-        if hook_type == 'http' and not hook.get('url'):
-            warning('Invalid http hook: missing url, skipping')
-            continue
-        if hook_type in ('prompt', 'agent') and not hook.get('prompt'):
-            warning(f'Invalid {hook_type} hook: missing prompt, skipping')
-            continue
-
-        # Add to settings
-        if event not in settings['hooks']:
-            settings['hooks'][event] = []
-
-        # Find or create matcher group
-        matcher_group: dict[str, Any] | None = None
-        hooks_list_raw = settings['hooks'][event]
-        if isinstance(hooks_list_raw, list):
-            hooks_list: list[dict[str, Any]] = cast(list[dict[str, Any]], hooks_list_raw)
-            for group_item in hooks_list:
-                if group_item.get('matcher') == matcher:
-                    matcher_group = group_item
-                    break
-
-        if not matcher_group:
-            matcher_group = {
-                'matcher': matcher,
-                'hooks': [],
-            }
-            hooks_event_list_raw = settings['hooks'][event]
-            if isinstance(hooks_event_list_raw, list):
-                hooks_event_list: list[dict[str, Any]] = cast(list[dict[str, Any]], hooks_event_list_raw)
-                hooks_event_list.append(matcher_group)
-
-        # Build hook configuration based on hook type
-        hook_config: dict[str, Any]
-
-        if hook_type == 'command':
-            # Command hooks require file path processing
-            # command is guaranteed to be non-None here due to validation above
-            assert command is not None
-
-            # Build the proper command based on file type
-            # Strip query parameters from command if present
-            clean_command = command.split('?')[0] if '?' in command else command
-
-            # Check if this looks like a file reference or a direct command
-            # File references typically don't contain spaces (just the filename)
-            # Direct commands like 'echo "test"' contain spaces
-            is_file_reference = ' ' not in clean_command
-
-            if is_file_reference:
-                # Determine if this is a Python script (case-insensitive check)
-                # Supports both .py and .pyw extensions
-                is_python_script = clean_command.lower().endswith(('.py', '.pyw'))
-
-                # Determine if this is a JavaScript/Node.js script (case-insensitive check)
-                # Supports .js (standard), .mjs (ES modules), .cjs (CommonJS modules)
-                is_javascript_script = clean_command.lower().endswith(('.js', '.mjs', '.cjs'))
-
-                if is_python_script:
-                    # Python script - use uv run for cross-platform execution
-                    # Build absolute path to the hook file in hooks directory
-                    hook_path = hooks_dir / Path(clean_command).name
-                    # Use POSIX-style path (forward slashes) for cross-platform compatibility
-                    # This works on Windows, macOS, and Linux, and avoids JSON escaping issues
-                    hook_path_str = hook_path.as_posix()
-                    # Use uv run with Python 3.12 - works cross-platform without PATH dependency
-                    # uv automatically downloads Python 3.12 if not installed
-                    # For .pyw files on Windows, uv automatically uses pythonw
-                    # Use --no-project flag to prevent uv from detecting and applying project Python requirements
-                    full_command = f'uv run --no-project --python 3.12 {hook_path_str}'
-
-                    # Append config file path if specified
-                    if config:
-                        # Strip query parameters from config filename
-                        clean_config = config.split('?')[0] if '?' in config else config
-                        config_path = hooks_dir / Path(clean_config).name
-                        config_path_str = config_path.as_posix()
-                        full_command = f'{full_command} {config_path_str}'
-
-                elif is_javascript_script:
-                    # JavaScript script - use node for cross-platform execution
-                    # node.exe is a binary (not batch script), works directly on all platforms
-                    # Windows: .js files are associated with WSH (JScript), NOT Node.js
-                    # Unix: .js files have no default handler
-                    hook_path = hooks_dir / Path(clean_command).name
-                    hook_path_str = hook_path.as_posix()
-                    full_command = f'node {hook_path_str}'
-
-                    # Append config file path if specified
-                    if config:
-                        # Strip query parameters from config filename
-                        clean_config = config.split('?')[0] if '?' in config else config
-                        config_path = hooks_dir / Path(clean_config).name
-                        config_path_str = config_path.as_posix()
-                        full_command = f'{full_command} {config_path_str}'
-
-                else:
-                    # Other file - build absolute path and use as-is
-                    # System will handle execution based on file extension (.sh, .bat, .cmd, .ps1, etc.)
-                    hook_path = hooks_dir / Path(clean_command).name
-                    hook_path_str = hook_path.as_posix()
-                    full_command = hook_path_str
-
-                    # Append config file path if specified
-                    if config:
-                        # Strip query parameters from config filename
-                        clean_config = config.split('?')[0] if '?' in config else config
-                        config_path = hooks_dir / Path(clean_config).name
-                        config_path_str = config_path.as_posix()
-                        full_command = f'{full_command} {config_path_str}'
-            else:
-                # Direct command with spaces - use as-is
-                full_command = command
-
-            # Add hook configuration for command hook
-            hook_config = {
-                'type': hook_type,
-                'command': full_command,
-            }
-            # Pass through command-specific optional fields
-            if hook.get('async') is not None:
-                hook_config['async'] = hook['async']
-            if hook.get('shell') is not None:
-                hook_config['shell'] = hook['shell']
-
-        elif hook_type == 'http':
-            # HTTP hooks: pure pass-through, no file-path processing
-            hook_config = {
-                'type': hook_type,
-                'url': hook.get('url', ''),
-            }
-            if hook.get('headers') is not None:
-                hook_config['headers'] = hook['headers']
-            if hook.get('allowed-env-vars') is not None:
-                hook_config['allowedEnvVars'] = hook['allowed-env-vars']
-
-        elif hook_type == 'prompt':
-            # Prompt hooks: pass-through for prompt and model
-            hook_config = {
-                'type': hook_type,
-                'prompt': hook.get('prompt', ''),
-            }
-            if hook.get('model') is not None:
-                hook_config['model'] = hook['model']
-
-        elif hook_type == 'agent':
-            # Agent hooks: same structure as prompt but type is 'agent'
-            hook_config = {
-                'type': hook_type,
-                'prompt': hook.get('prompt', ''),
-            }
-            if hook.get('model') is not None:
-                hook_config['model'] = hook['model']
-
-        else:
-            warning(f'Unknown hook type: {hook_type}, skipping')
-            continue
-
-        # Apply common fields to ALL hook types
-        _apply_common_hook_fields(hook_config, hook)
-
-        if matcher_group and 'hooks' in matcher_group:
-            matcher_hooks_raw = matcher_group['hooks']
-            if isinstance(matcher_hooks_raw, list):
-                # Cast to typed list for type safety
-                matcher_hooks_list = cast(list[object], matcher_hooks_raw)
-                matcher_hooks_list.append(hook_config)
+        hooks_json = _build_hooks_json(hooks, hooks_dir)
+        if hooks_json:
+            settings['hooks'] = hooks_json
 
     # Save settings (always overwrite)
     settings_path = config_base_dir / 'config.json'
@@ -10095,9 +10166,29 @@ def main() -> None:
             else:
                 warning('Launcher script was not created')
         else:
-            # Skip command creation
+            # No command-names: check if hooks need to be written to settings.json
+            hooks = config.get('hooks', {})
+            has_hook_events = bool(hooks and hooks.get('events'))
+
+            if has_hook_events:
+                # Step 17: Download hooks to ~/.claude/hooks/
+                print()
+                print(f'{Colors.CYAN}Step 17: Downloading hooks...{Colors.NC}')
+                if not download_hook_files(hooks, claude_user_dir, config_source, base_url, args.auth,
+                                           auth_cache=auth_cache):
+                    download_failures.append('hook files')
+
+                # Step 18: Write hooks to settings.json
+                print()
+                print(f'{Colors.CYAN}Step 18: Writing hooks to settings.json...{Colors.NC}')
+                write_hooks_to_settings(hooks, hooks_dir, claude_user_dir)
+            else:
+                print()
+                print(f'{Colors.CYAN}Steps 17-18: Skipping hooks (none configured)...{Colors.NC}')
+
+            # Steps 19-21: Skip command creation
             print()
-            print(f'{Colors.CYAN}Steps 17-21: Skipping command creation (no command-names specified)...{Colors.NC}')
+            print(f'{Colors.CYAN}Steps 19-21: Skipping command creation (no command-names specified)...{Colors.NC}')
             info('Environment configuration completed successfully')
             info('To create custom commands, add "command-names: [name1, name2]" to your config')
 
@@ -10206,15 +10297,18 @@ def main() -> None:
             print('   * Global config: configured in ~/.claude.json')
         if claude_code_version_normalized is not None:
             print(f'   * IDE extensions: {IDE_EXTENSION_ID} v{claude_code_version_normalized} (auto-install disabled)')
-        # Only show hooks count if command was specified (hooks was defined)
+        # Show hooks count with routing information
+        hooks = config.get('hooks', {})
+        hook_event_count = len(hooks.get('events', [])) if hooks else 0
         if command_names:
-            hooks = config.get('hooks', {})
-            print(f"   * Hooks: {len(hooks.get('events', [])) if hooks else 0} configured")
+            print(f'   * Hooks: {hook_event_count} configured (in config.json)')
             if len(command_names) > 1:
                 print(f'   * Global commands: {", ".join(command_names)} registered')
             else:
                 print(f'   * Global command: {primary_command_name} registered')
         else:
+            if hook_event_count > 0:
+                print(f'   * Hooks: {hook_event_count} configured (in settings.json)')
             print('   * Custom command: Not created (no command-names specified)')
 
         print()

--- a/tests/e2e/test_hooks_settings_routing.py
+++ b/tests/e2e/test_hooks_settings_routing.py
@@ -1,0 +1,720 @@
+"""E2E tests for hooks routing to settings.json when command-names is absent.
+
+These tests verify the dual hooks routing behavior:
+- When command-names IS present: hooks written to config.json (existing behavior)
+- When command-names is ABSENT: hooks written to settings.json (new behavior)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Any
+from unittest.mock import patch
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.setup_environment import _build_hooks_json
+from scripts.setup_environment import create_profile_config
+from scripts.setup_environment import write_hooks_to_settings
+from tests.e2e.validators import _validate_hooks_structure
+from tests.e2e.validators import validate_hooks_in_settings_json
+
+# ---------------------------------------------------------------------------
+# Inline YAML-like configs (dicts) for tests WITHOUT command-names
+# ---------------------------------------------------------------------------
+
+
+def _hooks_only_config() -> dict[str, Any]:
+    """Minimal config with hooks but NO command-names."""
+    return {
+        'name': 'Hooks Only',
+        'hooks': {
+            'files': ['hooks/e2e_test_hook.py'],
+            'events': [
+                {
+                    'event': 'PostToolUse',
+                    'matcher': 'Write',
+                    'type': 'command',
+                    'command': 'e2e_test_hook.py',
+                },
+                {
+                    'event': 'PostToolUse',
+                    'matcher': 'Read',
+                    'type': 'http',
+                    'url': 'http://localhost:8080/hooks',
+                    'headers': {'Authorization': 'Bearer $TOKEN'},
+                    'allowed-env-vars': ['TOKEN'],
+                    'timeout': 15,
+                    'status-message': 'Sending webhook...',
+                },
+                {
+                    'event': 'PreToolUse',
+                    'matcher': 'Bash',
+                    'type': 'prompt',
+                    'prompt': 'Check safety before bash execution',
+                    'timeout': 30,
+                },
+                {
+                    'event': 'PreToolUse',
+                    'matcher': 'Bash(rm *)',
+                    'type': 'agent',
+                    'prompt': 'Verify security of: $ARGUMENTS',
+                    'model': 'sonnet',
+                    'once': True,
+                },
+            ],
+        },
+        # NO command-names
+    }
+
+
+def _hooks_with_user_settings_config() -> dict[str, Any]:
+    """Config with hooks AND user-settings but NO command-names."""
+    return {
+        'name': 'Hooks with User Settings',
+        'user-settings': {
+            'language': 'english',
+            'theme': 'dark',
+        },
+        'hooks': {
+            'files': ['hooks/e2e_test_hook.py'],
+            'events': [
+                {
+                    'event': 'PostToolUse',
+                    'matcher': 'Write',
+                    'type': 'command',
+                    'command': 'e2e_test_hook.py',
+                },
+            ],
+        },
+        # NO command-names
+    }
+
+
+def _no_hooks_no_commands_config() -> dict[str, Any]:
+    """Config with NO hooks and NO command-names."""
+    return {
+        'name': 'Minimal',
+        'user-settings': {
+            'language': 'russian',
+        },
+        # NO hooks, NO command-names
+    }
+
+
+# ---------------------------------------------------------------------------
+# E2E Test Class: Hooks routing to settings.json (no command-names)
+# ---------------------------------------------------------------------------
+
+
+class TestHooksToSettingsJson:
+    """Tests for hooks routing to settings.json when command-names is absent."""
+
+    def test_hooks_written_to_settings_json(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """Verify hooks are written to settings.json when command-names is absent.
+
+        Uses write_hooks_to_settings directly with a hooks-only config.
+        Validates hook structure, all four hook types, and path expansion.
+        """
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+        hooks_dir = claude_dir / 'hooks'
+
+        config = _hooks_only_config()
+        hooks = config['hooks']
+
+        result = write_hooks_to_settings(hooks, hooks_dir, claude_dir)
+        assert result is True
+
+        settings_path = claude_dir / 'settings.json'
+        assert settings_path.exists(), 'settings.json not created'
+
+        errors = validate_hooks_in_settings_json(settings_path, hooks)
+        assert not errors, 'Hooks in settings.json validation failed:\n' + '\n'.join(errors)
+
+    def test_all_four_hook_types_in_settings_json(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """Verify all four hook types (command, http, prompt, agent) in settings.json."""
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+        hooks_dir = claude_dir / 'hooks'
+
+        config = _hooks_only_config()
+        hooks = config['hooks']
+
+        write_hooks_to_settings(hooks, hooks_dir, claude_dir)
+
+        data = json.loads((claude_dir / 'settings.json').read_text())
+        hooks_data = data['hooks']
+
+        # Verify PostToolUse has command and http hooks
+        post_tool_groups = hooks_data['PostToolUse']
+        hook_types_found: set[str] = set()
+        for group in post_tool_groups:
+            hook_types_found.update(hook['type'] for hook in group.get('hooks', []))
+        assert 'command' in hook_types_found, 'command hook type missing'
+        assert 'http' in hook_types_found, 'http hook type missing'
+
+        # Verify PreToolUse has prompt and agent hooks
+        pre_tool_groups = hooks_data['PreToolUse']
+        pre_types: set[str] = set()
+        for group in pre_tool_groups:
+            pre_types.update(hook['type'] for hook in group.get('hooks', []))
+        assert 'prompt' in pre_types, 'prompt hook type missing'
+        assert 'agent' in pre_types, 'agent hook type missing'
+
+    def test_hook_paths_expanded_in_settings_json(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """Verify hook command paths are absolute POSIX with no unexpanded tildes."""
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+        hooks_dir = claude_dir / 'hooks'
+
+        hooks = {
+            'events': [
+                {'event': 'PostToolUse', 'matcher': 'Write', 'type': 'command',
+                 'command': 'e2e_test_hook.py'},
+                {'event': 'PostToolUse', 'matcher': 'Read', 'type': 'command',
+                 'command': 'e2e_test_hook.js'},
+            ],
+        }
+
+        write_hooks_to_settings(hooks, hooks_dir, claude_dir)
+
+        data = json.loads((claude_dir / 'settings.json').read_text())
+        hooks_data = data['hooks']
+
+        for event_groups in hooks_data.values():
+            for group in event_groups:
+                for hook in group.get('hooks', []):
+                    if hook.get('type') == 'command':
+                        cmd = hook.get('command', '')
+                        assert '~' not in cmd, f'Unexpanded tilde in command: {cmd}'
+                        # Python hooks should have uv run prefix
+                        if 'e2e_test_hook.py' in cmd:
+                            assert 'uv run' in cmd, f'Missing uv run prefix: {cmd}'
+                        # JS hooks should have node prefix
+                        if 'e2e_test_hook.js' in cmd:
+                            assert cmd.startswith('node '), f'Missing node prefix: {cmd}'
+
+    def test_stale_hooks_removed_on_rerun(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """Verify stale hook events from prior runs are removed on re-run."""
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+        hooks_dir = claude_dir / 'hooks'
+
+        # First run: create hooks with event A
+        hooks_v1 = {
+            'events': [
+                {'event': 'OldEvent', 'matcher': 'Write', 'type': 'command',
+                 'command': 'old.py'},
+            ],
+        }
+        write_hooks_to_settings(hooks_v1, hooks_dir, claude_dir)
+
+        data_v1 = json.loads((claude_dir / 'settings.json').read_text())
+        assert 'OldEvent' in data_v1['hooks'], 'First run: OldEvent should be present'
+
+        # Second run: create hooks with different event
+        hooks_v2 = {
+            'events': [
+                {'event': 'PostToolUse', 'matcher': 'Write', 'type': 'command',
+                 'command': 'new.py'},
+            ],
+        }
+        write_hooks_to_settings(hooks_v2, hooks_dir, claude_dir)
+
+        data_v2 = json.loads((claude_dir / 'settings.json').read_text())
+        assert 'OldEvent' not in data_v2['hooks'], 'Second run: OldEvent should be removed'
+        assert 'PostToolUse' in data_v2['hooks'], 'Second run: PostToolUse should be present'
+
+    def test_config_json_not_created_without_command_names(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """Verify config.json is NOT created when command-names is absent."""
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+        hooks_dir = claude_dir / 'hooks'
+
+        config = _hooks_only_config()
+        write_hooks_to_settings(config['hooks'], hooks_dir, claude_dir)
+
+        # config.json should NOT exist (no command-names means no isolated environment)
+        config_json = claude_dir / 'config.json'
+        assert not config_json.exists(), 'config.json should not be created without command-names'
+
+
+class TestHooksToConfigJsonRegression:
+    """Regression tests: hooks routed to config.json when command-names IS present."""
+
+    def test_hooks_in_config_json_with_command_names(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        golden_config: dict[str, Any],
+    ) -> None:
+        """Verify hooks are written to config.json when command-names is present."""
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+        cmd = golden_config['command-names'][0]
+        artifact_dir = claude_dir / cmd
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+
+        hooks = golden_config.get('hooks', {})
+        create_profile_config(
+            hooks=hooks,
+            config_base_dir=artifact_dir,
+            model=golden_config.get('model'),
+            permissions=golden_config.get('permissions'),
+            env=golden_config.get('env-variables'),
+            always_thinking_enabled=golden_config.get('always-thinking-enabled'),
+            company_announcements=golden_config.get('company-announcements'),
+            attribution=golden_config.get('attribution'),
+            status_line=golden_config.get('status-line'),
+            effort_level=golden_config.get('effort-level'),
+        )
+
+        config_path = artifact_dir / 'config.json'
+        assert config_path.exists(), 'config.json not created'
+
+        data = json.loads(config_path.read_text())
+        assert 'hooks' in data, 'config.json missing hooks key'
+
+        errors = _validate_hooks_structure(data['hooks'], hooks)
+        assert not errors, 'Hooks in config.json validation failed:\n' + '\n'.join(errors)
+
+    def test_settings_json_no_hooks_with_command_names(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        golden_config: dict[str, Any],
+    ) -> None:
+        """Verify settings.json does NOT contain hooks when command-names is present.
+
+        When command-names is present, hooks go to config.json only.
+        write_user_settings should not write hooks (it's in USER_SETTINGS_EXCLUDED_KEYS).
+        """
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+
+        user_settings = golden_config.get('user-settings')
+        if user_settings:
+            from scripts.setup_environment import write_user_settings
+            write_user_settings(user_settings, claude_dir)
+
+        settings_path = claude_dir / 'settings.json'
+        if settings_path.exists():
+            data = json.loads(settings_path.read_text())
+            assert 'hooks' not in data, (
+                'settings.json should NOT contain hooks when command-names is present'
+            )
+
+
+class TestHooksAndUserSettingsCoexistence:
+    """Test hooks + user-settings co-existence in settings.json."""
+
+    def test_hooks_and_user_settings_coexist(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """Verify settings.json contains both user-settings and hooks."""
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+        hooks_dir = claude_dir / 'hooks'
+
+        config = _hooks_with_user_settings_config()
+
+        # Simulate Step 14: write user settings
+        from scripts.setup_environment import write_user_settings
+        write_user_settings(config['user-settings'], claude_dir)
+
+        # Simulate Step 18: write hooks to settings.json
+        write_hooks_to_settings(config['hooks'], hooks_dir, claude_dir)
+
+        settings_path = claude_dir / 'settings.json'
+        assert settings_path.exists()
+
+        data = json.loads(settings_path.read_text())
+
+        # User settings preserved
+        assert data.get('language') == 'english', 'language setting lost'
+        assert data.get('theme') == 'dark', 'theme setting lost'
+
+        # Hooks present
+        assert 'hooks' in data, 'hooks key missing'
+        assert 'PostToolUse' in data['hooks'], 'PostToolUse event missing'
+
+    def test_hooks_do_not_corrupt_user_settings(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """Verify hooks write does not alter non-hooks keys in settings.json."""
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+        hooks_dir = claude_dir / 'hooks'
+
+        # Pre-populate with rich user settings
+        settings_file = claude_dir / 'settings.json'
+        original_settings = {
+            'language': 'english',
+            'permissions': {'allow': ['Read', 'Write']},
+            'theme': 'dark',
+            'nested': {'key1': 'val1', 'key2': [1, 2, 3]},
+        }
+        settings_file.write_text(json.dumps(original_settings))
+
+        hooks = {
+            'events': [
+                {'event': 'PostToolUse', 'matcher': 'Write', 'type': 'command',
+                 'command': 'hook.py'},
+            ],
+        }
+        write_hooks_to_settings(hooks, hooks_dir, claude_dir)
+
+        data = json.loads(settings_file.read_text())
+
+        # All original keys preserved exactly
+        assert data['language'] == 'english'
+        assert data['permissions'] == {'allow': ['Read', 'Write']}
+        assert data['theme'] == 'dark'
+        assert data['nested'] == {'key1': 'val1', 'key2': [1, 2, 3]}
+
+        # Hooks added
+        assert 'hooks' in data
+
+
+class TestNoHooksNoCommandNames:
+    """Test the skip scenario: no hooks, no command-names."""
+
+    def test_settings_json_no_hooks_key(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """Verify settings.json does NOT contain hooks when none configured."""
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+
+        config = _no_hooks_no_commands_config()
+
+        # Write user settings only (simulates the no-hooks path)
+        from scripts.setup_environment import write_user_settings
+        if config.get('user-settings'):
+            write_user_settings(config['user-settings'], claude_dir)
+
+        settings_path = claude_dir / 'settings.json'
+        if settings_path.exists():
+            data = json.loads(settings_path.read_text())
+            assert 'hooks' not in data, 'hooks key should not be present when none configured'
+
+    def test_empty_hooks_cleans_up(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """Verify write_hooks_to_settings with empty hooks removes stale hooks key."""
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+        hooks_dir = claude_dir / 'hooks'
+
+        # Pre-populate with stale hooks
+        settings_file = claude_dir / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'hooks': {'OldEvent': []},
+            'language': 'russian',
+        }))
+
+        # Write empty hooks (simulates config with no hook events)
+        write_hooks_to_settings({}, hooks_dir, claude_dir)
+
+        data = json.loads(settings_file.read_text())
+        assert 'hooks' not in data, 'Stale hooks key should be removed'
+        assert data['language'] == 'russian', 'Other settings should be preserved'
+
+
+class TestSummaryOutputRouting:
+    """Test summary output distinguishes hooks routing target."""
+
+    @patch('scripts.setup_environment.load_config_from_source')
+    @patch('scripts.setup_environment.validate_all_config_files')
+    @patch('scripts.setup_environment.install_claude')
+    @patch('scripts.setup_environment.install_dependencies')
+    @patch('scripts.setup_environment.process_resources')
+    @patch('scripts.setup_environment.process_skills')
+    @patch('scripts.setup_environment.configure_all_mcp_servers')
+    @patch('scripts.setup_environment.find_command', return_value='/usr/bin/claude')
+    @patch('scripts.setup_environment.is_admin', return_value=True)
+    @patch('pathlib.Path.mkdir')
+    def test_summary_shows_settings_json_routing(
+        self,
+        mock_mkdir: MagicMock,
+        mock_is_admin: MagicMock,
+        mock_find_cmd: MagicMock,
+        mock_mcp: MagicMock,
+        mock_skills: MagicMock,
+        mock_resources: MagicMock,
+        mock_deps: MagicMock,
+        mock_install: MagicMock,
+        mock_validate: MagicMock,
+        mock_load: MagicMock,
+        e2e_isolated_home: dict[str, Path],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Verify summary shows 'in settings.json' when no command-names."""
+        del mock_mkdir, mock_is_admin, mock_find_cmd, mock_skills, mock_resources
+        del mock_deps, e2e_isolated_home
+        mock_load.return_value = (
+            {
+                'name': 'Hooks Test',
+                'hooks': {
+                    'files': ['hooks/hook.py'],
+                    'events': [
+                        {'event': 'PostToolUse', 'matcher': 'Write',
+                         'type': 'command', 'command': 'hook.py'},
+                    ],
+                },
+                # NO command-names
+            },
+            'test.yaml',
+        )
+        mock_validate.return_value = (True, [])
+        mock_install.return_value = True
+        mock_mcp.return_value = (True, [], {'global_count': 0, 'profile_count': 0, 'combined_count': 0})
+
+        from scripts import setup_environment
+
+        with patch('sys.argv', ['setup_environment.py', 'test', '--yes', '--skip-install']), \
+             patch('sys.exit') as mock_exit, \
+             patch.object(setup_environment, 'download_hook_files', return_value=True), \
+             patch.object(setup_environment, 'write_hooks_to_settings', return_value=True):
+            setup_environment.main()
+            mock_exit.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert 'Hooks: 1 configured (in settings.json)' in captured.out
+
+    @patch('scripts.setup_environment.load_config_from_source')
+    @patch('scripts.setup_environment.validate_all_config_files')
+    @patch('scripts.setup_environment.install_claude')
+    @patch('scripts.setup_environment.install_dependencies')
+    @patch('scripts.setup_environment.process_resources')
+    @patch('scripts.setup_environment.process_skills')
+    @patch('scripts.setup_environment.configure_all_mcp_servers')
+    @patch('scripts.setup_environment.write_user_settings')
+    @patch('scripts.setup_environment.create_profile_config')
+    @patch('scripts.setup_environment.create_launcher_script')
+    @patch('scripts.setup_environment.register_global_command')
+    @patch('scripts.setup_environment.find_command', return_value='/usr/bin/claude')
+    @patch('scripts.setup_environment.is_admin', return_value=True)
+    @patch('pathlib.Path.mkdir')
+    def test_summary_shows_config_json_routing(
+        self,
+        mock_mkdir: MagicMock,
+        mock_is_admin: MagicMock,
+        mock_find_cmd: MagicMock,
+        mock_register: MagicMock,
+        mock_launcher: MagicMock,
+        mock_profile: MagicMock,
+        mock_write_settings: MagicMock,
+        mock_mcp: MagicMock,
+        mock_skills: MagicMock,
+        mock_resources: MagicMock,
+        mock_deps: MagicMock,
+        mock_install: MagicMock,
+        mock_validate: MagicMock,
+        mock_load: MagicMock,
+        e2e_isolated_home: dict[str, Path],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Verify summary shows 'in config.json' when command-names is present."""
+        del mock_mkdir, mock_is_admin, mock_find_cmd, mock_skills, mock_resources
+        del mock_deps, e2e_isolated_home, mock_register, mock_profile, mock_write_settings
+        mock_load.return_value = (
+            {
+                'name': 'Hooks Test with Command',
+                'command-names': ['test-cmd'],
+                'hooks': {
+                    'files': ['hooks/hook.py'],
+                    'events': [
+                        {'event': 'PostToolUse', 'matcher': 'Write',
+                         'type': 'command', 'command': 'hook.py'},
+                        {'event': 'PreToolUse', 'matcher': 'Bash',
+                         'type': 'prompt', 'prompt': 'check safety'},
+                    ],
+                },
+            },
+            'test.yaml',
+        )
+        mock_validate.return_value = (True, [])
+        mock_install.return_value = True
+        mock_mcp.return_value = (True, [], {'global_count': 0, 'profile_count': 0, 'combined_count': 0})
+
+        from scripts import setup_environment
+
+        mock_launcher.return_value = (Path('/fake/launcher.sh'), Path('/fake/launch.sh'))
+
+        with patch('sys.argv', ['setup_environment.py', 'test', '--yes', '--skip-install']), \
+             patch('sys.exit') as mock_exit, \
+             patch.object(setup_environment, 'download_hook_files', return_value=True):
+            setup_environment.main()
+            mock_exit.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert 'Hooks: 2 configured (in config.json)' in captured.out
+
+
+class TestHooksSettingsRoutingStepOutput:
+    """Test that step output messages are correct for hooks routing."""
+
+    @patch('scripts.setup_environment.load_config_from_source')
+    @patch('scripts.setup_environment.validate_all_config_files')
+    @patch('scripts.setup_environment.install_claude')
+    @patch('scripts.setup_environment.install_dependencies')
+    @patch('scripts.setup_environment.process_resources')
+    @patch('scripts.setup_environment.process_skills')
+    @patch('scripts.setup_environment.configure_all_mcp_servers')
+    @patch('scripts.setup_environment.find_command', return_value='/usr/bin/claude')
+    @patch('scripts.setup_environment.is_admin', return_value=True)
+    @patch('pathlib.Path.mkdir')
+    def test_steps_17_18_run_when_hooks_present(
+        self,
+        mock_mkdir: MagicMock,
+        mock_is_admin: MagicMock,
+        mock_find_cmd: MagicMock,
+        mock_mcp: MagicMock,
+        mock_skills: MagicMock,
+        mock_resources: MagicMock,
+        mock_deps: MagicMock,
+        mock_install: MagicMock,
+        mock_validate: MagicMock,
+        mock_load: MagicMock,
+        e2e_isolated_home: dict[str, Path],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Verify Steps 17-18 run when hooks are present without command-names."""
+        del mock_mkdir, mock_is_admin, mock_find_cmd, mock_skills, mock_resources
+        del mock_deps, e2e_isolated_home
+        mock_load.return_value = (
+            {
+                'name': 'Hooks Only',
+                'hooks': {
+                    'events': [
+                        {'event': 'PostToolUse', 'matcher': 'Write',
+                         'type': 'command', 'command': 'hook.py'},
+                    ],
+                },
+            },
+            'test.yaml',
+        )
+        mock_validate.return_value = (True, [])
+        mock_install.return_value = True
+        mock_mcp.return_value = (True, [], {'global_count': 0, 'profile_count': 0, 'combined_count': 0})
+
+        from scripts import setup_environment
+
+        with patch('sys.argv', ['setup_environment.py', 'test', '--yes', '--skip-install']), \
+             patch('sys.exit') as mock_exit, \
+             patch.object(setup_environment, 'download_hook_files', return_value=True), \
+             patch.object(setup_environment, 'write_hooks_to_settings', return_value=True):
+            setup_environment.main()
+            mock_exit.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert 'Step 17: Downloading hooks' in captured.out
+        assert 'Step 18: Writing hooks to settings.json' in captured.out
+        assert 'Steps 19-21: Skipping command creation' in captured.out
+
+    @patch('scripts.setup_environment.load_config_from_source')
+    @patch('scripts.setup_environment.validate_all_config_files')
+    @patch('scripts.setup_environment.install_claude')
+    @patch('scripts.setup_environment.install_dependencies')
+    @patch('scripts.setup_environment.process_resources')
+    @patch('scripts.setup_environment.process_skills')
+    @patch('scripts.setup_environment.configure_all_mcp_servers')
+    @patch('scripts.setup_environment.find_command', return_value='/usr/bin/claude')
+    @patch('scripts.setup_environment.is_admin', return_value=True)
+    @patch('pathlib.Path.mkdir')
+    def test_steps_17_18_skipped_when_no_hooks(
+        self,
+        mock_mkdir: MagicMock,
+        mock_is_admin: MagicMock,
+        mock_find_cmd: MagicMock,
+        mock_mcp: MagicMock,
+        mock_skills: MagicMock,
+        mock_resources: MagicMock,
+        mock_deps: MagicMock,
+        mock_install: MagicMock,
+        mock_validate: MagicMock,
+        mock_load: MagicMock,
+        e2e_isolated_home: dict[str, Path],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Verify Steps 17-18 are skipped when no hooks and no command-names."""
+        del mock_mkdir, mock_is_admin, mock_find_cmd, mock_skills, mock_resources
+        del mock_deps, e2e_isolated_home
+        mock_load.return_value = (
+            {
+                'name': 'No Hooks',
+                # No hooks, no command-names
+            },
+            'test.yaml',
+        )
+        mock_validate.return_value = (True, [])
+        mock_install.return_value = True
+        mock_mcp.return_value = (True, [], {'global_count': 0, 'profile_count': 0, 'combined_count': 0})
+
+        from scripts import setup_environment
+
+        with patch('sys.argv', ['setup_environment.py', 'test', '--yes', '--skip-install']), \
+             patch('sys.exit') as mock_exit:
+            setup_environment.main()
+            mock_exit.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert 'Steps 17-18: Skipping hooks (none configured)' in captured.out
+        assert 'Steps 19-21: Skipping command creation' in captured.out
+
+
+class TestBuildHooksJsonParity:
+    """E2E parity tests: _build_hooks_json matches create_profile_config output."""
+
+    def test_golden_config_hooks_parity(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        golden_config: dict[str, Any],
+    ) -> None:
+        """Verify _build_hooks_json produces identical output to create_profile_config.
+
+        Uses the full golden config hooks section for comprehensive parity.
+        """
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+        artifact_dir = claude_dir / 'test-parity'
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        hooks_dir = artifact_dir / 'hooks'
+
+        hooks = golden_config.get('hooks', {})
+
+        # Generate via create_profile_config
+        create_profile_config(hooks=hooks, config_base_dir=artifact_dir)
+        config_data = json.loads((artifact_dir / 'config.json').read_text())
+        config_hooks = config_data.get('hooks', {})
+
+        # Generate via _build_hooks_json
+        direct_hooks = _build_hooks_json(hooks, hooks_dir)
+
+        assert direct_hooks == config_hooks, (
+            'Parity failure: _build_hooks_json output differs from create_profile_config'
+        )

--- a/tests/e2e/validators.py
+++ b/tests/e2e/validators.py
@@ -1656,3 +1656,30 @@ def validate_launcher_env_sourcing(
             )
 
     return errors
+
+
+def validate_hooks_in_settings_json(path: Path, config: dict[str, Any]) -> list[str]:
+    """Validate hooks structure in settings.json (no-command-names flow).
+
+    Reads the settings.json file and validates the hooks structure against
+    the YAML hooks configuration. Delegates structural validation to the
+    existing _validate_hooks_structure helper.
+
+    Args:
+        path: Path to settings.json file
+        config: Hooks configuration dictionary (the 'hooks' section from YAML)
+
+    Returns:
+        List of error strings (empty if validation passes)
+    """
+    errors: list[str] = []
+    data, file_errors = validate_json_file(path)
+    if file_errors:
+        return file_errors
+    assert data is not None
+    hooks_data = data.get('hooks', {})
+    if not hooks_data:
+        errors.append('settings.json missing hooks key')
+        return errors
+    errors.extend(_validate_hooks_structure(hooks_data, config))
+    return errors

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -4415,6 +4415,323 @@ class TestArtifactIsolation:
             assert 'my-env/hooks/my_hook.sh' in hook_cmd
 
 
+class TestBuildHooksJson:
+    """Tests for _build_hooks_json() extracted helper."""
+
+    def test_empty_hooks(self):
+        """Empty hooks dict returns empty dict."""
+        result = setup_environment._build_hooks_json({}, Path('/hooks'))
+        assert result == {}
+
+    def test_no_events(self):
+        """Hooks dict without events key returns empty dict."""
+        result = setup_environment._build_hooks_json({'files': ['a.py']}, Path('/hooks'))
+        assert result == {}
+
+    def test_empty_events_list(self):
+        """Hooks dict with empty events list returns empty dict."""
+        result = setup_environment._build_hooks_json({'events': []}, Path('/hooks'))
+        assert result == {}
+
+    def test_python_hook_uv_run_prefix(self):
+        """Python hook gets uv run prefix with absolute POSIX path."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write', 'type': 'command', 'command': 'linter.py'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/home/user/.claude/hooks'))
+        assert 'PostToolUse' in result
+        hook_cmd = result['PostToolUse'][0]['hooks'][0]['command']
+        assert 'uv run' in hook_cmd
+        assert '/home/user/.claude/hooks/linter.py' in hook_cmd
+        assert '~' not in hook_cmd
+
+    def test_javascript_hook_node_prefix(self):
+        """JavaScript hook gets node prefix."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Read', 'type': 'command', 'command': 'check.js'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook_cmd = result['PostToolUse'][0]['hooks'][0]['command']
+        assert hook_cmd.startswith('node ')
+
+    def test_mjs_hook_node_prefix(self):
+        """ES module (.mjs) hook gets node prefix."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Edit', 'type': 'command', 'command': 'check.mjs'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook_cmd = result['PostToolUse'][0]['hooks'][0]['command']
+        assert hook_cmd.startswith('node ')
+
+    def test_cjs_hook_node_prefix(self):
+        """CommonJS (.cjs) hook gets node prefix."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Edit', 'type': 'command', 'command': 'check.cjs'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook_cmd = result['PostToolUse'][0]['hooks'][0]['command']
+        assert hook_cmd.startswith('node ')
+
+    def test_http_hook(self):
+        """HTTP hook passes through url, headers, allowedEnvVars."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write', 'type': 'http',
+                             'url': 'http://localhost:8080/hooks', 'headers': {'X-Key': 'val'},
+                             'allowed-env-vars': ['TOKEN']}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PostToolUse'][0]['hooks'][0]
+        assert hook['type'] == 'http'
+        assert hook['url'] == 'http://localhost:8080/hooks'
+        assert hook['headers'] == {'X-Key': 'val'}
+        assert hook['allowedEnvVars'] == ['TOKEN']
+
+    def test_prompt_hook(self):
+        """Prompt hook passes through prompt and model."""
+        hooks = {'events': [{'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'prompt',
+                             'prompt': 'Check safety', 'model': 'sonnet'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PreToolUse'][0]['hooks'][0]
+        assert hook['type'] == 'prompt'
+        assert hook['prompt'] == 'Check safety'
+        assert hook['model'] == 'sonnet'
+
+    def test_agent_hook(self):
+        """Agent hook passes through prompt, model, and once."""
+        hooks = {'events': [{'event': 'PreToolUse', 'matcher': 'Bash(rm *)', 'type': 'agent',
+                             'prompt': 'Verify security', 'once': True}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PreToolUse'][0]['hooks'][0]
+        assert hook['type'] == 'agent'
+        assert hook['prompt'] == 'Verify security'
+        assert hook['once'] is True
+
+    def test_common_fields_pass_through(self):
+        """Common fields (if, statusMessage, once, timeout) pass through."""
+        hooks = {'events': [{'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'prompt',
+                             'prompt': 'test', 'if': 'condition', 'status-message': 'checking',
+                             'once': True, 'timeout': 30}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PreToolUse'][0]['hooks'][0]
+        assert hook['if'] == 'condition'
+        assert hook['statusMessage'] == 'checking'
+        assert hook['once'] is True
+        assert hook['timeout'] == 30
+
+    def test_config_file_appended(self):
+        """Config file path appended to command."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Edit', 'type': 'command',
+                             'command': 'linter.py', 'config': 'linter-config.yaml'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/home/user/.claude/hooks'))
+        hook_cmd = result['PostToolUse'][0]['hooks'][0]['command']
+        assert '/home/user/.claude/hooks/linter-config.yaml' in hook_cmd
+
+    def test_matcher_grouping(self):
+        """Multiple hooks with same event+matcher are grouped."""
+        hooks = {'events': [
+            {'event': 'PostToolUse', 'matcher': 'Write', 'type': 'command', 'command': 'a.py'},
+            {'event': 'PostToolUse', 'matcher': 'Write', 'type': 'command', 'command': 'b.py'},
+        ]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        assert len(result['PostToolUse']) == 1
+        assert len(result['PostToolUse'][0]['hooks']) == 2
+
+    def test_different_matchers_separate_groups(self):
+        """Different matchers create separate groups."""
+        hooks = {'events': [
+            {'event': 'PostToolUse', 'matcher': 'Write', 'type': 'command', 'command': 'a.py'},
+            {'event': 'PostToolUse', 'matcher': 'Edit', 'type': 'command', 'command': 'b.py'},
+        ]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        assert len(result['PostToolUse']) == 2
+
+    def test_direct_command_passthrough(self):
+        """Direct commands with spaces are passed through as-is."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write', 'type': 'command',
+                             'command': 'echo "hello world"'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook_cmd = result['PostToolUse'][0]['hooks'][0]['command']
+        assert hook_cmd == 'echo "hello world"'
+
+    def test_command_async_and_shell_fields(self):
+        """Command-specific async and shell fields pass through."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write', 'type': 'command',
+                             'command': 'hook.py', 'async': True, 'shell': '/bin/bash'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PostToolUse'][0]['hooks'][0]
+        assert hook['async'] is True
+        assert hook['shell'] == '/bin/bash'
+
+    def test_invalid_event_skipped(self):
+        """Hook with missing event is skipped."""
+        hooks = {'events': [{'matcher': 'Write', 'type': 'command', 'command': 'a.py'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        assert result == {}
+
+    def test_invalid_command_hook_skipped(self):
+        """Command hook without command is skipped."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write', 'type': 'command'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        assert result == {}
+
+    def test_parity_with_create_profile_config(self):
+        """Verify _build_hooks_json produces same output as create_profile_config."""
+        hooks = {
+            'events': [
+                {'event': 'PostToolUse', 'matcher': 'Write', 'type': 'command', 'command': 'linter.py'},
+                {'event': 'PostToolUse', 'matcher': 'Edit|MultiEdit|Write', 'type': 'command',
+                 'command': 'check.js', 'config': 'check-config.yaml'},
+                {'event': 'PostToolUse', 'matcher': 'Write', 'type': 'http',
+                 'url': 'http://localhost:8080/hooks', 'headers': {'Auth': 'Bearer tok'},
+                 'allowed-env-vars': ['TOK']},
+                {'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'prompt',
+                 'prompt': 'Is this safe?', 'model': 'sonnet'},
+                {'event': 'PreToolUse', 'matcher': 'Bash(rm *)', 'type': 'agent',
+                 'prompt': 'Verify security', 'once': True},
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / 'cmd'
+            config_dir.mkdir()
+            hooks_dir = config_dir / 'hooks'
+
+            # Get result from create_profile_config
+            setup_environment.create_profile_config(hooks, config_dir)
+            config_json = json.loads((config_dir / 'config.json').read_text())
+            config_hooks = config_json.get('hooks', {})
+
+            # Get result from _build_hooks_json
+            direct_hooks = setup_environment._build_hooks_json(hooks, hooks_dir)
+
+            assert direct_hooks == config_hooks
+
+
+class TestWriteHooksToSettings:
+    """Tests for write_hooks_to_settings() function."""
+
+    def test_creates_new_file(self, tmp_path):
+        """Creates settings.json when it does not exist."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write',
+                             'type': 'command', 'command': 'hook.py'}]}
+        hooks_dir = tmp_path / 'hooks'
+        result = setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
+        assert result is True
+        settings_file = tmp_path / 'settings.json'
+        assert settings_file.exists()
+        data = json.loads(settings_file.read_text())
+        assert 'hooks' in data
+        assert 'PostToolUse' in data['hooks']
+
+    def test_preserves_existing_keys(self, tmp_path):
+        """Existing keys in settings.json are preserved."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({'language': 'english', 'theme': 'dark'}))
+        hooks = {'events': [{'event': 'SessionStart', 'matcher': '*',
+                             'type': 'command', 'command': 'hook.py'}]}
+        hooks_dir = tmp_path / 'hooks'
+        result = setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
+        assert result is True
+        data = json.loads(settings_file.read_text())
+        assert data['language'] == 'english'
+        assert data['theme'] == 'dark'
+        assert 'hooks' in data
+
+    def test_replaces_stale_hooks(self, tmp_path):
+        """Stale hook events from prior runs are removed."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'hooks': {'OldEvent': [{'matcher': '', 'hooks': [{'type': 'command', 'command': 'old.py'}]}]},
+        }))
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write',
+                             'type': 'command', 'command': 'new.py'}]}
+        hooks_dir = tmp_path / 'hooks'
+        result = setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
+        assert result is True
+        data = json.loads(settings_file.read_text())
+        assert 'OldEvent' not in data['hooks']
+        assert 'PostToolUse' in data['hooks']
+
+    def test_empty_hooks_removes_key(self, tmp_path):
+        """Empty hooks configuration removes 'hooks' key from settings."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'hooks': {'SomeEvent': []},
+            'language': 'english',
+        }))
+        hooks_dir = tmp_path / 'hooks'
+        result = setup_environment.write_hooks_to_settings({}, hooks_dir, tmp_path)
+        assert result is True
+        data = json.loads(settings_file.read_text())
+        assert 'hooks' not in data
+        assert data['language'] == 'english'
+
+    def test_invalid_json_starts_fresh(self, tmp_path):
+        """Invalid JSON in existing file starts with fresh dict."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text('not valid json!!!')
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': '',
+                             'type': 'command', 'command': 'hook.py'}]}
+        hooks_dir = tmp_path / 'hooks'
+        result = setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
+        assert result is True
+        data = json.loads(settings_file.read_text())
+        assert 'hooks' in data
+
+    def test_non_dict_json_starts_fresh(self, tmp_path):
+        """Non-dict JSON content starts with fresh dict."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text('"just a string"')
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': '',
+                             'type': 'command', 'command': 'hook.py'}]}
+        hooks_dir = tmp_path / 'hooks'
+        result = setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
+        assert result is True
+        data = json.loads(settings_file.read_text())
+        assert 'hooks' in data
+
+    def test_preserves_user_settings_from_prior_step(self, tmp_path):
+        """Hooks write preserves user settings written by write_user_settings."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'language': 'english',
+            'theme': 'dark',
+            'permissions': {'allow': ['Read']},
+        }))
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write',
+                             'type': 'command', 'command': 'hook.py'}]}
+        hooks_dir = tmp_path / 'hooks'
+        result = setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
+        assert result is True
+        data = json.loads(settings_file.read_text())
+        assert data['language'] == 'english'
+        assert data['theme'] == 'dark'
+        assert data['permissions'] == {'allow': ['Read']}
+        assert 'PostToolUse' in data['hooks']
+
+    def test_idempotent(self, tmp_path):
+        """Running write_hooks_to_settings twice produces same result."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write',
+                             'type': 'command', 'command': 'hook.py'}]}
+        hooks_dir = tmp_path / 'hooks'
+        setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
+        first_content = (tmp_path / 'settings.json').read_text()
+        setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
+        second_content = (tmp_path / 'settings.json').read_text()
+        assert first_content == second_content
+
+    def test_creates_directory_if_missing(self, tmp_path):
+        """Creates settings_dir if it does not exist."""
+        new_dir = tmp_path / 'new_dir'
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write',
+                             'type': 'command', 'command': 'hook.py'}]}
+        hooks_dir = new_dir / 'hooks'
+        result = setup_environment.write_hooks_to_settings(hooks, hooks_dir, new_dir)
+        assert result is True
+        assert (new_dir / 'settings.json').exists()
+
+    def test_empty_file_starts_fresh(self, tmp_path):
+        """Empty settings.json starts with fresh dict."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text('')
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write',
+                             'type': 'command', 'command': 'hook.py'}]}
+        hooks_dir = tmp_path / 'hooks'
+        result = setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
+        assert result is True
+        data = json.loads(settings_file.read_text())
+        assert 'hooks' in data
+
+
 class TestCreateLauncherScript:
     """Test launcher script creation."""
 
@@ -9459,9 +9776,10 @@ class TestMainFunctionUserSettings:
         call_args = mock_write_user_settings.call_args
         assert call_args[0][0] == {'language': 'russian', 'model': 'claude-opus-4'}
 
-        # Verify output shows Steps 16-20 skipped
+        # Verify output shows hooks skipped and command creation skipped
         captured = capsys.readouterr()
-        assert 'Steps 17-21: Skipping command creation' in captured.out
+        assert 'Steps 17-18: Skipping hooks (none configured)' in captured.out
+        assert 'Steps 19-21: Skipping command creation (no command-names specified)' in captured.out
         assert 'Step 14: Writing user settings' in captured.out
 
     @patch('setup_environment.load_config_from_source')


### PR DESCRIPTION
When command-names is not specified in the YAML configuration, hooks are now downloaded and written to the global settings.json instead of being skipped entirely. The existing per-environment flow that writes hooks to config.json via create_profile_config() is preserved.

Extract _build_hooks_json() as a shared helper from create_profile_config() to generate Claude Code hooks JSON with absolute POSIX paths. Add write_hooks_to_settings() with read-pop-replace-write semantics that replaces the hooks key entirely to prevent stale event accumulation. Update main() else branch to run Steps 17-18 for hooks when configured.