### PR TITLE
Add profile-settings parity for non-command-names mode

### DIFF
--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -811,6 +811,50 @@ user-settings:
     DISABLE_AUTOUPDATER: "1"
 ```
 
+##### Relationship to Profile-Owned Keys
+
+`user-settings` is the **forward-compatibility escape hatch** for the ~85% of Claude Code CLI `settings.json` schema that the toolbox does not model at the YAML root level. It COMPLEMENTS (does not replace or contradict) the profile-settings writer used in non-command-names mode. See also [Profile-Level Settings Routing](#profile-level-settings-routing) for the end-to-end picture.
+
+**Decision matrix -- where should I put a given setting?**
+
+| Setting category                     | YAML root level                      | `user-settings:`         | `global-config:`         |
+|--------------------------------------|--------------------------------------|--------------------------|--------------------------|
+| 9 profile-owned keys (below)         | **YES** (profile-owned, auto-routed) | No                       | No                       |
+| Any other `settings.json` CLI key    | No                                   | **YES** (free-form)      | No                       |
+| Any `~/.claude.json` CLI key         | No                                   | No                       | **YES** (free-form)      |
+
+**9 profile-owned keys (placed at YAML root level):**
+
+- `model`, `permissions`, `env-variables`, `attribution`, `always-thinking-enabled`, `effort-level`, `company-announcements`, `status-line`, `hooks`
+
+**Examples of "any other `settings.json` CLI key" (placed under `user-settings:`):**
+
+- `language`, `theme`, `includeGitInstructions`, `apiKeyHelper`, `awsCredentialExport`, `cleanupPeriodDays`, `outputStyle`, `autoMemoryDirectory`, `defaultShell`, `respectGitignore`, `sandbox.*`, plus any new Claude Code CLI setting not yet modeled at YAML root level. `user-settings` uses `extra='allow'` Pydantic semantics, so any key that is not explicitly excluded passes through unchanged.
+
+**Examples of "any `~/.claude.json` CLI key" (placed under `global-config:`):**
+
+- `autoConnectIde`, `editorMode`, `showTurnDuration`, `terminalProgressBarEnabled`, and any other global CLI settings.
+
+**Precedence rule for the 9 profile-owned keys:**
+
+If you declare a profile-owned key (e.g., `permissions`) at BOTH YAML root level AND under `user-settings:`, the **root-level value wins** because Step 18 `write_profile_settings_to_settings()` runs AFTER Step 14 `write_user_settings()` and performs a full top-level REPLACE (not a deep merge). A warning from `detect_settings_conflicts()` is emitted during validation to make the precedence explicit. The warning fires in BOTH command-names-present and command-names-absent modes.
+
+**Why the two surfaces coexist:**
+
+- **Profile-owned keys** (9 keys) have first-class atomic semantics because the toolbox fully owns them: kebab-to-camel translation (`default-mode` -> `defaultMode`), file path resolution for hook events, status-line command-string generation with absolute POSIX paths, and auto-update Target 2/3 injection management.
+- **`user-settings`** passes through any other key without interpretation. This allows users to configure any Claude Code CLI setting the toolbox does not model at the YAML root level -- including settings added in future Claude Code releases -- without waiting for a toolbox update. This is the meaning of "forward-compatibility escape hatch".
+
+**Keys explicitly FORBIDDEN under `user-settings:` (validation error):**
+
+- `hooks` -- must be at YAML root level (requires file download, path resolution, type processing via `_build_hooks_json()`).
+- `statusLine` -- must be at YAML root level via `status-line:` (requires file download and path resolution into `hooks.files`).
+
+These two keys are blocked by `check_excluded_keys` in the `UserSettings` Pydantic model (`USER_SETTINGS_EXCLUDED_KEYS = {'hooks', 'statusLine'}`). No other keys are blocked -- this exclusion set is NOT extended to cover the 9 profile-owned keys.
+
+**Preservation contract for `user-settings`:**
+
+Keys that you put under `user-settings:` are preserved even when you re-run the setup with a different YAML that omits them, because Step 14 `write_user_settings()` uses deep-merge semantics and never deletes keys unless you set them to `null`. Additionally, Step 18 `write_profile_settings_to_settings()` only touches keys that appear in the profile delta; all other keys (including your `user-settings` contributions and any user-managed keys outside the YAML) remain intact. This is the deliberate shared-file semantics: the toolbox does NOT surprise-delete anything from the shared `~/.claude/settings.json`. See [Profile-Level Settings Routing](#profile-level-settings-routing) below for the full write semantics contract and the deferred stale-key behavior.
+
 #### `global-config`
 
 Settings merged into `~/.claude.json` (the Claude Code global configuration file). When `command-names` is present, additionally written to `~/.claude/{cmd}/.claude.json` for isolated environments (Claude Code CLI resolves `getGlobalClaudeFile()` via `CLAUDE_CONFIG_DIR` with no fallback to the home directory). Uses deep merge with no array union (arrays are replaced, not merged).
@@ -853,6 +897,8 @@ global-config:
 - The `--dry-run` summary shows `[DELETE]` markers for null-valued keys
 
 > **Warning:** Bare YAML keys with no value (`key:`) are equivalent to `key: null`. This means accidentally omitting a value will DELETE that key rather than set it to an empty string. Always use explicit values: `key: ""` for empty strings, `key: null` for intentional deletion.
+
+**Profile-owned keys in non-command-names mode:** The nine profile-owned keys (`model`, `permissions`, `env-variables`, `attribution`, `always-thinking-enabled`, `effort-level`, `company-announcements`, `status-line`, `hooks`) also support null-as-delete at the YAML root level via the [conditional top-level replace writer](#profile-level-settings-routing). Setting `model: null` at YAML root level deletes the `model` key from `~/.claude/settings.json`. OMITTING a profile-owned key from a subsequent YAML run does NOT delete it -- see [Deferred Stale-Key Behavior](#deferred-stale-key-behavior-user-facing-contract) for the intentional preservation contract.
 
 #### `company-announcements`
 
@@ -1146,16 +1192,18 @@ hooks:
 
 #### Hooks Routing
 
-Hooks are routed to different target files based on whether `command-names` is specified:
+Hooks are routed to different target files based on whether `command-names` is specified. Both paths share the same pure builder `_build_hooks_json()` for the `hooks` key universe:
 
-| Scenario                | Target File                    | Write Mechanism                              | Hook Files Directory     |
-|-------------------------|--------------------------------|----------------------------------------------|--------------------------|
-| `command-names` present | `~/.claude/{cmd}/config.json`  | `create_profile_config()` (atomic overwrite) | `~/.claude/{cmd}/hooks/` |
-| `command-names` absent  | `~/.claude/settings.json`      | `write_hooks_to_settings()` (key-replace)    | `~/.claude/hooks/`       |
+| Scenario                | Target File                    | Write Mechanism                                                  | Hook Files Directory     |
+|-------------------------|--------------------------------|------------------------------------------------------------------|--------------------------|
+| `command-names` present | `~/.claude/{cmd}/config.json`  | `create_profile_config()` (atomic overwrite)                     | `~/.claude/{cmd}/hooks/` |
+| `command-names` absent  | `~/.claude/settings.json`      | `write_profile_settings_to_settings()` (top-level replace)       | `~/.claude/hooks/`       |
 
-When `command-names` is absent, the setup writes hooks to the global `~/.claude/settings.json` using read-pop-replace-write semantics: the existing file is read, the `hooks` key is replaced entirely (removing stale events from prior runs), and all other keys are preserved. This avoids deep merge, which would retain stale hook event keys across re-runs.
+When `command-names` is absent, the setup writes hooks to the global `~/.claude/settings.json` via `write_profile_settings_to_settings()` as part of the 9-key `PROFILE_OWNED_KEYS` delta. The writer uses **conditional top-level replace** semantics: the existing file is read, the `hooks` top-level key is replaced entirely (removing stale events from prior runs), and all other keys -- including user-managed keys and other profile-owned keys not in the current delta -- are preserved. See [Profile-Level Settings Routing](#profile-level-settings-routing) for the full contract.
 
-**Re-run behavior:** The toolbox owns the `hooks` key in `settings.json`. Re-running the setup overwrites any manually-added hooks in `settings.json`. To configure hooks, define them in the YAML configuration rather than editing `settings.json` directly.
+**Re-run behavior:** The toolbox owns the `hooks` key in `settings.json`. Re-running the setup overwrites any manually-added hook events when the YAML re-declares `hooks` (top-level replace semantics). To configure hooks, define them in the YAML configuration rather than editing `settings.json` directly.
+
+**Deleting hooks:** Setting `hooks: null` at YAML root level deletes the entire `hooks` key from `~/.claude/settings.json` via RFC 7396 null-as-delete. OMITTING `hooks` from a subsequent YAML run does NOT delete it (per [Deferred Stale-Key Behavior](#deferred-stale-key-behavior-user-facing-contract)); the prior-run `hooks` content is preserved.
 
 The installation summary distinguishes between the two routing targets:
 
@@ -1512,14 +1560,14 @@ When `claude-code-version` specifies a pinned version (any value other than `"la
 
 #### Injection Targets
 
-| Target             | Key                       | Value   | Config Section                     |
-|--------------------|---------------------------|---------|------------------------------------|
-| `global-config`    | `autoUpdates`             | `false` | `~/.claude.json`                   |
-| `user-settings`    | `env.DISABLE_AUTOUPDATER` | `"1"`   | `settings.json`                    |
-| `env-variables`    | `DISABLE_AUTOUPDATER`     | `"1"`   | `config.json` (profile)            |
-| `os-env-variables` | `DISABLE_AUTOUPDATER`     | `"1"`   | Shell profiles / Windows registry  |
+| Target             | Key                       | Value   | On-disk file (isolated)                           | On-disk file (non-isolated)                         |
+|--------------------|---------------------------|---------|---------------------------------------------------|-----------------------------------------------------|
+| `global-config`    | `autoUpdates`             | `false` | `~/.claude/{cmd}/.claude.json` + `~/.claude.json` | `~/.claude.json`                                    |
+| `user-settings`    | `env.DISABLE_AUTOUPDATER` | `"1"`   | `~/.claude/{cmd}/settings.json`                   | `~/.claude/settings.json`                           |
+| `env-variables`    | `DISABLE_AUTOUPDATER`     | `"1"`   | `~/.claude/{cmd}/config.json` (`env` key)         | `~/.claude/settings.json` (`env` key, top-replace)  |
+| `os-env-variables` | `DISABLE_AUTOUPDATER`     | `"1"`   | Shell profiles / Windows registry                 | Shell profiles / Windows registry                   |
 
-All four targets are injected unconditionally regardless of whether `command-names` is present. The existing write routing infrastructure handles which files are actually created -- for example, `env-variables` only reaches `config.json` when `command-names` is specified, making injection into that dict a harmless no-op for non-isolated environments.
+All four targets are injected unconditionally regardless of whether `command-names` is present. In isolated mode (`command-names` present), `env-variables` reaches `~/.claude/{cmd}/config.json` via `create_profile_config()` (Step 18). In non-isolated mode (`command-names` absent), `env-variables` is routed directly to `~/.claude/settings.json['env']` via `write_profile_settings_to_settings()` (Step 18) using conditional top-level replace semantics. Both Target 2 (`user-settings.env.DISABLE_AUTOUPDATER`) and Target 3 (`env-variables.DISABLE_AUTOUPDATER`) therefore reach the same on-disk `settings.json['env']` container in non-isolated mode -- Target 2 via Step 14 `write_user_settings()` deep-merge, Target 3 via Step 18 top-level replace. When YAML has NO root-level `env-variables`, Step 18 omits `env` from its delta and the Target 2 Step 14 contribution SURVIVES Step 18's preservation invariant (see [Profile-Level Settings Routing](#profile-level-settings-routing)).
 
 #### Removal Behavior
 
@@ -1563,14 +1611,14 @@ This feature mirrors the [Automatic Auto-Update Management](#automatic-auto-upda
 
 #### Injection Targets
 
-| Target             | Key                                     | Value   | Config Section                    |
-|--------------------|-----------------------------------------|---------|-----------------------------------|
-| `global-config`    | `autoInstallIdeExtension`               | `false` | `~/.claude.json`                  |
-| `user-settings`    | `env.CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL` | `"1"`   | `settings.json`                   |
-| `env-variables`    | `CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL`     | `"1"`   | `config.json` (profile)           |
-| `os-env-variables` | `CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL`     | `"1"`   | Shell profiles / Windows registry |
+| Target             | Key                                     | Value   | On-disk file (isolated)                           | On-disk file (non-isolated)                         |
+|--------------------|-----------------------------------------|---------|---------------------------------------------------|-----------------------------------------------------|
+| `global-config`    | `autoInstallIdeExtension`               | `false` | `~/.claude/{cmd}/.claude.json` + `~/.claude.json` | `~/.claude.json`                                    |
+| `user-settings`    | `env.CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL` | `"1"`   | `~/.claude/{cmd}/settings.json`                   | `~/.claude/settings.json`                           |
+| `env-variables`    | `CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL`     | `"1"`   | `~/.claude/{cmd}/config.json` (`env` key)         | `~/.claude/settings.json` (`env` key, top-replace)  |
+| `os-env-variables` | `CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL`     | `"1"`   | Shell profiles / Windows registry                 | Shell profiles / Windows registry                   |
 
-All four targets are injected unconditionally regardless of whether `command-names` is present, consistent with auto-update management behavior.
+All four targets are injected unconditionally regardless of whether `command-names` is present, consistent with auto-update management behavior. In non-isolated mode, `env-variables` reaches `~/.claude/settings.json['env']` via conditional top-level replace (identical routing to auto-update Target 3).
 
 #### Removal Behavior
 
@@ -1677,13 +1725,180 @@ Here is a conceptual overview of what the setup script does when you run it with
 14. **Write user settings** -- Merges `user-settings` into `~/.claude/settings.json`.
 15. **Write global config** -- Merges `global-config` into `~/.claude.json`.
 16. **Cleanup stale controls** -- Sweeps all filesystem locations for stale auto-update and IDE extension artifacts from prior configurations.
-17. **Download hooks** -- Downloads hook script files to `~/.claude/{cmd}/hooks/` (with `command-names`) or `~/.claude/hooks/` (without).
-18. **Write hooks** -- With `command-names`: writes hooks to `config.json` via `create_profile_config()`. Without `command-names`: writes hooks to `~/.claude/settings.json` via `write_hooks_to_settings()`.
+17. **Download hooks** -- Downloads hook script files to `~/.claude/{cmd}/hooks/` (with `command-names`) or `~/.claude/hooks/` (without). In non-command-names mode, Step 17 runs when ANY of the following are declared: `hooks.events` non-empty, `hooks.files` non-empty, or `status-line.file` set.
+18. **Write profile settings** -- Writes all nine profile-owned keys (`model`, `permissions`, `env`, `attribution`, `alwaysThinkingEnabled`, `effortLevel`, `companyAnnouncements`, `statusLine`, `hooks`) as camelCase keys on disk. With `command-names`: writes to `~/.claude/{cmd}/config.json` via `create_profile_config()` (atomic overwrite -- fresh dict each run). Without `command-names`: writes to `~/.claude/settings.json` via `write_profile_settings_to_settings()` using **conditional top-level replace semantics** (preserves non-delta keys; see [Profile-Level Settings Routing](#profile-level-settings-routing)).
 19. **Write manifest** -- Creates an installation tracking manifest. (Only if `command-names` is specified.)
 20. **Create launcher** -- Creates the launcher script for the command. (Only if `command-names` is specified.)
 21. **Register commands** -- Creates global command wrappers. (Only if `command-names` is specified.)
 
-Steps 17-18 are skipped if no hooks are configured. Steps 19-21 are skipped if `command-names` is not specified.
+Step 17 is skipped if no hooks, hook files, or status-line file are configured. Step 18 is a no-op if the profile delta is empty (no profile-owned keys declared at YAML root level). Steps 19-21 are skipped if `command-names` is not specified.
+
+## Profile-Level Settings Routing
+
+The setup script supports two modes of profile-settings routing, controlled by the presence of `command-names:` in the YAML configuration. This section documents how the nine profile-owned keys land on disk in each mode and how they interact with `user-settings:`.
+
+### Profile-Owned Keys
+
+Nine YAML root-level keys are **profile-owned** -- they are written to disk by the profile-settings subsystem (`_build_profile_settings()` builder + one of two writers):
+
+| YAML root key (kebab-case)    | On-disk key (camelCase)   |
+|-------------------------------|---------------------------|
+| `model`                       | `model`                   |
+| `permissions`                 | `permissions`             |
+| `env-variables`               | `env`                     |
+| `attribution`                 | `attribution`             |
+| `always-thinking-enabled`     | `alwaysThinkingEnabled`   |
+| `effort-level`                | `effortLevel`             |
+| `company-announcements`       | `companyAnnouncements`    |
+| `status-line`                 | `statusLine`              |
+| `hooks`                       | `hooks`                   |
+
+The shared pure builder `_build_profile_settings()` performs kebab-to-camel translation and delegates to `_build_hooks_json()` for the `hooks` universe. The 9-key set is declared as `PROFILE_OWNED_KEYS` (a `frozenset`) in `scripts/setup_environment.py`. These keys are distinct from `USER_SETTINGS_EXCLUDED_KEYS = {'hooks', 'statusLine'}`, which is NOT extended to cover all 9 profile-owned keys -- `user-settings` remains a free-form pass-through for forward compatibility (see [Relationship to Profile-Owned Keys](#relationship-to-profile-owned-keys)).
+
+### Isolated Mode (command-names present)
+
+When `command-names` is specified, the setup creates an isolated directory `~/.claude/{cmd}/` containing:
+
+| File            | Priority (CLI)   | Content                                                 | Writer                    | Step | Semantics                                                                         |
+|-----------------|------------------|---------------------------------------------------------|---------------------------|------|-----------------------------------------------------------------------------------|
+| `settings.json` | 5 (userSettings) | YAML `user-settings:` (all non-excluded keys)           | `write_user_settings()`   | 14   | Deep merge + array-union (`permissions.allow/deny/ask`) + RFC 7396 null-as-delete |
+| `config.json`   | 2 (flagSettings) | 9 `PROFILE_OWNED_KEYS` from YAML root                   | `create_profile_config()` | 18   | Atomic overwrite (fresh dict each run)                                            |
+
+The launcher script passes `config.json` via the `--settings` flag and sets `CLAUDE_CONFIG_DIR` to the isolated directory. Claude Code CLI's native priority resolution (`flagSettings (2) > userSettings (5)`) ensures `config.json` wins over `settings.json` for overlapping keys at runtime. In isolated mode, stale-key accumulation is NOT a concern because `create_profile_config()` uses atomic overwrite: every run produces a fresh `config.json` containing only the currently-declared keys, so removing a key from YAML cleanly removes it from `config.json` on the next run.
+
+### Non-Isolated Mode (command-names absent)
+
+When `command-names` is ABSENT, the setup writes to the shared `~/.claude/` directory. BOTH Step 14 and Step 18 target the SAME file (`~/.claude/settings.json`) but with strict step ordering and distinct merge semantics:
+
+| File                       | Content                                            | Writer                                  | Step | Semantics                                              |
+|----------------------------|----------------------------------------------------|-----------------------------------------|------|--------------------------------------------------------|
+| `~/.claude/settings.json`  | YAML `user-settings:` (all non-excluded keys)      | `write_user_settings()`                 | 14   | Deep merge + array-union + RFC 7396 null-as-delete     |
+| `~/.claude/settings.json`  | 9 `PROFILE_OWNED_KEYS` delta from YAML root        | `write_profile_settings_to_settings()`  | 18   | Conditional top-level replace                          |
+
+1. **Step 14** deep-merges `user-settings:` into `settings.json`. Existing keys are preserved; merged keys are overridden by the new YAML values; `permissions.allow/deny/ask` arrays are unioned with deduplication; `null` values delete keys via RFC 7396.
+2. **Step 18** applies the profile delta: for each key in the builder delta, REPLACE the entire top-level key value (or DELETE if explicitly `None`). Keys NOT in the delta are PRESERVED.
+
+This preserves the Step 14 contributions (and any user-managed keys outside the YAML) and ensures the shared `settings.json` is never scrubbed of keys the current YAML does not declare.
+
+### Write Semantics Contract
+
+**Design principle:** `~/.claude/settings.json` is a SHARED/COMMON user-facing file, NOT an isolated profile. The toolbox must NOT scrub or delete existing keys merely because the YAML does not declare them. Unexpected deletion of settings the user did not intend to remove is explicitly prohibited.
+
+`write_profile_settings_to_settings()` implements three branches for each key in the profile delta:
+
+| Branch | YAML root state                         | Builder delta   | On-disk effect                                                          |
+|--------|-----------------------------------------|-----------------|-------------------------------------------------------------------------|
+| 1      | Key present with non-null value         | `{key: value}`  | **REPLACE** entire top-level value (no deep merge, no array-union)      |
+| 2      | Key present with explicit `null` value  | `{key: None}`   | **DELETE** key from file (RFC 7396 null-as-delete via `existing.pop()`) |
+| 3      | Key absent from YAML root               | `{}` (omitted)  | **PRESERVE** existing value unchanged                                   |
+
+The builder `_build_profile_settings()` OMITS `None` inputs from its returned dict by default -- this means that when you OMIT a key from YAML, it is not represented in the delta at all (branch 3, preserve). To trigger branch 2 (explicit delete), construct the delta directly in code or -- at the YAML level -- set the key to `null` (the merge/validation layers translate this to an explicit `None` passed to the writer for the profile-owned keys that support it).
+
+**Preservation coverage (what survives profile-settings writes):**
+
+Keys NOT present in the delta are preserved in `~/.claude/settings.json`. This covers:
+
+- Prior-run contributions from `write_profile_settings_to_settings()` itself.
+- Deep-merged contributions from Step 14 `write_user_settings()` (including `user-settings.permissions.allow/deny/ask` array-unions and any free-form `user-settings` keys).
+- User-managed keys outside the toolbox's YAML schema (e.g., `includeGitInstructions`, `apiKeyHelper`, `cleanupPeriodDays`, `outputStyle`, `autoMemoryDirectory`, `sandbox.*`).
+- Auto-injected `env.DISABLE_AUTOUPDATER` (auto-update Target 2) and `env.CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL` (IDE extension Target 2) controls written via `user-settings.env` when YAML has no root-level `env-variables`. In that case, Step 18's builder omits `env` entirely from the delta, and the Step 14 contributions SURVIVE.
+
+**Empty-delta no-op:** If no profile-owned keys are declared at YAML root level, the builder returns `{}` and `write_profile_settings_to_settings()` performs ZERO file I/O -- it neither creates nor touches `~/.claude/settings.json`. A YAML with only `user-settings:`, `global-config:`, `agents:`, etc. will never have Step 18 modify `settings.json`.
+
+**Malformed or non-dict existing content:** If `~/.claude/settings.json` contains invalid JSON, unreadable content, or a non-dict top-level value (e.g., a bare list), the writer emits a warning (`"Existing ... is not a dict, starting fresh"` or `"Invalid JSON in ..."`) and starts fresh (treats `existing` as `{}`). The written file ends with a trailing newline for file-format consistency with `write_hooks_to_settings()`.
+
+### Deferred Stale-Key Behavior (User-Facing Contract)
+
+This is an INTENTIONAL user-facing contract, not a bug. Understanding this behavior is critical to using `command-names`-absent mode correctly.
+
+**Scenario:** You had `permissions: {allow: [Read]}` at YAML root in a previous setup run. You then remove the entire `permissions` block from your YAML and re-run setup.
+
+**Result:** The `permissions` key in `~/.claude/settings.json` RETAINS its previous value (`{allow: [Read]}`). It is NOT deleted.
+
+**Why:** `~/.claude/settings.json` is a shared file. Removing a key from YAML is NOT a sufficient signal for the toolbox to delete that key from the shared file, because:
+
+1. The key might have been set by a previous toolbox run with a different YAML.
+2. The key might have been set manually by the user or by another tool.
+3. The key might have been set by a teammate's YAML that is managed separately.
+4. The profile-settings writer has no state-tracking sidecar to distinguish keys it wrote in prior runs from user-managed keys.
+
+**To remove a key, you have two explicit options:**
+
+1. **Set the key to `null` in YAML.** Examples:
+   ```yaml
+   permissions: null        # Delete entire permissions block from settings.json
+   model: null              # Delete model key
+   hooks: null              # Delete hooks block (but see note below)
+   env-variables: null      # Delete env block from settings.json
+   ```
+2. **Manually delete the key** from `~/.claude/settings.json` using a text editor.
+
+Automated YAML-removal-triggered cleanup (a state-tracking sidecar approach, e.g., `~/.claude/toolbox-managed-keys.json` recording which keys the toolbox wrote in the last run) is not implemented. The preservation behavior is the intended design.
+
+**Security implication for `permissions.deny`:** If you previously declared `permissions.deny: ['Bash(rm -rf)']` at YAML root and then remove `permissions:` from YAML, the deny rule REMAINS in `~/.claude/settings.json`. This is the INTENDED behavior: removing security rules from YAML should NOT silently remove them from the shared file. If you want to remove deny rules, you must either explicitly set `permissions: {deny: []}` or `permissions: null`, or edit the file manually.
+
+**Note on `hooks` deletion:** Because Step 18 performs top-level replace, setting `hooks: null` at YAML root deletes the entire `hooks` key. Removing individual hook entries requires re-declaring the full `hooks` block with the entries you want to keep.
+
+### Profile-Scoped MCP Servers in Non-Command-Names Mode (ERROR)
+
+Profile-scoped MCP servers (`scope: profile` or `scope: [user, profile]`) CANNOT work without `command-names` because the launcher script that consumes `--mcp-config` is only created in isolated mode. In non-isolated mode, profile-scoped servers would have no launcher target and would be silently dropped at runtime -- a correctness risk.
+
+The setup script enforces this with a hard validation error (exit 1) at the validation phase, BEFORE any side effects (downloads, writes) occur:
+
+```text
+[ERROR] MCP server 'my-server' declares scope: profile but command-names is not specified.
+[ERROR] Profile-scoped MCP servers require a launcher script with --mcp-config flag, which
+[ERROR] is only created when command-names is present in your YAML configuration.
+[ERROR]
+[ERROR] Fix one of:
+[ERROR]   1. Add "command-names: [your-name]" to enable isolated environment (preferred)
+[ERROR]   2. Change scope to "user" to install globally via ~/.claude.json
+[ERROR]   3. Change scope to "local" to install in project-specific .mcp.json
+[ERROR]   4. Change scope to "project" to install in shared project .mcp.json
+```
+
+The validation walks `config.get('mcp-servers', [])` and matches BOTH the string form (`scope: profile`) AND the list form (`scope: [user, profile]`) -- a combined `[user, profile]` scope without `command-names` also triggers the error because the `profile` portion of the list has no launcher target. Error output is written to `sys.stderr` (not stdout).
+
+### `command-defaults.system-prompt` in Non-Command-Names Mode (WARNING)
+
+System prompts are applied by the launcher via `--system-prompt` or `--append-system-prompt` CLI flags. Without `command-names`, there is no launcher, so the prompt file cannot be passed to Claude at runtime. The setup script emits a non-fatal WARNING (setup continues):
+
+```text
+[WARN] command-defaults.system-prompt is set to 'prompts/my-prompt.md' but command-names is not specified.
+[WARN] System prompts are applied by the launcher; without command-names there is no launcher,
+[WARN] so the system prompt will NOT be applied.
+[WARN] Add 'command-names: [your-name]' to enable isolated environment with launcher-based system prompt injection.
+```
+
+Unlike profile-scoped MCP servers (which are a hard error because silently-dropped servers are a correctness risk), a silently-unused system prompt file is merely a configuration mistake -- a warning is sufficient. Warning output is written to stdout.
+
+### Conflict Detection
+
+`detect_settings_conflicts()` runs UNCONDITIONALLY in BOTH modes (isolated and non-isolated). If you declare a profile-owned key under BOTH `user-settings:` AND at YAML root level, a warning is emitted during the validation phase:
+
+```text
+[WARN] Key 'model' specified in both root level and user-settings.
+[WARN]   user-settings value: claude-opus-4
+[WARN]   root-level value: claude-sonnet-4
+[WARN]   Root-level value takes precedence (written last in Step 18).
+```
+
+**Why root-level wins (in both modes):**
+
+- **Isolated mode:** Step 14 writes `user-settings:` to `~/.claude/{cmd}/settings.json` (priority 5), Step 18 writes the profile delta to `~/.claude/{cmd}/config.json` (priority 2). The CLI's native `flagSettings > userSettings` resolution means `config.json` wins at runtime.
+- **Non-isolated mode:** Step 14 writes `user-settings:` to `~/.claude/settings.json` via deep-merge, Step 18 writes the profile delta to the SAME file via top-level replace. Step 18 writes last, so its REPLACE overwrites the Step 14 merge result for the overlapping profile-owned key.
+
+The conflict warning ensures users are informed regardless of which mode they use.
+
+### Three-Writer Architectural Model Summary
+
+| Writer                                 | YAML Source                  | Target                                                       | Key Universe                              | Semantics                                                                          | Step                |
+|----------------------------------------|------------------------------|--------------------------------------------------------------|-------------------------------------------|------------------------------------------------------------------------------------|---------------------|
+| `write_user_settings()`                | `user-settings:`             | `~/.claude/settings.json` OR `~/.claude/{cmd}/settings.json` | ~58 non-excluded CLI keys                 | Deep merge + array-union (`permissions.allow/deny/ask`) + RFC 7396 null-as-delete  | 14                  |
+| `create_profile_config()`              | YAML root profile keys       | `~/.claude/{cmd}/config.json`                                | 9 `PROFILE_OWNED_KEYS`                    | Atomic overwrite (fresh dict each run)                                             | 18 (isolated)       |
+| `write_profile_settings_to_settings()` | YAML root profile keys       | `~/.claude/settings.json`                                    | 9 `PROFILE_OWNED_KEYS` delta              | Conditional top-level replace                                                      | 18 (non-isolated)   |
+
+Both Step 18 writers are fed by the shared pure builder `_build_profile_settings()`, which translates kebab-case YAML keys to camelCase JSON keys and delegates to `_build_hooks_json()` for hook events. `create_profile_config()` is a thin wrapper that delegates to the pure builder and atomically writes `config.json`; its output dict is identical to what the builder returns for the same inputs.
 
 ## Complete Annotated Example
 

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -198,6 +198,33 @@ ROOT_TO_USER_SETTINGS_KEY_MAP: dict[str, str] = {
     'effort-level': 'effortLevel',              # Adaptive reasoning effort
 }
 
+# Keys that are owned and written by the profile-settings subsystem.
+# These keys are extracted from YAML root level and routed via
+# create_profile_config() (isolated mode -> config.json) or
+# write_profile_settings_to_settings() (non-isolated mode -> settings.json).
+#
+# Both writers are fed by the shared pure builder _build_profile_settings(),
+# which performs kebab-to-camel translation. Values below are the POST-TRANSLATION
+# camelCase keys as they appear in settings.json / config.json on disk.
+#
+# In non-isolated mode, write_profile_settings_to_settings() performs a
+# conditional top-level replace for only the keys present in the builder
+# delta. Keys not declared at YAML root level are PRESERVED in
+# ~/.claude/settings.json (unchanged by this writer), including any
+# prior-run contributions and any keys written by Step 14
+# write_user_settings() under user-settings:.
+PROFILE_OWNED_KEYS: frozenset[str] = frozenset({
+    'model',
+    'permissions',
+    'env',
+    'attribution',
+    'alwaysThinkingEnabled',
+    'effortLevel',
+    'companyAnnouncements',
+    'statusLine',
+    'hooks',
+})
+
 
 # Platform-specific imports with proper type checking support
 if sys.platform == 'win32':
@@ -8391,9 +8418,97 @@ def write_hooks_to_settings(
         return False
 
 
-def create_profile_config(
+def write_profile_settings_to_settings(
+    settings_delta: dict[str, Any],
+    settings_dir: Path,
+) -> bool:
+    """Write profile-owned settings delta to ~/.claude/settings.json.
+
+    Applies a conditional top-level replace to the shared settings.json
+    file used by the non-command-names mode:
+
+    - READS existing settings.json (or starts from empty dict if missing).
+    - For each top-level key in settings_delta:
+        - If value is None: DELETE the key from the existing dict
+          (RFC 7396 null-as-delete semantics).
+        - Otherwise: REPLACE the entire top-level key value with the delta
+          value (no deep-merge, no array-union at this level).
+    - Keys NOT present in settings_delta are PRESERVED unchanged. This is
+      the core preservation guarantee: when YAML omits a profile-owned
+      key, the corresponding key in ~/.claude/settings.json is left
+      alone. The shared settings.json is a user-facing file that may
+      contain manually-edited entries or contributions from other tools;
+      this writer must not delete keys it was not asked to touch.
+
+    The delta is expected to be the output of _build_profile_settings(),
+    which contains only the keys explicitly declared at YAML root level
+    (PROFILE_OWNED_KEYS subset).
+
+    IMPORTANT: This function is called ONLY in non-command-names mode. In
+    command-names mode, profile settings are routed to config.json via
+    create_profile_config() with atomic overwrite semantics.
+
+    Args:
+        settings_delta: Dict of profile-owned keys to write (output of
+            _build_profile_settings()). May be empty, in which case no
+            file I/O occurs and the function returns True.
+        settings_dir: Directory containing settings.json (typically
+            ~/.claude/).
+
+    Returns:
+        True if the file was written successfully or no-op (empty delta),
+        False on read or write failure.
+    """
+    if not settings_delta:
+        info('No profile settings to write to settings.json')
+        return True
+
+    settings_file = settings_dir / 'settings.json'
+    info('Writing profile settings to settings.json...')
+
+    # Read existing settings.json (or empty dict if missing / malformed)
+    existing: dict[str, Any] = {}
+    if settings_file.exists():
+        try:
+            file_content = settings_file.read_text(encoding='utf-8')
+            if file_content.strip():
+                parsed = json.loads(file_content)
+                if isinstance(parsed, dict):
+                    existing = parsed
+                else:
+                    warning(f'Existing {settings_file} is not a dict, starting fresh')
+        except json.JSONDecodeError as e:
+            warning(f'Invalid JSON in {settings_file}: {e}, starting fresh')
+        except OSError as e:
+            warning(f'Failed to read {settings_file}: {e}, starting fresh')
+
+    # Conditional top-level replace: only keys in the delta are touched.
+    # Keys not in the delta are PRESERVED unchanged (Step 14 contributions,
+    # user-managed settings, and prior-run profile keys not re-declared all
+    # remain intact). None values delete keys (RFC 7396 null-as-delete).
+    for key, value in settings_delta.items():
+        if value is None:
+            existing.pop(key, None)
+        else:
+            existing[key] = value
+
+    # Write back
+    try:
+        settings_dir.mkdir(parents=True, exist_ok=True)
+        settings_file.write_text(
+            json.dumps(existing, indent=2, ensure_ascii=False) + '\n',
+            encoding='utf-8',
+        )
+        success(f'Wrote profile settings to {settings_file}')
+        return True
+    except OSError as e:
+        warning(f'Failed to write profile settings to {settings_file}: {e}')
+        return False
+
+
+def _build_profile_settings(
     hooks: dict[str, Any],
-    config_base_dir: Path,
+    hooks_dir: Path,
     model: str | None = None,
     permissions: dict[str, Any] | None = None,
     env: dict[str, str] | None = None,
@@ -8402,43 +8517,56 @@ def create_profile_config(
     attribution: dict[str, str] | None = None,
     status_line: dict[str, Any] | None = None,
     effort_level: str | None = None,
-    hooks_base_dir: Path | None = None,
-) -> bool:
-    """Create config.json (profile configuration) for the isolated environment.
+) -> dict[str, Any]:
+    """Build profile settings dict from YAML inputs (pure, zero I/O).
 
-    This file is always overwritten to avoid duplicate hooks when re-running the installer.
-    It's loaded via --settings flag when launching Claude.
+    Produces a dict containing ONLY the keys that were explicitly configured
+    (None inputs are omitted). Values correspond to the 9 PROFILE_OWNED_KEYS
+    in their camelCase form as they appear in settings.json / config.json.
+
+    Performs kebab-to-camel translation for nested permissions keys
+    ('default-mode' -> 'defaultMode', 'additional-directories' ->
+    'additionalDirectories'), builds the statusLine command string with
+    absolute POSIX paths under hooks_dir, and delegates to _build_hooks_json()
+    for the hooks key universe.
 
     Args:
-        hooks: Hooks configuration dictionary with 'files' and 'events' keys
-        config_base_dir: Path to the isolated environment directory (e.g., ~/.claude/{cmd}/)
-        model: Optional model alias or custom model name
-        permissions: Optional permissions configuration dict
-        env: Optional environment variables dict
-        always_thinking_enabled: Optional flag to enable always-on thinking mode
-        company_announcements: Optional list of company announcement strings
-        attribution: Optional dict with 'commit' and 'pr' keys for custom attribution strings.
-            Empty strings hide attribution.
-        status_line: Optional dict with 'file' key for status line script path, optional
-            'padding' key, and optional 'config' key for config file reference.
-            Both the script and config file are downloaded to the hooks directory and
-            the config path is appended as a command line argument.
+        hooks: Hooks configuration dictionary with 'files' and 'events' keys.
+        hooks_dir: Absolute directory path where downloaded hook files reside.
+            For isolated mode: ~/.claude/{cmd}/hooks/.
+            For non-isolated mode: ~/.claude/hooks/.
+        model: Optional model alias or custom model name.
+        permissions: Optional permissions configuration dict (kebab-case nested
+            keys are translated to camelCase).
+        env: Optional environment variables dict (keys as-is, values stringified).
+        always_thinking_enabled: Optional flag to enable always-on thinking mode.
+        company_announcements: Optional list of company announcement strings.
+        attribution: Optional dict with 'commit' and 'pr' keys for custom
+            attribution strings. Empty strings hide attribution.
+        status_line: Optional dict with 'file', optional 'config', and optional
+            'padding' keys. 'file' references a script previously downloaded to
+            hooks_dir; its absolute POSIX path is embedded in the generated
+            command string.
         effort_level: Optional effort level for adaptive reasoning.
-            Valid values: 'low', 'medium', 'high', 'max'. The 'max' level is
-            only available for Opus models.
-        hooks_base_dir: Optional base directory for hook files.
-            When provided, hook file paths are resolved relative to this directory
-            instead of config_base_dir / 'hooks'.
+            Valid values: 'low', 'medium', 'high', 'max'.
 
     Returns:
-        bool: True if successful, False otherwise.
+        Dict containing only explicitly-configured PROFILE_OWNED_KEYS, with
+        camelCase keys and all values ready to be serialized to JSON.
+
+    Examples:
+        >>> _build_profile_settings({}, Path('/tmp/hooks'), model='sonnet')
+        {'model': 'sonnet'}
+
+        >>> _build_profile_settings(
+        ...     {}, Path('/tmp/hooks'),
+        ...     permissions={'default-mode': 'ask', 'allow': ['Read']},
+        ... )
+        {'permissions': {'defaultMode': 'ask', 'allow': ['Read']}}
+
+        >>> _build_profile_settings({}, Path('/tmp/hooks'))
+        {}
     """
-    # Determine hooks directory: use hooks_base_dir if provided, else default
-    hooks_dir = hooks_base_dir if hooks_base_dir is not None else config_base_dir / 'hooks'
-
-    info('Creating config.json...')
-
-    # Create fresh settings structure for this environment
     settings: dict[str, Any] = {}
 
     # Add model if specified
@@ -8446,13 +8574,10 @@ def create_profile_config(
         settings['model'] = model
         info(f'Setting model: {model}')
 
-    # Handle permissions from configuration
-    final_permissions = {}
-
-    # Use permissions from env config if provided
+    # Handle permissions from configuration with kebab-to-camel translation
+    final_permissions: dict[str, Any] = {}
     if permissions:
         final_permissions = permissions.copy()
-        # Translate kebab-case YAML keys to camelCase JSON keys
         if 'default-mode' in final_permissions:
             final_permissions['defaultMode'] = final_permissions.pop('default-mode')
         if 'additional-directories' in final_permissions:
@@ -8549,7 +8674,71 @@ def create_profile_config(
         if hooks_json:
             settings['hooks'] = hooks_json
 
-    # Save settings (always overwrite)
+    return settings
+
+
+def create_profile_config(
+    hooks: dict[str, Any],
+    config_base_dir: Path,
+    model: str | None = None,
+    permissions: dict[str, Any] | None = None,
+    env: dict[str, str] | None = None,
+    always_thinking_enabled: bool | None = None,
+    company_announcements: list[str] | None = None,
+    attribution: dict[str, str] | None = None,
+    status_line: dict[str, Any] | None = None,
+    effort_level: str | None = None,
+    hooks_base_dir: Path | None = None,
+) -> bool:
+    """Create config.json (profile configuration) for the isolated environment.
+
+    Delegates to the pure builder _build_profile_settings() and atomically
+    writes the result to ~/.claude/{cmd}/config.json. This file is always
+    overwritten on re-run, so YAML removals of keys cleanly propagate to the
+    isolated profile (isolated-mode atomic rebuild semantics).
+
+    Args:
+        hooks: Hooks configuration dictionary with 'files' and 'events' keys.
+        config_base_dir: Path to the isolated environment directory
+            (e.g., ~/.claude/{cmd}/).
+        model: Optional model alias or custom model name.
+        permissions: Optional permissions configuration dict.
+        env: Optional environment variables dict.
+        always_thinking_enabled: Optional flag to enable always-on thinking mode.
+        company_announcements: Optional list of company announcement strings.
+        attribution: Optional dict with 'commit' and 'pr' keys for custom
+            attribution strings. Empty strings hide attribution.
+        status_line: Optional dict with 'file'/'config'/'padding' keys.
+        effort_level: Optional effort level for adaptive reasoning.
+            Valid values: 'low', 'medium', 'high', 'max'. The 'max' level is
+            only available for Opus models.
+        hooks_base_dir: Optional base directory for hook files.
+            When provided, hook file paths are resolved relative to this directory
+            instead of config_base_dir / 'hooks'.
+
+    Returns:
+        bool: True if successful, False otherwise.
+    """
+    # Determine hooks directory: use hooks_base_dir if provided, else default
+    hooks_dir = hooks_base_dir if hooks_base_dir is not None else config_base_dir / 'hooks'
+
+    info('Creating config.json...')
+
+    # Build the profile settings dict via the shared pure builder
+    settings = _build_profile_settings(
+        hooks=hooks,
+        hooks_dir=hooks_dir,
+        model=model,
+        permissions=permissions,
+        env=env,
+        always_thinking_enabled=always_thinking_enabled,
+        company_announcements=company_announcements,
+        attribution=attribution,
+        status_line=status_line,
+        effort_level=effort_level,
+    )
+
+    # Save settings (always overwrite) - atomic rebuild semantics
     settings_path = config_base_dir / 'config.json'
     try:
         config_base_dir.mkdir(parents=True, exist_ok=True)
@@ -9766,14 +9955,59 @@ def main() -> None:
                     error(err)
                 sys.exit(1)
 
-        # Detect conflicts between user-settings and root-level settings
-        if user_settings and primary_command_name:
+        # Detect conflicts between user-settings and root-level settings.
+        # Warnings fire in BOTH modes (isolated and non-isolated). In non-
+        # isolated mode, write_profile_settings_to_settings() also applies
+        # root-level precedence for profile-owned keys via Step 14 / Step 18
+        # ordering, so the conflict is meaningful in both branches.
+        if user_settings:
             conflicts = detect_settings_conflicts(user_settings, config)
             for user_key, user_value, root_value in conflicts:
                 warning(f"Key '{user_key}' specified in both root level and user-settings.")
                 warning(f'  user-settings value: {user_value}')
                 warning(f'  root-level value: {root_value}')
-                warning('  When using profile command, root-level value takes precedence.')
+                warning('  Root-level value takes precedence (written last in Step 18).')
+
+        # Validate: profile-scoped MCP servers require command-names (launcher)
+        # In non-command-names mode, profile-scoped servers have no launcher
+        # to consume --mcp-config, so they would be silently dropped. This is
+        # a hard error with 4-option actionable fix-up message.
+        if not primary_command_name:
+            mcp_servers_raw_for_validation = config.get('mcp-servers', [])
+            if isinstance(mcp_servers_raw_for_validation, list):
+                profile_mcp_names: list[str] = []
+                for server in mcp_servers_raw_for_validation:
+                    if not isinstance(server, dict):
+                        continue
+                    scope_raw = server.get('scope')
+                    # scope may be str or list[str]; check for 'profile' membership
+                    if isinstance(scope_raw, str):
+                        scopes_set = {scope_raw}
+                    elif isinstance(scope_raw, list):
+                        scopes_set = {s for s in scope_raw if isinstance(s, str)}
+                    else:
+                        scopes_set = set()
+                    if 'profile' in scopes_set:
+                        server_name = server.get('name', '<unnamed>')
+                        profile_mcp_names.append(str(server_name))
+                if profile_mcp_names:
+                    for server_name_out in profile_mcp_names:
+                        error(
+                            f"MCP server '{server_name_out}' declares scope: profile "
+                            f'but command-names is not specified.',
+                        )
+                    error(
+                        'Profile-scoped MCP servers require a launcher script '
+                        'with --mcp-config flag, which is only created when '
+                        'command-names is present in your YAML configuration.',
+                    )
+                    error('')
+                    error('Fix one of:')
+                    error('  1. Add "command-names: [your-name]" to enable isolated environment (preferred)')
+                    error('  2. Change scope to "user" to install globally via ~/.claude.json')
+                    error('  3. Change scope to "local" to install in project-specific .mcp.json')
+                    error('  4. Change scope to "project" to install in shared project .mcp.json')
+                    sys.exit(1)
 
         header(environment_name)
 
@@ -10166,25 +10400,81 @@ def main() -> None:
             else:
                 warning('Launcher script was not created')
         else:
-            # No command-names: check if hooks need to be written to settings.json
+            # No command-names: route all profile-owned YAML keys to the
+            # shared ~/.claude/settings.json via conditional top-level
+            # replace. This achieves full feature parity for model,
+            # permissions, env, attribution, alwaysThinkingEnabled,
+            # effortLevel, companyAnnouncements, statusLine, and hooks
+            # between command-names present/absent modes.
             hooks = config.get('hooks', {})
-            has_hook_events = bool(hooks and hooks.get('events'))
 
-            if has_hook_events:
-                # Step 17: Download hooks to ~/.claude/hooks/
+            # Warn about command-defaults.system-prompt without command-names.
+            # System prompts are applied by the launcher via --system-prompt /
+            # --append-system-prompt CLI flags; without command-names there is
+            # no launcher to consume the prompt file, so it would be silently
+            # unused at runtime.
+            if system_prompt:
+                warning(
+                    f"command-defaults.system-prompt is set to '{system_prompt}' "
+                    f'but command-names is not specified.',
+                )
+                warning(
+                    'System prompts are applied by the launcher; without command-names '
+                    'there is no launcher, so the system prompt will NOT be applied.',
+                )
+                warning(
+                    "Add 'command-names: [your-name]' to enable isolated environment "
+                    'with launcher-based system prompt injection.',
+                )
+
+            # Step 17: Download hooks (and status-line file + config) to
+            # ~/.claude/hooks/. The status-line file and its config must be
+            # listed in hooks.files per the EnvironmentConfig schema Rule 3,
+            # so download_hook_files() handles both automatically.
+            has_hook_events = bool(hooks and hooks.get('events'))
+            has_status_line_file = bool(
+                status_line
+                and isinstance(status_line, dict)
+                and status_line.get('file'),
+            )
+            hook_files_list = hooks.get('files') if isinstance(hooks, dict) else None
+            has_hook_files = bool(hook_files_list)
+
+            if has_hook_events or has_status_line_file or has_hook_files:
                 print()
                 print(f'{Colors.CYAN}Step 17: Downloading hooks...{Colors.NC}')
                 if not download_hook_files(hooks, claude_user_dir, config_source, base_url, args.auth,
                                            auth_cache=auth_cache):
                     download_failures.append('hook files')
-
-                # Step 18: Write hooks to settings.json
-                print()
-                print(f'{Colors.CYAN}Step 18: Writing hooks to settings.json...{Colors.NC}')
-                write_hooks_to_settings(hooks, hooks_dir, claude_user_dir)
             else:
                 print()
-                print(f'{Colors.CYAN}Steps 17-18: Skipping hooks (none configured)...{Colors.NC}')
+                print(f'{Colors.CYAN}Step 17: Skipping hooks download (none configured)...{Colors.NC}')
+
+            # Step 18: Write profile settings delta to the shared
+            # settings.json via conditional top-level replace.
+            print()
+            print(f'{Colors.CYAN}Step 18: Writing profile settings to settings.json...{Colors.NC}')
+
+            # Cast status_line for type safety (same pattern as isolated branch)
+            status_line_arg_else: dict[str, Any] | None = None
+            if status_line is not None and isinstance(status_line, dict):
+                status_line_arg_else = cast(dict[str, Any], status_line)
+
+            # Build the profile settings delta (pure, no I/O)
+            settings_delta = _build_profile_settings(
+                hooks=hooks,
+                hooks_dir=hooks_dir,
+                model=model,
+                permissions=permissions,
+                env=env_variables,
+                always_thinking_enabled=always_thinking_enabled,
+                company_announcements=company_announcements,
+                attribution=attribution,
+                status_line=status_line_arg_else,
+                effort_level=effort_level,
+            )
+
+            write_profile_settings_to_settings(settings_delta, claude_user_dir)
 
             # Steps 19-21: Skip command creation
             print()

--- a/tests/e2e/golden_config_no_command_names.yaml
+++ b/tests/e2e/golden_config_no_command_names.yaml
@@ -1,0 +1,237 @@
+# E2E Test Environment - No Command-Names Variant
+# Mirrors golden_config.yaml but with command-names REMOVED.
+# Used by tests/e2e/test_profile_settings_routing.py to verify the
+# profile-settings routing when command-names is absent (non-isolated
+# mode that writes profile-owned keys to the shared settings.json).
+#
+# Differences from golden_config.yaml:
+# 1. command-names section REMOVED
+# 2. Profile-scoped MCP servers changed to valid non-profile scopes
+#    (profile scope without command-names triggers validation error, so
+#    we use 'user' scope here for the happy-path coverage).
+# 3. All other keys (hooks, permissions, model, env-variables, attribution,
+#    always-thinking-enabled, company-announcements, status-line, effort-level,
+#    user-settings, global-config) are identical.
+
+name: "E2E Test Environment (No Command-Names)"
+
+# Configuration version for update checking
+version: "1.0.0"
+
+# Description shown in installation summary
+description: |
+  A comprehensive test environment for validating profile-settings parity
+  between command-names present and command-names absent modes.
+
+# Notes displayed after successful installation
+post-install-notes: |
+  E2E non-command-names mode post-install notes.
+
+# NO command-names declared (intentional)
+
+# Base URL for resources (uses local mock_repo for testing)
+base-url: "file://./tests/e2e/fixtures/mock_repo"
+
+# Claude Code version
+claude-code-version: "latest"
+
+# Node.js installation flag
+install-nodejs: false
+
+# Platform-specific dependencies
+dependencies:
+  common:
+    - "echo 'common-dependency-installed'"
+  windows:
+    - "echo 'windows-dependency-installed'"
+  linux:
+    - "echo 'linux-dependency-installed'"
+  macos:
+    - "echo 'macos-dependency-installed'"
+
+# Agent markdown files
+agents:
+  - "agents/e2e-test-agent.md"
+
+# Slash command files
+slash-commands:
+  - "commands/e2e-test-command.md"
+
+# Rule markdown files
+rules:
+  - "rules/e2e-test-rule.md"
+
+# Skills configuration
+skills:
+  - name: "e2e-test-skill"
+    base: "skills/"
+    files:
+      - "SKILL.md"
+      - "e2e-test-skill.md"
+
+# Additional files to download
+files-to-download:
+  - source: "configs/e2e-extra-file.txt"
+    dest: "~/.claude/e2e-extra-file.txt"
+
+# Hooks configuration (identical to golden_config.yaml, plus status-line files)
+hooks:
+  files:
+    - "hooks/e2e_test_hook.py"
+    - "configs/e2e-hook-config.yaml"
+    - "hooks/e2e_test_hook.js"
+    - "hooks/e2e_test_hook_esm.mjs"
+    - "hooks/e2e_test_hook_cjs.cjs"
+    - "configs/e2e-js-hook-config.json"
+    # status-line.file and status-line.config must also appear in hooks.files
+    # (per EnvironmentConfig schema Rule 3)
+    - "hooks/e2e_statusline.py"
+    - "configs/e2e-statusline-config.yaml"
+  events:
+    - event: "PostToolUse"
+      matcher: "Edit|MultiEdit|Write"
+      type: "command"
+      command: "e2e_test_hook.py"
+      config: "e2e-hook-config.yaml"
+    - event: "PostToolUse"
+      matcher: "Read"
+      type: "command"
+      command: "e2e_test_hook.js"
+    - event: "PreToolUse"
+      matcher: "Glob"
+      type: "command"
+      command: "e2e_test_hook_esm.mjs"
+      config: "e2e-js-hook-config.json"
+    - event: "PreToolUse"
+      matcher: "Grep"
+      type: "command"
+      command: "e2e_test_hook_cjs.cjs"
+    - event: "PreToolUse"
+      matcher: "Bash"
+      type: "prompt"
+      prompt: "Consider security implications before executing bash commands"
+      timeout: 30
+    - event: "PostToolUse"
+      matcher: "Write"
+      type: "http"
+      url: "http://localhost:8080/hooks/post-tool-use"
+      headers:
+        Authorization: "Bearer $MY_TOKEN"
+        Content-Type: "application/json"
+      allowed-env-vars:
+        - "MY_TOKEN"
+      timeout: 15
+      status-message: "Sending webhook notification..."
+    - event: "PreToolUse"
+      matcher: "Bash(rm *)"
+      type: "agent"
+      prompt: "Verify security implications of: $ARGUMENTS"
+      model: "sonnet"
+      timeout: 60
+      if: "Bash(rm *)"
+      once: true
+    - event: "Notification"
+      matcher: ""
+      type: "command"
+      command: "e2e_test_hook.py"
+      async: true
+      shell: "bash"
+      status-message: "Running notification handler..."
+
+# MCP Servers - NO profile scopes (those require command-names)
+mcp-servers:
+  - name: "e2e-http-server"
+    scope: "user"
+    transport: "http"
+    url: "http://localhost:3000/api"
+    header: "X-API-Key: test-key"
+    env: "E2E_HTTP_TOKEN"
+  - name: "e2e-sse-server"
+    scope: "project"
+    transport: "sse"
+    url: "http://localhost:3001/events"
+  - name: "e2e-npx-server"
+    scope: "local"
+    command: "npx @modelcontextprotocol/server-memory"
+    env:
+      - "E2E_NPX_DEBUG=1"
+
+# Model configuration
+model: "sonnet"
+
+# Permissions configuration
+permissions:
+  default-mode: "default"
+  additional-directories:
+    - "/tmp/e2e-test-dir"
+  allow:
+    - "mcp__e2e-http-server"
+    - "mcp__e2e-sse-server"
+    - "mcp__e2e-npx-server"
+    - "Read"
+    - "Glob"
+    - "Grep"
+  deny:
+    - "Bash(rm -rf)"
+  ask:
+    - "Edit"
+    - "Write"
+
+# Environment variables for Claude
+env-variables:
+  E2E_TEST_VAR: "test_value"
+  E2E_ANOTHER_VAR: "another_value"
+  E2E_PATH_VAR: "~/.claude/e2e-data"
+  E2E_INT_VAR: 42
+
+# OS-level environment variables
+os-env-variables:
+  E2E_OS_VAR: "os_test_value"
+  E2E_OS_PATH: "/opt/e2e/bin"
+  E2E_OS_DELETE_VAR: null
+  E2E_OS_DELETE_TOKEN: null
+  E2E_OS_INT_VAR: 30000
+  E2E_OS_BOOL_VAR: true
+
+# Command defaults - system-prompt in non-command-names mode emits a WARNING
+command-defaults:
+  system-prompt: "prompts/e2e-test-prompt.md"
+  mode: "replace"
+
+# user-settings retains free-form non-profile keys for forward-compat
+user-settings:
+  language: "english"
+  theme: "dark"
+  apiKeyHelper: "uv run --no-project --python 3.12 ~/.claude/scripts/api-key-helper.py"
+  staleSettingToDelete: null
+
+# Global config (merged into ~/.claude.json)
+global-config:
+  autoConnectIde: true
+  editorMode: "vim"
+  showTurnDuration: true
+  terminalProgressBarEnabled: false
+  oauthAccount: null
+  staleConfigToDelete: null
+
+# Always-thinking mode
+always-thinking-enabled: true
+
+# Effort level for adaptive reasoning
+effort-level: "low"
+
+# Company announcements
+company-announcements:
+  - "Welcome to E2E Testing Environment"
+  - "This is a test announcement for validation"
+
+# Attribution settings
+attribution:
+  commit: "E2E Test Attribution for Commits"
+  pr: "E2E Test Attribution for Pull Requests"
+
+# Status line configuration
+status-line:
+  file: "hooks/e2e_statusline.py"
+  config: "configs/e2e-statusline-config.yaml"
+  padding: 0

--- a/tests/e2e/test_full_setup.py
+++ b/tests/e2e/test_full_setup.py
@@ -137,18 +137,22 @@ class TestE2EFullSetup:
 
         assert not errors, 'Expected files not created:\n' + '\n'.join(errors)
 
-    def test_setup_processes_all_config_keys(
+    def test_create_profile_config_processes_all_keys(
         self,
         e2e_isolated_home: dict[str, Path],
         golden_config: dict[str, Any],
     ) -> None:
-        """Verify ALL config keys from golden_config are processed.
+        """Verify create_profile_config() writes ALL profile-owned keys to config.json.
 
-        This test validates that:
-        - model, permissions, env-variables are in settings.json
-        - mcp-servers are in {cmd}-mcp.json
-        - hooks events are configured
-        - always-thinking-enabled, company-announcements, attribution, status-line are present
+        This test validates the isolated-mode writer:
+        - model, permissions, env, attribution, alwaysThinkingEnabled, effortLevel,
+          companyAnnouncements, statusLine, hooks are all present in config.json
+          (the file written by create_profile_config() when command-names is set).
+
+        NOTE: This test covers ONLY the isolated mode writer. For the non-
+        command-names mode, where write_profile_settings_to_settings()
+        writes the same profile-owned keys into the shared settings.json,
+        see tests/e2e/test_profile_settings_routing.py.
         """
         paths = e2e_isolated_home
         claude_dir = paths['claude_dir']

--- a/tests/e2e/test_hooks_settings_routing.py
+++ b/tests/e2e/test_hooks_settings_routing.py
@@ -498,7 +498,7 @@ class TestSummaryOutputRouting:
         with patch('sys.argv', ['setup_environment.py', 'test', '--yes', '--skip-install']), \
              patch('sys.exit') as mock_exit, \
              patch.object(setup_environment, 'download_hook_files', return_value=True), \
-             patch.object(setup_environment, 'write_hooks_to_settings', return_value=True):
+             patch.object(setup_environment, 'write_profile_settings_to_settings', return_value=True):
             setup_environment.main()
             mock_exit.assert_not_called()
 
@@ -627,13 +627,15 @@ class TestHooksSettingsRoutingStepOutput:
         with patch('sys.argv', ['setup_environment.py', 'test', '--yes', '--skip-install']), \
              patch('sys.exit') as mock_exit, \
              patch.object(setup_environment, 'download_hook_files', return_value=True), \
-             patch.object(setup_environment, 'write_hooks_to_settings', return_value=True):
+             patch.object(setup_environment, 'write_profile_settings_to_settings', return_value=True):
             setup_environment.main()
             mock_exit.assert_not_called()
 
         captured = capsys.readouterr()
         assert 'Step 17: Downloading hooks' in captured.out
-        assert 'Step 18: Writing hooks to settings.json' in captured.out
+        # Step 18 writes the full profile-owned delta (not just hooks) to
+        # the shared settings.json in non-command-names mode.
+        assert 'Step 18: Writing profile settings to settings.json' in captured.out
         assert 'Steps 19-21: Skipping command creation' in captured.out
 
     @patch('scripts.setup_environment.load_config_from_source')
@@ -678,12 +680,17 @@ class TestHooksSettingsRoutingStepOutput:
         from scripts import setup_environment
 
         with patch('sys.argv', ['setup_environment.py', 'test', '--yes', '--skip-install']), \
-             patch('sys.exit') as mock_exit:
+             patch('sys.exit') as mock_exit, \
+             patch.object(setup_environment, 'write_profile_settings_to_settings', return_value=True):
             setup_environment.main()
             mock_exit.assert_not_called()
 
         captured = capsys.readouterr()
-        assert 'Steps 17-18: Skipping hooks (none configured)' in captured.out
+        # In non-command-names mode, Step 17 skips the download when no
+        # hooks are configured, and Step 18 still runs (the empty profile
+        # delta makes the writer a no-op).
+        assert 'Step 17: Skipping hooks download (none configured)' in captured.out
+        assert 'Step 18: Writing profile settings to settings.json' in captured.out
         assert 'Steps 19-21: Skipping command creation' in captured.out
 
 

--- a/tests/e2e/test_profile_settings_routing.py
+++ b/tests/e2e/test_profile_settings_routing.py
@@ -1,0 +1,926 @@
+"""E2E tests for profile-settings routing in non-command-names mode.
+
+Verifies that when `command-names` is absent, all profile-owned keys
+(model, permissions, env, attribution, alwaysThinkingEnabled, effortLevel,
+companyAnnouncements, statusLine, hooks) are correctly routed to
+~/.claude/settings.json via write_profile_settings_to_settings(), which
+applies a conditional top-level replace: keys present in the delta are
+overwritten (or deleted when set to None), and keys not present in the
+delta are preserved unchanged.
+
+Test coverage matrix:
+- Happy path: all 9 profile-owned keys routed correctly
+- Partial config: only subset of keys declared, rest omitted
+- Preservation: pre-existing settings.json keys survive
+- Step 14/18 interaction: user-settings contributions preserved
+- Conflict detection: warnings fire in non-command-names mode
+- Re-invocation across configurations: a second invocation updates values
+  written by the first invocation when keys are re-declared
+- Stale-key preservation: when an invocation omits a previously-written
+  key, the existing value is left in place
+- Profile-scoped MCP validation: exit 1 with 4-option message
+- System-prompt warning: warning emitted, setup continues
+- Empty profile delta: settings.json untouched when no profile keys
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from scripts.setup_environment import PROFILE_OWNED_KEYS
+from scripts.setup_environment import _build_profile_settings
+from scripts.setup_environment import detect_settings_conflicts
+from scripts.setup_environment import write_profile_settings_to_settings
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Test Class 1: Conditional Top-Level Replace Filesystem Semantics
+# ---------------------------------------------------------------------------
+
+
+class TestConditionalReplaceWriterFilesystem:
+    """Filesystem-level tests of write_profile_settings_to_settings().
+
+    Verifies the conditional top-level replace semantics on the real
+    filesystem: only keys present in the delta are written; keys not in
+    the delta are preserved unchanged; None values delete keys.
+    """
+
+    def test_happy_path_all_nine_keys(self, tmp_path: Path) -> None:
+        """All nine PROFILE_OWNED_KEYS routed to settings.json correctly."""
+        hooks_dir = tmp_path / 'hooks'
+        hooks_dir.mkdir()
+
+        delta = _build_profile_settings(
+            hooks={'events': [{'event': 'PreToolUse', 'matcher': 'Bash',
+                               'type': 'command', 'command': 'test.sh'}]},
+            hooks_dir=hooks_dir,
+            model='sonnet',
+            permissions={'allow': ['Read'], 'deny': ['Bash(rm -rf)']},
+            env={'FOO': 'bar'},
+            always_thinking_enabled=True,
+            company_announcements=['Welcome'],
+            attribution={'commit': 'cm', 'pr': 'pr'},
+            status_line={'file': 'status.py'},
+            effort_level='high',
+        )
+
+        write_profile_settings_to_settings(delta, tmp_path)
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+        assert set(content.keys()) == PROFILE_OWNED_KEYS
+
+    def test_partial_delta_only_specified_keys_written(self, tmp_path: Path) -> None:
+        """YAML with only model and permissions writes only those two keys."""
+        delta = _build_profile_settings(
+            hooks={}, hooks_dir=tmp_path / 'hooks',
+            model='sonnet',
+            permissions={'allow': ['Read']},
+        )
+        write_profile_settings_to_settings(delta, tmp_path)
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+        assert set(content.keys()) == {'model', 'permissions'}
+
+    def test_unrelated_keys_preserved(self, tmp_path: Path) -> None:
+        """Non-profile keys in existing settings.json are preserved."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'language': 'english',
+            'includeGitInstructions': False,
+            'apiKeyHelper': '/tmp/key.sh',
+            'cleanupPeriodDays': 30,
+        }), encoding='utf-8')
+
+        delta = _build_profile_settings(hooks={}, hooks_dir=tmp_path / 'hooks', model='sonnet')
+        write_profile_settings_to_settings(delta, tmp_path)
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert content['language'] == 'english'
+        assert content['includeGitInstructions'] is False
+        assert content['apiKeyHelper'] == '/tmp/key.sh'
+        assert content['cleanupPeriodDays'] == 30
+        assert content['model'] == 'sonnet'
+
+    def test_omitted_profile_key_preserved_when_yaml_does_not_declare_it(
+        self, tmp_path: Path,
+    ) -> None:
+        """A profile key that the new delta does not declare survives unchanged.
+
+        The shared settings.json is a user-facing file, so the writer must
+        not silently scrub previously-written profile keys when the current
+        configuration omits them. To delete a key, the user must declare it
+        explicitly as None in the delta or remove it manually.
+        """
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'model': 'sonnet',
+            'permissions': {'allow': ['Read']},
+            'effortLevel': 'high',
+        }), encoding='utf-8')
+
+        # New invocation declares ONLY model (permissions and effortLevel omitted)
+        delta = _build_profile_settings(hooks={}, hooks_dir=tmp_path / 'hooks', model='opus')
+        write_profile_settings_to_settings(delta, tmp_path)
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+
+        # Model updated
+        assert content['model'] == 'opus'
+        # Omitted keys PRESERVED unchanged
+        assert content['permissions'] == {'allow': ['Read']}
+        assert content['effortLevel'] == 'high'
+
+    def test_explicit_null_deletes_key(self, tmp_path: Path) -> None:
+        """Explicit None value in delta deletes the key from settings.json."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'model': 'sonnet',
+            'permissions': {'allow': ['Read']},
+        }), encoding='utf-8')
+
+        # Note: _build_profile_settings() does not currently emit None values
+        # for profile keys (it omits None inputs). For null-as-delete coverage,
+        # construct the delta directly.
+        write_profile_settings_to_settings({'model': None}, tmp_path)
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert 'model' not in content
+        # Unrelated profile key PRESERVED
+        assert content['permissions'] == {'allow': ['Read']}
+
+    def test_top_level_replace_not_deep_merge(self, tmp_path: Path) -> None:
+        """The writer fully replaces a delta key value (no deep-merge).
+
+        When a profile-owned key already exists in settings.json and the
+        delta provides a new value for it, the writer must overwrite the
+        entire top-level value rather than recursively merging the two
+        dicts. Sub-keys not present in the new value disappear from disk.
+        """
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'permissions': {
+                'allow': ['Read', 'Write', 'Glob'],
+                'deny': ['Bash(rm -rf)'],
+                'ask': ['Edit'],
+            },
+        }), encoding='utf-8')
+
+        # YAML declares narrower permissions
+        delta: dict[str, Any] = {'permissions': {'allow': ['Read']}}
+        write_profile_settings_to_settings(delta, tmp_path)
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+
+        # Full replacement (not merge): 'deny' and 'ask' are GONE
+        assert content['permissions'] == {'allow': ['Read']}
+
+
+# ---------------------------------------------------------------------------
+# Test Class 2: Step 14 / Step 18 Interaction (user-settings + profile delta)
+# ---------------------------------------------------------------------------
+
+
+class TestStep14Step18Interaction:
+    """Verify write_user_settings() contributions survive Step 18 writes.
+
+    Step 14 (write_user_settings) runs first and deep-merges the
+    user-settings YAML section into settings.json. Step 18
+    (write_profile_settings_to_settings) runs second and applies the
+    profile delta. Step 18 must not delete keys that Step 14 wrote
+    when those keys are absent from the profile delta.
+    """
+
+    def test_user_settings_permissions_preserved_when_no_root_permissions(
+        self, tmp_path: Path,
+    ) -> None:
+        """user-settings.permissions survives when YAML has no root-level permissions.
+
+        Step 14 write_user_settings() runs first and writes
+        user-settings.permissions into settings.json via deep-merge. Step
+        18 write_profile_settings_to_settings() then runs against an
+        empty profile delta (root YAML has no permissions). The Step 14
+        permissions entry must remain in the file because the writer
+        only touches keys present in its own delta.
+        """
+        # Simulate Step 14 having written user-settings.permissions
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'permissions': {'allow': ['Read', 'Write']},
+            'language': 'english',
+        }), encoding='utf-8')
+
+        # Step 18: delta has NO 'permissions' (YAML root lacks it)
+        delta = _build_profile_settings(hooks={}, hooks_dir=tmp_path / 'hooks', model='sonnet')
+        assert 'permissions' not in delta
+
+        write_profile_settings_to_settings(delta, tmp_path)
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+
+        # user-settings.permissions PRESERVED
+        assert content['permissions'] == {'allow': ['Read', 'Write']}
+        # user-settings.language PRESERVED
+        assert content['language'] == 'english'
+        # Profile delta model ADDED
+        assert content['model'] == 'sonnet'
+
+    def test_root_permissions_wins_over_user_settings_permissions(
+        self, tmp_path: Path,
+    ) -> None:
+        """Root-level permissions REPLACES user-settings.permissions via step order."""
+        # Step 14 wrote user-settings.permissions
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'permissions': {'allow': ['Read']},
+        }), encoding='utf-8')
+
+        # Step 18 has root-level permissions (takes precedence)
+        delta = _build_profile_settings(
+            hooks={}, hooks_dir=tmp_path / 'hooks',
+            permissions={'allow': ['Write', 'Edit']},
+        )
+        write_profile_settings_to_settings(delta, tmp_path)
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+
+        # Root-level won (full replace)
+        assert content['permissions'] == {'allow': ['Write', 'Edit']}
+
+
+# ---------------------------------------------------------------------------
+# Test Class 3: Conflict Detection in Non-Command-Names Mode
+# ---------------------------------------------------------------------------
+
+
+class TestConflictDetectionInNonCommandNamesMode:
+    """Verify detect_settings_conflicts() fires when command-names is absent.
+
+    The function runs unconditionally in both isolated and non-isolated modes
+    and reports keys declared at both YAML root level and under user-settings.
+    """
+
+    def test_conflict_detected_in_non_command_names_mode(self) -> None:
+        """Conflict between user-settings and root fires in non-command-names mode."""
+        user_settings = {'model': 'claude-opus-4'}
+        root_config = {'model': 'claude-sonnet-4'}  # NO command-names
+
+        conflicts = detect_settings_conflicts(user_settings, root_config)
+        assert conflicts == [('model', 'claude-opus-4', 'claude-sonnet-4')]
+
+    def test_kebab_to_camel_key_mapped(self) -> None:
+        """kebab-case root keys mapped to camelCase user-settings keys."""
+        user_settings = {'alwaysThinkingEnabled': True}
+        root_config = {'always-thinking-enabled': False}
+
+        conflicts = detect_settings_conflicts(user_settings, root_config)
+        assert conflicts == [('alwaysThinkingEnabled', True, False)]
+
+    @patch('scripts.setup_environment.load_config_from_source')
+    @patch('scripts.setup_environment.validate_all_config_files')
+    @patch('scripts.setup_environment.install_claude')
+    @patch('scripts.setup_environment.install_dependencies')
+    @patch('scripts.setup_environment.process_resources')
+    @patch('scripts.setup_environment.process_skills')
+    @patch('scripts.setup_environment.configure_all_mcp_servers')
+    @patch('scripts.setup_environment.find_command', return_value='/usr/bin/claude')
+    @patch('scripts.setup_environment.is_admin', return_value=True)
+    @patch('pathlib.Path.mkdir')
+    def test_conflict_warning_emitted_via_main_without_command_names(
+        self,
+        mock_mkdir: MagicMock,
+        mock_is_admin: MagicMock,
+        mock_find_cmd: MagicMock,
+        mock_mcp: MagicMock,
+        mock_skills: MagicMock,
+        mock_resources: MagicMock,
+        mock_deps: MagicMock,
+        mock_install: MagicMock,
+        mock_validate: MagicMock,
+        mock_load: MagicMock,
+        e2e_isolated_home: dict[str, Path],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Warning is emitted via main() when root-level and user-settings conflict without command-names."""
+        del mock_mkdir, mock_is_admin, mock_find_cmd, mock_skills, mock_resources
+        del mock_deps, e2e_isolated_home
+        mock_load.return_value = (
+            {
+                'name': 'Conflict Test',
+                # NO command-names
+                'model': 'claude-sonnet-4',
+                'user-settings': {'model': 'claude-opus-4'},
+            },
+            'test.yaml',
+        )
+        mock_validate.return_value = (True, [])
+        mock_install.return_value = True
+        mock_mcp.return_value = (True, [], {'global_count': 0, 'profile_count': 0, 'combined_count': 0})
+
+        from scripts import setup_environment
+
+        with patch('sys.argv', ['setup_environment.py', 'test', '--yes', '--skip-install']), \
+             patch('sys.exit') as mock_exit, \
+             patch.object(setup_environment, 'write_user_settings', return_value=True), \
+             patch.object(setup_environment, 'write_profile_settings_to_settings', return_value=True):
+            setup_environment.main()
+            mock_exit.assert_not_called()
+
+        captured = capsys.readouterr()
+        # Warning text identifies the conflicting key and both surfaces
+        assert "Key 'model' specified in both root level and user-settings" in captured.out
+        # Precedence message indicates Step 18 writes last, so the root-level value wins
+        assert 'Root-level value takes precedence (written last in Step 18)' in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Test Class 4: Profile-Scoped MCP Validation Error
+# ---------------------------------------------------------------------------
+
+
+class TestProfileMcpValidationError:
+    """Verify exit 1 with 4-option fix-up message for profile MCP without command-names."""
+
+    @patch('scripts.setup_environment.load_config_from_source')
+    @patch('scripts.setup_environment.validate_all_config_files')
+    @patch('scripts.setup_environment.install_claude')
+    @patch('scripts.setup_environment.install_dependencies')
+    @patch('scripts.setup_environment.process_resources')
+    @patch('scripts.setup_environment.process_skills')
+    @patch('scripts.setup_environment.configure_all_mcp_servers')
+    @patch('scripts.setup_environment.find_command', return_value='/usr/bin/claude')
+    @patch('scripts.setup_environment.is_admin', return_value=True)
+    @patch('pathlib.Path.mkdir')
+    def test_profile_scope_alone_triggers_error(
+        self,
+        mock_mkdir: MagicMock,
+        mock_is_admin: MagicMock,
+        mock_find_cmd: MagicMock,
+        mock_mcp: MagicMock,
+        mock_skills: MagicMock,
+        mock_resources: MagicMock,
+        mock_deps: MagicMock,
+        mock_install: MagicMock,
+        mock_validate: MagicMock,
+        mock_load: MagicMock,
+        e2e_isolated_home: dict[str, Path],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Scope 'profile' without command-names -> exit 1 with actionable message."""
+        del mock_mkdir, mock_is_admin, mock_find_cmd, mock_skills, mock_resources
+        del mock_deps, e2e_isolated_home
+        mock_load.return_value = (
+            {
+                'name': 'Profile MCP No Command',
+                # NO command-names
+                'mcp-servers': [
+                    {
+                        'name': 'profile-server',
+                        'scope': 'profile',
+                        'transport': 'http',
+                        'url': 'http://localhost:3000',
+                    },
+                ],
+            },
+            'test.yaml',
+        )
+        mock_validate.return_value = (True, [])
+        mock_install.return_value = True
+        mock_mcp.return_value = (True, [], {'global_count': 0, 'profile_count': 0, 'combined_count': 0})
+
+        from scripts import setup_environment
+
+        with patch('sys.argv', ['setup_environment.py', 'test', '--yes', '--skip-install']), \
+             pytest.raises(SystemExit) as excinfo:
+            setup_environment.main()
+
+        # sys.exit(1) was called
+        assert excinfo.value.code == 1
+
+        # error() messages go to stderr
+        captured = capsys.readouterr()
+        assert "MCP server 'profile-server' declares scope: profile" in captured.err
+        assert 'command-names is not specified' in captured.err
+
+    @patch('scripts.setup_environment.load_config_from_source')
+    @patch('scripts.setup_environment.validate_all_config_files')
+    @patch('scripts.setup_environment.install_claude')
+    @patch('scripts.setup_environment.install_dependencies')
+    @patch('scripts.setup_environment.process_resources')
+    @patch('scripts.setup_environment.process_skills')
+    @patch('scripts.setup_environment.configure_all_mcp_servers')
+    @patch('scripts.setup_environment.find_command', return_value='/usr/bin/claude')
+    @patch('scripts.setup_environment.is_admin', return_value=True)
+    @patch('pathlib.Path.mkdir')
+    def test_combined_user_profile_scope_triggers_error(
+        self,
+        mock_mkdir: MagicMock,
+        mock_is_admin: MagicMock,
+        mock_find_cmd: MagicMock,
+        mock_mcp: MagicMock,
+        mock_skills: MagicMock,
+        mock_resources: MagicMock,
+        mock_deps: MagicMock,
+        mock_install: MagicMock,
+        mock_validate: MagicMock,
+        mock_load: MagicMock,
+        e2e_isolated_home: dict[str, Path],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Scope [user, profile] without command-names -> exit 1."""
+        del mock_mkdir, mock_is_admin, mock_find_cmd, mock_skills, mock_resources
+        del mock_deps, e2e_isolated_home
+        mock_load.return_value = (
+            {
+                'name': 'Combined Profile MCP No Command',
+                'mcp-servers': [
+                    {
+                        'name': 'combined-server',
+                        'scope': ['user', 'profile'],
+                        'transport': 'http',
+                        'url': 'http://localhost:3000',
+                    },
+                ],
+            },
+            'test.yaml',
+        )
+        mock_validate.return_value = (True, [])
+        mock_install.return_value = True
+        mock_mcp.return_value = (True, [], {'global_count': 0, 'profile_count': 0, 'combined_count': 0})
+
+        from scripts import setup_environment
+
+        with patch('sys.argv', ['setup_environment.py', 'test', '--yes', '--skip-install']), \
+             pytest.raises(SystemExit) as excinfo:
+            setup_environment.main()
+
+        assert excinfo.value.code == 1
+
+        captured = capsys.readouterr()
+        # error() messages go to stderr
+        assert "MCP server 'combined-server' declares scope: profile" in captured.err
+
+    @patch('scripts.setup_environment.load_config_from_source')
+    @patch('scripts.setup_environment.validate_all_config_files')
+    @patch('scripts.setup_environment.install_claude')
+    @patch('scripts.setup_environment.install_dependencies')
+    @patch('scripts.setup_environment.process_resources')
+    @patch('scripts.setup_environment.process_skills')
+    @patch('scripts.setup_environment.configure_all_mcp_servers')
+    @patch('scripts.setup_environment.find_command', return_value='/usr/bin/claude')
+    @patch('scripts.setup_environment.is_admin', return_value=True)
+    @patch('pathlib.Path.mkdir')
+    def test_error_message_contains_4_options(
+        self,
+        mock_mkdir: MagicMock,
+        mock_is_admin: MagicMock,
+        mock_find_cmd: MagicMock,
+        mock_mcp: MagicMock,
+        mock_skills: MagicMock,
+        mock_resources: MagicMock,
+        mock_deps: MagicMock,
+        mock_install: MagicMock,
+        mock_validate: MagicMock,
+        mock_load: MagicMock,
+        e2e_isolated_home: dict[str, Path],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Error message enumerates all 4 fix-up options."""
+        del mock_mkdir, mock_is_admin, mock_find_cmd, mock_skills, mock_resources
+        del mock_deps, e2e_isolated_home
+        mock_load.return_value = (
+            {
+                'name': 'Profile MCP 4 Options Test',
+                'mcp-servers': [
+                    {
+                        'name': 'any-profile-server',
+                        'scope': 'profile',
+                        'transport': 'http',
+                        'url': 'http://localhost:3000',
+                    },
+                ],
+            },
+            'test.yaml',
+        )
+        mock_validate.return_value = (True, [])
+        mock_install.return_value = True
+        mock_mcp.return_value = (True, [], {'global_count': 0, 'profile_count': 0, 'combined_count': 0})
+
+        from scripts import setup_environment
+
+        with patch('sys.argv', ['setup_environment.py', 'test', '--yes', '--skip-install']), \
+             pytest.raises(SystemExit):
+            setup_environment.main()
+
+        captured = capsys.readouterr()
+        # error() messages go to stderr - all four options enumerated in the error message
+        assert '1. Add "command-names: [your-name]"' in captured.err
+        assert '2. Change scope to "user"' in captured.err
+        assert '3. Change scope to "local"' in captured.err
+        assert '4. Change scope to "project"' in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Test Class 5: System-Prompt Warning Without Command-Names
+# ---------------------------------------------------------------------------
+
+
+class TestSystemPromptWarning:
+    """Verify warning emitted when command-defaults.system-prompt is set without command-names."""
+
+    @patch('scripts.setup_environment.load_config_from_source')
+    @patch('scripts.setup_environment.validate_all_config_files')
+    @patch('scripts.setup_environment.install_claude')
+    @patch('scripts.setup_environment.install_dependencies')
+    @patch('scripts.setup_environment.process_resources')
+    @patch('scripts.setup_environment.process_skills')
+    @patch('scripts.setup_environment.configure_all_mcp_servers')
+    @patch('scripts.setup_environment.find_command', return_value='/usr/bin/claude')
+    @patch('scripts.setup_environment.is_admin', return_value=True)
+    @patch('pathlib.Path.mkdir')
+    def test_warning_emitted(
+        self,
+        mock_mkdir: MagicMock,
+        mock_is_admin: MagicMock,
+        mock_find_cmd: MagicMock,
+        mock_mcp: MagicMock,
+        mock_skills: MagicMock,
+        mock_resources: MagicMock,
+        mock_deps: MagicMock,
+        mock_install: MagicMock,
+        mock_validate: MagicMock,
+        mock_load: MagicMock,
+        e2e_isolated_home: dict[str, Path],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Warning is printed; setup continues successfully."""
+        del mock_mkdir, mock_is_admin, mock_find_cmd, mock_skills, mock_resources
+        del mock_deps, e2e_isolated_home
+        mock_load.return_value = (
+            {
+                'name': 'System Prompt Warning Test',
+                # NO command-names
+                'command-defaults': {
+                    'system-prompt': 'prompts/my-prompt.md',
+                    'mode': 'replace',
+                },
+            },
+            'test.yaml',
+        )
+        mock_validate.return_value = (True, [])
+        mock_install.return_value = True
+        mock_mcp.return_value = (True, [], {'global_count': 0, 'profile_count': 0, 'combined_count': 0})
+
+        from scripts import setup_environment
+
+        with patch('sys.argv', ['setup_environment.py', 'test', '--yes', '--skip-install']), \
+             patch('sys.exit') as mock_exit, \
+             patch.object(setup_environment, 'handle_resource', return_value=True), \
+             patch.object(setup_environment, 'download_hook_files', return_value=True), \
+             patch.object(setup_environment, 'write_profile_settings_to_settings', return_value=True):
+            setup_environment.main()
+            mock_exit.assert_not_called()
+
+        captured = capsys.readouterr()
+        # warning() messages go to stdout
+        assert 'command-defaults.system-prompt' in captured.out
+        assert 'but command-names is not specified' in captured.out
+        assert 'there is no launcher' in captured.out
+        assert 'system prompt will NOT be applied' in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Test Class 6: Golden Config (No Command-Names) End-to-End Integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def golden_config_no_command_names() -> dict[str, Any]:
+    """Load the no-command-names variant of golden_config.yaml."""
+    config_path = Path(__file__).parent / 'golden_config_no_command_names.yaml'
+    with config_path.open('r', encoding='utf-8') as f:
+        config = yaml.safe_load(f)
+    result: dict[str, Any] = config
+    return result
+
+
+class TestGoldenConfigNoCommandNames:
+    """End-to-end integration test using golden_config_no_command_names.yaml."""
+
+    def test_golden_config_absence_of_command_names(
+        self,
+        golden_config_no_command_names: dict[str, Any],
+    ) -> None:
+        """Verify golden_config_no_command_names.yaml does not declare command-names."""
+        assert 'command-names' not in golden_config_no_command_names
+
+    def test_golden_config_has_all_profile_keys(
+        self,
+        golden_config_no_command_names: dict[str, Any],
+    ) -> None:
+        """Verify the golden config declares every profile-owned key at root level."""
+        cfg = golden_config_no_command_names
+        assert 'model' in cfg
+        assert 'permissions' in cfg
+        assert 'env-variables' in cfg
+        assert 'attribution' in cfg
+        assert 'always-thinking-enabled' in cfg
+        assert 'effort-level' in cfg
+        assert 'company-announcements' in cfg
+        assert 'status-line' in cfg
+        assert 'hooks' in cfg
+
+    def test_golden_config_no_profile_scoped_mcp(
+        self,
+        golden_config_no_command_names: dict[str, Any],
+    ) -> None:
+        """Verify NO mcp-server in the fixture uses scope 'profile'.
+
+        Profile-scoped servers without command-names trigger an error; the
+        no-command-names fixture must avoid them for happy-path coverage.
+        """
+        for server in golden_config_no_command_names.get('mcp-servers', []):
+            scope = server.get('scope')
+            if isinstance(scope, str):
+                assert scope != 'profile'
+            elif isinstance(scope, list):
+                assert 'profile' not in scope
+
+    def test_all_profile_keys_in_settings_json(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        golden_config_no_command_names: dict[str, Any],
+    ) -> None:
+        """After building delta + writing, all 9 profile-owned keys appear in settings.json."""
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+        hooks_dir = claude_dir / 'hooks'
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+
+        cfg = golden_config_no_command_names
+
+        delta = _build_profile_settings(
+            hooks=cfg.get('hooks', {}),
+            hooks_dir=hooks_dir,
+            model=cfg.get('model'),
+            permissions=cfg.get('permissions'),
+            env=cfg.get('env-variables'),
+            always_thinking_enabled=cfg.get('always-thinking-enabled'),
+            company_announcements=cfg.get('company-announcements'),
+            attribution=cfg.get('attribution'),
+            status_line=cfg.get('status-line'),
+            effort_level=cfg.get('effort-level'),
+        )
+
+        write_profile_settings_to_settings(delta, claude_dir)
+
+        settings_path = claude_dir / 'settings.json'
+        assert settings_path.exists()
+        content = json.loads(settings_path.read_text(encoding='utf-8'))
+
+        # All 9 profile keys present
+        assert set(content.keys()) == PROFILE_OWNED_KEYS
+
+    def test_hooks_in_settings_not_config_json(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        golden_config_no_command_names: dict[str, Any],
+    ) -> None:
+        """Hooks key appears in settings.json; no config.json is created."""
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+        hooks_dir = claude_dir / 'hooks'
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+
+        cfg = golden_config_no_command_names
+
+        delta = _build_profile_settings(
+            hooks=cfg.get('hooks', {}),
+            hooks_dir=hooks_dir,
+            model=cfg.get('model'),
+        )
+        write_profile_settings_to_settings(delta, claude_dir)
+
+        settings_path = claude_dir / 'settings.json'
+        content = json.loads(settings_path.read_text(encoding='utf-8'))
+        assert 'hooks' in content
+        assert 'PostToolUse' in content['hooks']
+        # Non-isolated mode: NO config.json anywhere
+        assert not (claude_dir / 'config.json').exists()
+
+    def test_status_line_absolute_path_in_settings(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        golden_config_no_command_names: dict[str, Any],
+    ) -> None:
+        """statusLine.command has absolute POSIX path under ~/.claude/hooks/."""
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+        hooks_dir = claude_dir / 'hooks'
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+
+        cfg = golden_config_no_command_names
+
+        delta = _build_profile_settings(
+            hooks=cfg.get('hooks', {}),
+            hooks_dir=hooks_dir,
+            status_line=cfg.get('status-line'),
+        )
+        write_profile_settings_to_settings(delta, claude_dir)
+
+        settings_path = claude_dir / 'settings.json'
+        content = json.loads(settings_path.read_text(encoding='utf-8'))
+        sl = content['statusLine']
+        assert sl['type'] == 'command'
+        expected_path = (hooks_dir / 'e2e_statusline.py').as_posix()
+        assert expected_path in sl['command']
+        # Python script -> uv run prefix
+        assert 'uv run' in sl['command']
+        # Config file embedded in command string
+        expected_cfg = (hooks_dir / 'e2e-statusline-config.yaml').as_posix()
+        assert expected_cfg in sl['command']
+
+
+# ---------------------------------------------------------------------------
+# Test Class 7: Behavior Across Repeated Invocations With Evolving Content
+# ---------------------------------------------------------------------------
+
+
+class TestRepeatedInvocationSemantics:
+    """Verify behavior across multiple invocations with evolving YAML content."""
+
+    def test_initial_invocation_populates_declared_keys(self, tmp_path: Path) -> None:
+        """First invocation against an empty file writes all declared keys."""
+        delta = _build_profile_settings(
+            hooks={}, hooks_dir=tmp_path / 'hooks',
+            model='sonnet', permissions={'allow': ['Read']},
+        )
+        write_profile_settings_to_settings(delta, tmp_path)
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+        assert content == {'model': 'sonnet', 'permissions': {'allow': ['Read']}}
+
+    def test_re_declaration_overwrites_previous_value(self, tmp_path: Path) -> None:
+        """Re-declaring a key with a new value overwrites the previous value."""
+        # First invocation
+        delta1 = _build_profile_settings(
+            hooks={}, hooks_dir=tmp_path / 'hooks',
+            model='sonnet', permissions={'allow': ['Read']},
+        )
+        write_profile_settings_to_settings(delta1, tmp_path)
+
+        # Second invocation (same keys, different values)
+        delta2 = _build_profile_settings(
+            hooks={}, hooks_dir=tmp_path / 'hooks',
+            model='opus', permissions={'allow': ['Write']},
+        )
+        write_profile_settings_to_settings(delta2, tmp_path)
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+        assert content['model'] == 'opus'
+        assert content['permissions'] == {'allow': ['Write']}
+
+    def test_omitting_key_preserves_previous_value(self, tmp_path: Path) -> None:
+        """Omitting a key on a later invocation preserves the previous value.
+
+        The shared settings.json is a user-facing file, so the writer
+        does not delete profile-owned keys when the current invocation
+        does not declare them. To delete a key, the user must declare it
+        explicitly as None or remove it manually.
+        """
+        # First invocation: both model and permissions
+        delta1 = _build_profile_settings(
+            hooks={}, hooks_dir=tmp_path / 'hooks',
+            model='sonnet', permissions={'allow': ['Read']},
+        )
+        write_profile_settings_to_settings(delta1, tmp_path)
+
+        # Second invocation: only model (permissions omitted)
+        delta2 = _build_profile_settings(
+            hooks={}, hooks_dir=tmp_path / 'hooks',
+            model='opus',
+        )
+        write_profile_settings_to_settings(delta2, tmp_path)
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+
+        # Model updated, permissions PRESERVED from previous invocation
+        assert content['model'] == 'opus'
+        assert content['permissions'] == {'allow': ['Read']}
+
+    def test_multiple_invocations_accumulate_distinct_keys(self, tmp_path: Path) -> None:
+        """Multiple invocations with different subsets preserve accumulated state."""
+        # First invocation: model + permissions
+        write_profile_settings_to_settings(
+            _build_profile_settings(
+                hooks={}, hooks_dir=tmp_path / 'hooks',
+                model='sonnet', permissions={'allow': ['Read']},
+            ),
+            tmp_path,
+        )
+
+        # Second invocation: add env (model re-declared, permissions omitted)
+        write_profile_settings_to_settings(
+            _build_profile_settings(
+                hooks={}, hooks_dir=tmp_path / 'hooks',
+                model='opus', env={'FOO': 'bar'},
+            ),
+            tmp_path,
+        )
+
+        # Third invocation: add effort_level (previous keys all omitted)
+        write_profile_settings_to_settings(
+            _build_profile_settings(
+                hooks={}, hooks_dir=tmp_path / 'hooks',
+                effort_level='high',
+            ),
+            tmp_path,
+        )
+
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+        # Accumulated: permissions from the first invocation, env from the
+        # second, effortLevel from the third. Model was re-declared in the
+        # second invocation, so it ends up as 'opus'.
+        assert content['model'] == 'opus'
+        assert content['permissions'] == {'allow': ['Read']}
+        assert content['env'] == {'FOO': 'bar'}
+        assert content['effortLevel'] == 'high'
+
+
+# ---------------------------------------------------------------------------
+# Test Class 8: Auto-Update Target 2 Survival (regression)
+# ---------------------------------------------------------------------------
+
+
+class TestAutoUpdateTarget2Survival:
+    """Verify the Target 2 auto-update injection survives the profile settings write.
+
+    When version pinning is active, apply_auto_update_settings() injects
+    DISABLE_AUTOUPDATER into user_settings.env (its Target 2). Step 14
+    then writes that entry to settings.json.env. The subsequent Step 18
+    profile-settings write must not destroy that entry when the YAML
+    root has no env-variables declaration.
+    """
+
+    def test_disable_autoupdater_preserved_when_no_root_env(self, tmp_path: Path) -> None:
+        """DISABLE_AUTOUPDATER in settings.json.env survives the profile write.
+
+        Set up settings.json.env containing DISABLE_AUTOUPDATER (the state
+        Step 14 leaves behind for a pinned-version configuration), then
+        run the profile-settings writer with a delta that contains no
+        'env' key. The writer must leave the existing 'env' value alone.
+        """
+        # Simulate Step 14 having written user_settings with env DISABLE_AUTOUPDATER
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'env': {'DISABLE_AUTOUPDATER': '1'},
+        }), encoding='utf-8')
+
+        # Step 18: delta has no 'env' key (YAML has no env-variables)
+        delta = _build_profile_settings(hooks={}, hooks_dir=tmp_path / 'hooks', model='sonnet')
+        assert 'env' not in delta
+
+        write_profile_settings_to_settings(delta, tmp_path)
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert content['env']['DISABLE_AUTOUPDATER'] == '1'
+        assert content['model'] == 'sonnet'
+
+    def test_root_env_variables_replace_existing_env_value(self, tmp_path: Path) -> None:
+        """When YAML declares env-variables, root-level env replaces the existing 'env' value."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'env': {'DISABLE_AUTOUPDATER': '1', 'STALE': 'x'},
+        }), encoding='utf-8')
+
+        # The delta carries a root-level env value
+        delta = _build_profile_settings(
+            hooks={}, hooks_dir=tmp_path / 'hooks',
+            env={'FOO': 'bar'},
+        )
+        write_profile_settings_to_settings(delta, tmp_path)
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        # Full replacement
+        assert content['env'] == {'FOO': 'bar'}
+
+
+# ---------------------------------------------------------------------------
+# Test Class 9: No Profile Keys = No File I/O
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyDeltaNoOp:
+    """Verify writer does not touch settings.json when delta is empty."""
+
+    def test_empty_delta_does_not_create_file(self, tmp_path: Path) -> None:
+        """Empty delta -> no file created."""
+        write_profile_settings_to_settings({}, tmp_path)
+        assert not (tmp_path / 'settings.json').exists()
+
+    def test_empty_delta_does_not_modify_existing(self, tmp_path: Path) -> None:
+        """Empty delta -> existing settings.json unchanged."""
+        settings_file = tmp_path / 'settings.json'
+        original = {'language': 'english', 'model': 'sonnet'}
+        settings_file.write_text(json.dumps(original), encoding='utf-8')
+
+        write_profile_settings_to_settings({}, tmp_path)
+
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert content == original

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -6834,6 +6834,402 @@ class TestValidateUserSettings:
             assert key in result[0]
 
 
+class TestProfileOwnedKeys:
+    """Unit tests for PROFILE_OWNED_KEYS constant."""
+
+    def test_contains_all_nine_profile_keys(self) -> None:
+        """PROFILE_OWNED_KEYS must contain exactly the 9 profile-owned keys."""
+        expected = {
+            'model', 'permissions', 'env', 'attribution',
+            'alwaysThinkingEnabled', 'effortLevel', 'companyAnnouncements',
+            'statusLine', 'hooks',
+        }
+        assert expected == setup_environment.PROFILE_OWNED_KEYS
+
+    def test_is_frozenset(self) -> None:
+        """PROFILE_OWNED_KEYS must be a frozenset (immutable)."""
+        assert isinstance(setup_environment.PROFILE_OWNED_KEYS, frozenset)
+
+    def test_user_settings_excluded_keys_still_only_two(self) -> None:
+        """USER_SETTINGS_EXCLUDED_KEYS must NOT be extended to PROFILE_OWNED_KEYS.
+
+        The user-settings section is a free-form escape hatch that accepts
+        arbitrary Claude Code CLI settings.json keys. Only hooks/statusLine
+        are excluded because they require dedicated path resolution and
+        must live at the YAML root level.
+        """
+        assert {'hooks', 'statusLine'} == setup_environment.USER_SETTINGS_EXCLUDED_KEYS
+
+
+class TestBuildProfileSettings:
+    """Unit tests for _build_profile_settings() pure builder."""
+
+    def test_all_none_returns_empty_dict(self, tmp_path: Path) -> None:
+        """All None inputs produce an empty dict (no side effects)."""
+        result = setup_environment._build_profile_settings(
+            hooks={}, hooks_dir=tmp_path,
+        )
+        assert result == {}
+
+    def test_model_only(self, tmp_path: Path) -> None:
+        """Only model set -> only 'model' key in result."""
+        result = setup_environment._build_profile_settings(
+            hooks={}, hooks_dir=tmp_path, model='sonnet',
+        )
+        assert result == {'model': 'sonnet'}
+
+    def test_permissions_kebab_to_camel(self, tmp_path: Path) -> None:
+        """'default-mode' translated to 'defaultMode'."""
+        result = setup_environment._build_profile_settings(
+            hooks={}, hooks_dir=tmp_path,
+            permissions={'default-mode': 'ask', 'allow': ['Read']},
+        )
+        assert 'defaultMode' in result['permissions']
+        assert 'default-mode' not in result['permissions']
+        assert result['permissions']['allow'] == ['Read']
+
+    def test_permissions_additional_directories_translation(self, tmp_path: Path) -> None:
+        """'additional-directories' translated to 'additionalDirectories'."""
+        result = setup_environment._build_profile_settings(
+            hooks={}, hooks_dir=tmp_path,
+            permissions={'additional-directories': ['/tmp/test']},
+        )
+        assert 'additionalDirectories' in result['permissions']
+        assert 'additional-directories' not in result['permissions']
+
+    def test_env_values_stringified(self, tmp_path: Path) -> None:
+        """Env values are preserved as strings in the output env dict."""
+        result = setup_environment._build_profile_settings(
+            hooks={}, hooks_dir=tmp_path,
+            env={'FOO': 'bar', 'HELLO': 'world'},
+        )
+        assert result['env']['FOO'] == 'bar'
+        assert result['env']['HELLO'] == 'world'
+
+    def test_attribution_passthrough(self, tmp_path: Path) -> None:
+        """Attribution dict passed through unchanged."""
+        attr = {'commit': 'Test commit', 'pr': 'Test PR'}
+        result = setup_environment._build_profile_settings(
+            hooks={}, hooks_dir=tmp_path, attribution=attr,
+        )
+        assert result['attribution'] == attr
+
+    def test_attribution_empty_dict_not_omitted(self, tmp_path: Path) -> None:
+        """Empty attribution dict is kept (not same as None)."""
+        result = setup_environment._build_profile_settings(
+            hooks={}, hooks_dir=tmp_path, attribution={},
+        )
+        assert 'attribution' in result
+        assert result['attribution'] == {}
+
+    def test_always_thinking_enabled_true(self, tmp_path: Path) -> None:
+        """always_thinking_enabled=True stored under alwaysThinkingEnabled."""
+        result = setup_environment._build_profile_settings(
+            hooks={}, hooks_dir=tmp_path, always_thinking_enabled=True,
+        )
+        assert result == {'alwaysThinkingEnabled': True}
+
+    def test_always_thinking_enabled_false_not_omitted(self, tmp_path: Path) -> None:
+        """always_thinking_enabled=False is explicit and kept."""
+        result = setup_environment._build_profile_settings(
+            hooks={}, hooks_dir=tmp_path, always_thinking_enabled=False,
+        )
+        assert result == {'alwaysThinkingEnabled': False}
+
+    def test_effort_level(self, tmp_path: Path) -> None:
+        """effort_level stored under effortLevel."""
+        result = setup_environment._build_profile_settings(
+            hooks={}, hooks_dir=tmp_path, effort_level='high',
+        )
+        assert result == {'effortLevel': 'high'}
+
+    def test_company_announcements_list(self, tmp_path: Path) -> None:
+        """company_announcements list stored under companyAnnouncements."""
+        result = setup_environment._build_profile_settings(
+            hooks={}, hooks_dir=tmp_path, company_announcements=['msg1', 'msg2'],
+        )
+        assert result == {'companyAnnouncements': ['msg1', 'msg2']}
+
+    def test_status_line_python_script(self, tmp_path: Path) -> None:
+        """status_line with .py file builds uv run command with absolute path."""
+        result = setup_environment._build_profile_settings(
+            hooks={}, hooks_dir=tmp_path,
+            status_line={'file': 'status.py'},
+        )
+        sl = result['statusLine']
+        assert sl['type'] == 'command'
+        assert 'uv run' in sl['command']
+        assert '--python 3.12' in sl['command']
+        assert 'status.py' in sl['command']
+        # Absolute POSIX path
+        expected_path = (tmp_path / 'status.py').as_posix()
+        assert expected_path in sl['command']
+
+    def test_status_line_with_config(self, tmp_path: Path) -> None:
+        """status_line with config appends config path to command."""
+        result = setup_environment._build_profile_settings(
+            hooks={}, hooks_dir=tmp_path,
+            status_line={'file': 'status.py', 'config': 'status.yaml'},
+        )
+        sl = result['statusLine']
+        config_path = (tmp_path / 'status.yaml').as_posix()
+        assert config_path in sl['command']
+
+    def test_status_line_non_python_direct_path(self, tmp_path: Path) -> None:
+        """status_line with non-.py file uses direct path (no uv run)."""
+        result = setup_environment._build_profile_settings(
+            hooks={}, hooks_dir=tmp_path,
+            status_line={'file': 'status.sh'},
+        )
+        sl = result['statusLine']
+        assert 'uv run' not in sl['command']
+        assert 'status.sh' in sl['command']
+
+    def test_status_line_padding_included(self, tmp_path: Path) -> None:
+        """status_line padding is included in the result."""
+        result = setup_environment._build_profile_settings(
+            hooks={}, hooks_dir=tmp_path,
+            status_line={'file': 'status.py', 'padding': 2},
+        )
+        assert result['statusLine']['padding'] == 2
+
+    def test_hooks_builder_delegation(self, tmp_path: Path) -> None:
+        """hooks key populated via _build_hooks_json() delegation."""
+        hooks_input = {
+            'events': [
+                {'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'command', 'command': 'test.sh'},
+            ],
+        }
+        result = setup_environment._build_profile_settings(
+            hooks=hooks_input, hooks_dir=tmp_path,
+        )
+        assert 'hooks' in result
+        assert 'PreToolUse' in result['hooks']
+
+    def test_hooks_empty_events_omitted(self, tmp_path: Path) -> None:
+        """hooks with empty events is omitted from result."""
+        result = setup_environment._build_profile_settings(
+            hooks={'events': []}, hooks_dir=tmp_path,
+        )
+        assert 'hooks' not in result
+
+    def test_all_nine_keys_together(self, tmp_path: Path) -> None:
+        """All nine keys provided simultaneously produce full delta."""
+        result = setup_environment._build_profile_settings(
+            hooks={'events': [{'event': 'PreToolUse', 'matcher': 'Bash',
+                               'type': 'command', 'command': 'test.sh'}]},
+            hooks_dir=tmp_path,
+            model='sonnet',
+            permissions={'allow': ['Read']},
+            env={'FOO': 'bar'},
+            always_thinking_enabled=True,
+            company_announcements=['Welcome'],
+            attribution={'commit': 'x', 'pr': 'y'},
+            status_line={'file': 'status.py'},
+            effort_level='high',
+        )
+        assert set(result.keys()) == setup_environment.PROFILE_OWNED_KEYS
+
+
+class TestWriteProfileSettingsToSettings:
+    """Unit tests for write_profile_settings_to_settings().
+
+    Verifies the conditional top-level replace semantics applied when
+    writing profile-owned keys to the shared ~/.claude/settings.json
+    file in non-command-names mode.
+    """
+
+    def test_empty_delta_no_op(self, tmp_path: Path) -> None:
+        """Empty delta does not create or modify settings.json."""
+        settings_file = tmp_path / 'settings.json'
+        result = setup_environment.write_profile_settings_to_settings({}, tmp_path)
+        assert result is True
+        assert not settings_file.exists()
+
+    def test_creates_new_settings_json_with_delta(self, tmp_path: Path) -> None:
+        """Writer creates settings.json from scratch when missing."""
+        result = setup_environment.write_profile_settings_to_settings(
+            {'model': 'sonnet'}, tmp_path,
+        )
+        assert result is True
+        settings_file = tmp_path / 'settings.json'
+        assert settings_file.exists()
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert content == {'model': 'sonnet'}
+
+    def test_preserves_unrelated_keys(self, tmp_path: Path) -> None:
+        """Existing unrelated keys are preserved across the write.
+
+        The writer must only touch keys explicitly present in the delta;
+        keys the writer was not asked to update must survive unchanged.
+        """
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'language': 'english',
+            'theme': 'dark',
+            'includeGitInstructions': False,
+            'model': 'old-model',
+        }), encoding='utf-8')
+
+        result = setup_environment.write_profile_settings_to_settings(
+            {'model': 'sonnet'}, tmp_path,
+        )
+        assert result is True
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        # Delta key replaced
+        assert content['model'] == 'sonnet'
+        # Unrelated keys preserved
+        assert content['language'] == 'english'
+        assert content['theme'] == 'dark'
+        assert content['includeGitInstructions'] is False
+
+    def test_preserves_profile_owned_keys_not_in_delta(self, tmp_path: Path) -> None:
+        """Profile-owned keys NOT in the delta are preserved.
+
+        If YAML declares only 'model' at root level and settings.json already
+        has 'permissions' from a previous invocation (or from Step 14
+        write_user_settings()), the 'permissions' key MUST survive. The writer
+        preserves any profile-owned key it was not asked to update, so that
+        previously-written values and Step 14 contributions are never silently
+        destroyed.
+        """
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'model': 'old-model',
+            'permissions': {'allow': ['Read'], 'deny': ['Bash(rm -rf)']},
+            'env': {'FOO': 'bar'},
+        }), encoding='utf-8')
+
+        # Delta contains ONLY 'model' (not permissions or env)
+        result = setup_environment.write_profile_settings_to_settings(
+            {'model': 'sonnet'}, tmp_path,
+        )
+        assert result is True
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert content['model'] == 'sonnet'
+        # Non-delta profile-owned keys PRESERVED
+        assert content['permissions'] == {'allow': ['Read'], 'deny': ['Bash(rm -rf)']}
+        assert content['env'] == {'FOO': 'bar'}
+
+    def test_top_level_replace_not_deep_merge(self, tmp_path: Path) -> None:
+        """Delta key value fully replaces existing value (no deep merge)."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'permissions': {'allow': ['Read', 'Write'], 'deny': ['Bash']},
+        }), encoding='utf-8')
+
+        # Delta permissions has only 'allow' (no 'deny')
+        result = setup_environment.write_profile_settings_to_settings(
+            {'permissions': {'allow': ['Read']}}, tmp_path,
+        )
+        assert result is True
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        # Full replacement: 'allow' is [Read] only, 'deny' is GONE
+        assert content['permissions'] == {'allow': ['Read']}
+
+    def test_none_value_deletes_key(self, tmp_path: Path) -> None:
+        """None value in delta deletes key from existing settings.json."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'model': 'sonnet',
+            'permissions': {'allow': ['Read']},
+        }), encoding='utf-8')
+
+        result = setup_environment.write_profile_settings_to_settings(
+            {'model': None}, tmp_path,
+        )
+        assert result is True
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert 'model' not in content
+        # Unrelated key preserved
+        assert content['permissions'] == {'allow': ['Read']}
+
+    def test_none_value_delete_missing_key_is_noop(self, tmp_path: Path) -> None:
+        """Setting a nonexistent key to None is a silent no-op."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({'permissions': {'allow': ['Read']}}), encoding='utf-8')
+
+        result = setup_environment.write_profile_settings_to_settings(
+            {'model': None}, tmp_path,
+        )
+        assert result is True
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert content == {'permissions': {'allow': ['Read']}}
+
+    def test_malformed_existing_starts_fresh(self, tmp_path: Path) -> None:
+        """Malformed JSON in existing settings.json triggers fresh start."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text('not valid json{{{', encoding='utf-8')
+
+        result = setup_environment.write_profile_settings_to_settings(
+            {'model': 'sonnet'}, tmp_path,
+        )
+        assert result is True
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert content == {'model': 'sonnet'}
+
+    def test_non_dict_existing_starts_fresh(self, tmp_path: Path) -> None:
+        """Existing settings.json containing non-dict (e.g., list) starts fresh."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text('[1, 2, 3]', encoding='utf-8')
+
+        result = setup_environment.write_profile_settings_to_settings(
+            {'model': 'sonnet'}, tmp_path,
+        )
+        assert result is True
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert content == {'model': 'sonnet'}
+
+    def test_creates_parent_directory(self, tmp_path: Path) -> None:
+        """Writer creates settings_dir if it does not exist."""
+        target_dir = tmp_path / 'new_dir'
+        result = setup_environment.write_profile_settings_to_settings(
+            {'model': 'sonnet'}, target_dir,
+        )
+        assert result is True
+        assert (target_dir / 'settings.json').exists()
+
+
+class TestCreateProfileConfigDelegation:
+    """Regression tests verifying create_profile_config() delegates to builder."""
+
+    def test_output_matches_builder(self, tmp_path: Path) -> None:
+        """create_profile_config() output matches _build_profile_settings() result."""
+        # Setup
+        config_dir = tmp_path / 'profile'
+        hooks = {
+            'events': [
+                {'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'command', 'command': 'test.sh'},
+            ],
+        }
+
+        # Call create_profile_config (writes to config.json)
+        setup_environment.create_profile_config(
+            hooks=hooks,
+            config_base_dir=config_dir,
+            model='sonnet',
+            permissions={'allow': ['Read']},
+            env={'FOO': 'bar'},
+            always_thinking_enabled=True,
+            effort_level='high',
+        )
+        on_disk = json.loads((config_dir / 'config.json').read_text(encoding='utf-8'))
+
+        # Call builder directly (use same hooks dir create_profile_config would use)
+        expected = setup_environment._build_profile_settings(
+            hooks=hooks,
+            hooks_dir=config_dir / 'hooks',
+            model='sonnet',
+            permissions={'allow': ['Read']},
+            env={'FOO': 'bar'},
+            always_thinking_enabled=True,
+            effort_level='high',
+        )
+
+        # Must match
+        assert on_disk == expected
+
+
 class TestWriteMergedJson:
     """Tests for _write_merged_json helper function."""
 
@@ -9776,9 +10172,13 @@ class TestMainFunctionUserSettings:
         call_args = mock_write_user_settings.call_args
         assert call_args[0][0] == {'language': 'russian', 'model': 'claude-opus-4'}
 
-        # Verify output shows hooks skipped and command creation skipped
+        # Verify output shows hooks skipped and command creation skipped.
+        # In non-command-names mode, Step 17 skips the hooks download when
+        # nothing is configured, and Step 18 still announces the profile
+        # settings write step (the empty delta is a no-op for the writer).
         captured = capsys.readouterr()
-        assert 'Steps 17-18: Skipping hooks (none configured)' in captured.out
+        assert 'Step 17: Skipping hooks download (none configured)' in captured.out
+        assert 'Step 18: Writing profile settings to settings.json' in captured.out
         assert 'Steps 19-21: Skipping command creation (no command-names specified)' in captured.out
         assert 'Step 14: Writing user settings' in captured.out
 


### PR DESCRIPTION
Bring full feature parity between command-names-present (isolated) and command-names-absent (shared) modes for the 9 profile-owned keys: model, permissions, env, attribution, alwaysThinkingEnabled, effortLevel, companyAnnouncements, statusLine, and hooks.

Introduce a shared pure builder _build_profile_settings() consumed by both create_profile_config() (isolated mode, config.json atomic overwrite) and the new write_profile_settings_to_settings() (shared mode, ~/.claude/settings.json conditional top-level replace).

The non-isolated writer applies RFC 7396 null-as-delete semantics and preserves any keys not present in the profile delta, including Step 14 user-settings contributions and user-managed keys outside the YAML.

Add PROFILE_OWNED_KEYS as the canonical set of profile-owned camelCase keys and expand Step 17/18 in the non-command-names branch of main() to download hooks and status-line files and write the profile delta via the new writer.

Emit detect_settings_conflicts() warnings unconditionally in both modes with a root-level-value-takes-precedence message, add a hard error for profile-scoped mcp-servers missing command-names with a 4-option fix-up, and add a non-fatal warning when command-defaults.system-prompt is set without command-names.

Add new E2E coverage via tests/e2e/test_profile_settings_routing.py and tests/e2e/golden_config_no_command_names.yaml, plus unit tests for the pure builder, the conditional replace writer, and repeated-invocation semantics.

Update existing E2E hooks-routing tests and full-setup tests to reflect the new routing and step output, and document the three-writer architectural model, PROFILE_OWNED_KEYS and its complement relationship to user-settings as a forward-compatibility escape hatch, null-as-delete behavior at YAML root, kebab-to-camel translation rules, and the deferred stale-key preservation contract in docs/environment-configuration-guide.md.