### PR TITLE
Deep-merge profile-owned keys in shared settings.json

### DIFF
--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -837,7 +837,7 @@ user-settings:
 
 **Precedence rule for the 9 profile-owned keys:**
 
-If you declare a profile-owned key (e.g., `permissions`) at BOTH YAML root level AND under `user-settings:`, the **root-level value wins** because Step 18 `write_profile_settings_to_settings()` runs AFTER Step 14 `write_user_settings()` and performs a full top-level REPLACE (not a deep merge). A warning from `detect_settings_conflicts()` is emitted during validation to make the precedence explicit. The warning fires in BOTH command-names-present and command-names-absent modes.
+If you declare a profile-owned key (for example, `permissions`) at BOTH YAML root level AND under `user-settings:`, Step 18 `write_profile_settings_to_settings()` runs AFTER Step 14 `write_user_settings()` and deep-merges its delta on top of the Step 14 result. For scalar keys, the root-level value overwrites the `user-settings` value. For dict keys (such as `permissions`), the two contributions are deep-merged: sub-keys declared only on one side are preserved, sub-keys declared on both sides are resolved by the root-level value winning, and `permissions.allow/deny/ask` arrays are unioned (deduplicated) across both sources. A warning from `detect_settings_conflicts()` is emitted during validation to make the contract explicit. The warning fires in BOTH command-names-present and command-names-absent modes.
 
 **Why the two surfaces coexist:**
 
@@ -898,7 +898,12 @@ global-config:
 
 > **Warning:** Bare YAML keys with no value (`key:`) are equivalent to `key: null`. This means accidentally omitting a value will DELETE that key rather than set it to an empty string. Always use explicit values: `key: ""` for empty strings, `key: null` for intentional deletion.
 
-**Profile-owned keys in non-command-names mode:** The nine profile-owned keys (`model`, `permissions`, `env-variables`, `attribution`, `always-thinking-enabled`, `effort-level`, `company-announcements`, `status-line`, `hooks`) also support null-as-delete at the YAML root level via the [conditional top-level replace writer](#profile-level-settings-routing). Setting `model: null` at YAML root level deletes the `model` key from `~/.claude/settings.json`. OMITTING a profile-owned key from a subsequent YAML run does NOT delete it -- see [Deferred Stale-Key Behavior](#deferred-stale-key-behavior-user-facing-contract) for the intentional preservation contract.
+**Profile-owned keys in non-command-names mode:** The nine profile-owned keys (`model`, `permissions`, `env-variables`, `attribution`, `always-thinking-enabled`, `effort-level`, `company-announcements`, `status-line`, `hooks`) all support null-as-delete at the YAML root level via the deep-merge writer -- see [Profile-Level Settings Routing](#profile-level-settings-routing). Both top-level and nested nulls are covered end-to-end:
+
+- **Top-level null** (for example, `model: null`, `permissions: null`, `hooks: null`, `env-variables: null`): deletes the entire on-disk key from `~/.claude/settings.json`.
+- **Nested null** (for example, `permissions: {deny: null}`, `hooks: {PreToolUse: null}`): deletes only the nested sub-key while preserving the rest of the block (`permissions.allow`/`permissions.ask`, other hook event names).
+
+The dict-membership construction in the data flow from YAML root to the writer preserves the distinction between "declared with explicit null" and "absent from YAML" -- only the former triggers deletion. OMITTING a profile-owned key from a subsequent YAML run does NOT delete it; see [Deferred Stale-Key Behavior](#deferred-stale-key-behavior-user-facing-contract) for the intentional preservation contract.
 
 #### `company-announcements`
 
@@ -1194,16 +1199,16 @@ hooks:
 
 Hooks are routed to different target files based on whether `command-names` is specified. Both paths share the same pure builder `_build_hooks_json()` for the `hooks` key universe:
 
-| Scenario                | Target File                    | Write Mechanism                                                  | Hook Files Directory     |
-|-------------------------|--------------------------------|------------------------------------------------------------------|--------------------------|
-| `command-names` present | `~/.claude/{cmd}/config.json`  | `create_profile_config()` (atomic overwrite)                     | `~/.claude/{cmd}/hooks/` |
-| `command-names` absent  | `~/.claude/settings.json`      | `write_profile_settings_to_settings()` (top-level replace)       | `~/.claude/hooks/`       |
+| Scenario                | Target File                    | Write Mechanism                                        | Hook Files Directory     |
+|-------------------------|--------------------------------|--------------------------------------------------------|--------------------------|
+| `command-names` present | `~/.claude/{cmd}/config.json`  | `create_profile_config()` (atomic overwrite)           | `~/.claude/{cmd}/hooks/` |
+| `command-names` absent  | `~/.claude/settings.json`      | `write_profile_settings_to_settings()` (deep-merge)    | `~/.claude/hooks/`       |
 
-When `command-names` is absent, the setup writes hooks to the global `~/.claude/settings.json` via `write_profile_settings_to_settings()` as part of the 9-key `PROFILE_OWNED_KEYS` delta. The writer uses **conditional top-level replace** semantics: the existing file is read, the `hooks` top-level key is replaced entirely (removing stale events from prior runs), and all other keys -- including user-managed keys and other profile-owned keys not in the current delta -- are preserved. See [Profile-Level Settings Routing](#profile-level-settings-routing) for the full contract.
+When `command-names` is absent, the setup writes hooks to the global `~/.claude/settings.json` via `write_profile_settings_to_settings()` as part of the 9-key `PROFILE_OWNED_KEYS` delta. The writer delegates to `_write_merged_json()`, which deep-merges the `hooks` dict into the existing file: disjoint event names (in the delta but not on disk, and vice versa) compose additively, and overlapping event names have their per-event lists replaced at the leaf (because `hooks.{EventName}` is NOT in `DEFAULT_ARRAY_UNION_KEYS`). All other keys -- user-managed keys, other profile-owned keys not in the current delta, and Step 14 `user-settings` contributions -- are preserved. See [Profile-Level Settings Routing](#profile-level-settings-routing) for the full contract.
 
-**Re-run behavior:** The toolbox owns the `hooks` key in `settings.json`. Re-running the setup overwrites any manually-added hook events when the YAML re-declares `hooks` (top-level replace semantics). To configure hooks, define them in the YAML configuration rather than editing `settings.json` directly.
+**Re-run behavior:** When the YAML re-declares `hooks`, the deep-merge writer recurses into the existing `hooks` dict. Disjoint event names compose additively across runs. Overlapping event names have their per-event lists replaced at the leaf, so manually-added events under new event names survive, while manually-added events under event names that the YAML re-declares are replaced by the YAML's new entries. To fully clear stale events for a specific event name, either re-declare the event name with the desired list in YAML, or set `hooks: {EventName: null}` to delete just that event list.
 
-**Deleting hooks:** Setting `hooks: null` at YAML root level deletes the entire `hooks` key from `~/.claude/settings.json` via RFC 7396 null-as-delete. OMITTING `hooks` from a subsequent YAML run does NOT delete it (per [Deferred Stale-Key Behavior](#deferred-stale-key-behavior-user-facing-contract)); the prior-run `hooks` content is preserved.
+**Deleting hooks:** Setting `hooks: null` at YAML root level deletes the entire `hooks` key from `~/.claude/settings.json` via RFC 7396 null-as-delete. Setting `hooks: {EventName: null}` deletes just that event list while preserving the other events under `hooks`. OMITTING `hooks` entirely from a subsequent YAML run does NOT delete it (per [Deferred Stale-Key Behavior](#deferred-stale-key-behavior-user-facing-contract)); the prior-run `hooks` content is preserved.
 
 The installation summary distinguishes between the two routing targets:
 
@@ -1564,10 +1569,10 @@ When `claude-code-version` specifies a pinned version (any value other than `"la
 |--------------------|---------------------------|---------|---------------------------------------------------|-----------------------------------------------------|
 | `global-config`    | `autoUpdates`             | `false` | `~/.claude/{cmd}/.claude.json` + `~/.claude.json` | `~/.claude.json`                                    |
 | `user-settings`    | `env.DISABLE_AUTOUPDATER` | `"1"`   | `~/.claude/{cmd}/settings.json`                   | `~/.claude/settings.json`                           |
-| `env-variables`    | `DISABLE_AUTOUPDATER`     | `"1"`   | `~/.claude/{cmd}/config.json` (`env` key)         | `~/.claude/settings.json` (`env` key, top-replace)  |
+| `env-variables`    | `DISABLE_AUTOUPDATER`     | `"1"`   | `~/.claude/{cmd}/config.json` (`env` key)         | `~/.claude/settings.json` (`env` key, deep-merge)   |
 | `os-env-variables` | `DISABLE_AUTOUPDATER`     | `"1"`   | Shell profiles / Windows registry                 | Shell profiles / Windows registry                   |
 
-All four targets are injected unconditionally regardless of whether `command-names` is present. In isolated mode (`command-names` present), `env-variables` reaches `~/.claude/{cmd}/config.json` via `create_profile_config()` (Step 18). In non-isolated mode (`command-names` absent), `env-variables` is routed directly to `~/.claude/settings.json['env']` via `write_profile_settings_to_settings()` (Step 18) using conditional top-level replace semantics. Both Target 2 (`user-settings.env.DISABLE_AUTOUPDATER`) and Target 3 (`env-variables.DISABLE_AUTOUPDATER`) therefore reach the same on-disk `settings.json['env']` container in non-isolated mode -- Target 2 via Step 14 `write_user_settings()` deep-merge, Target 3 via Step 18 top-level replace. When YAML has NO root-level `env-variables`, Step 18 omits `env` from its delta and the Target 2 Step 14 contribution SURVIVES Step 18's preservation invariant (see [Profile-Level Settings Routing](#profile-level-settings-routing)).
+All four targets are injected unconditionally regardless of whether `command-names` is present. In isolated mode (`command-names` present), `env-variables` reaches `~/.claude/{cmd}/config.json` via `create_profile_config()` (Step 18). In non-isolated mode (`command-names` absent), `env-variables` is routed to `~/.claude/settings.json['env']` via `write_profile_settings_to_settings()` (Step 18), which deep-merges the delta into the existing file. Both Target 2 (`user-settings.env.DISABLE_AUTOUPDATER`, written in Step 14) and Target 3 (`env-variables.DISABLE_AUTOUPDATER`, written in Step 18) therefore reach the same on-disk `settings.json['env']` container in non-isolated mode, and deep-merge makes them additive: the Step 14 contribution survives the Step 18 write because `_merge_recursive()` recurses into the `env` dict and preserves sub-keys not present in the delta. When YAML has NO root-level `env-variables`, Step 18 omits `env` from its delta and the Target 2 Step 14 contribution also survives -- unrelated keys to the delta are preserved (see [Profile-Level Settings Routing](#profile-level-settings-routing)).
 
 #### Removal Behavior
 
@@ -1615,10 +1620,10 @@ This feature mirrors the [Automatic Auto-Update Management](#automatic-auto-upda
 |--------------------|-----------------------------------------|---------|---------------------------------------------------|-----------------------------------------------------|
 | `global-config`    | `autoInstallIdeExtension`               | `false` | `~/.claude/{cmd}/.claude.json` + `~/.claude.json` | `~/.claude.json`                                    |
 | `user-settings`    | `env.CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL` | `"1"`   | `~/.claude/{cmd}/settings.json`                   | `~/.claude/settings.json`                           |
-| `env-variables`    | `CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL`     | `"1"`   | `~/.claude/{cmd}/config.json` (`env` key)         | `~/.claude/settings.json` (`env` key, top-replace)  |
+| `env-variables`    | `CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL`     | `"1"`   | `~/.claude/{cmd}/config.json` (`env` key)         | `~/.claude/settings.json` (`env` key, deep-merge)   |
 | `os-env-variables` | `CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL`     | `"1"`   | Shell profiles / Windows registry                 | Shell profiles / Windows registry                   |
 
-All four targets are injected unconditionally regardless of whether `command-names` is present, consistent with auto-update management behavior. In non-isolated mode, `env-variables` reaches `~/.claude/settings.json['env']` via conditional top-level replace (identical routing to auto-update Target 3).
+All four targets are injected unconditionally regardless of whether `command-names` is present, consistent with auto-update management behavior. In non-isolated mode, `env-variables` reaches `~/.claude/settings.json['env']` via the deep-merge writer (`write_profile_settings_to_settings()`), identical routing to auto-update Target 3. Deep-merge recurses into the `env` dict so that the injected IDE control coexists with any user-declared environment variables in the same on-disk container.
 
 #### Removal Behavior
 
@@ -1726,7 +1731,7 @@ Here is a conceptual overview of what the setup script does when you run it with
 15. **Write global config** -- Merges `global-config` into `~/.claude.json`.
 16. **Cleanup stale controls** -- Sweeps all filesystem locations for stale auto-update and IDE extension artifacts from prior configurations.
 17. **Download hooks** -- Downloads hook script files to `~/.claude/{cmd}/hooks/` (with `command-names`) or `~/.claude/hooks/` (without). In non-command-names mode, Step 17 runs when ANY of the following are declared: `hooks.events` non-empty, `hooks.files` non-empty, or `status-line.file` set.
-18. **Write profile settings** -- Writes all nine profile-owned keys (`model`, `permissions`, `env`, `attribution`, `alwaysThinkingEnabled`, `effortLevel`, `companyAnnouncements`, `statusLine`, `hooks`) as camelCase keys on disk. With `command-names`: writes to `~/.claude/{cmd}/config.json` via `create_profile_config()` (atomic overwrite -- fresh dict each run). Without `command-names`: writes to `~/.claude/settings.json` via `write_profile_settings_to_settings()` using **conditional top-level replace semantics** (preserves non-delta keys; see [Profile-Level Settings Routing](#profile-level-settings-routing)).
+18. **Write profile settings** -- Writes all nine profile-owned keys (`model`, `permissions`, `env`, `attribution`, `alwaysThinkingEnabled`, `effortLevel`, `companyAnnouncements`, `statusLine`, `hooks`) as camelCase keys on disk. With `command-names`: writes to `~/.claude/{cmd}/config.json` via `create_profile_config()` (atomic overwrite -- fresh dict each run). Without `command-names`: writes to `~/.claude/settings.json` via `write_profile_settings_to_settings()`, which delegates to `_write_merged_json()` for **deep-merge, array-union for `permissions.allow/deny/ask`, and RFC 7396 null-as-delete** (preserves non-delta keys; see [Profile-Level Settings Routing](#profile-level-settings-routing)).
 19. **Write manifest** -- Creates an installation tracking manifest. (Only if `command-names` is specified.)
 20. **Create launcher** -- Creates the launcher script for the command. (Only if `command-names` is specified.)
 21. **Register commands** -- Creates global command wrappers. (Only if `command-names` is specified.)
@@ -1739,7 +1744,7 @@ The setup script supports two modes of profile-settings routing, controlled by t
 
 ### Profile-Owned Keys
 
-Nine YAML root-level keys are **profile-owned** -- they are written to disk by the profile-settings subsystem (`_build_profile_settings()` builder + one of two writers):
+Nine YAML root-level keys are **profile-owned** -- they are extracted from YAML root, translated to camelCase, and written to disk by the profile-settings subsystem (`_build_profile_settings()` builder + one of two writers):
 
 | YAML root key (kebab-case)    | On-disk key (camelCase)   |
 |-------------------------------|---------------------------|
@@ -1753,7 +1758,7 @@ Nine YAML root-level keys are **profile-owned** -- they are written to disk by t
 | `status-line`                 | `statusLine`              |
 | `hooks`                       | `hooks`                   |
 
-The shared pure builder `_build_profile_settings()` performs kebab-to-camel translation and delegates to `_build_hooks_json()` for the `hooks` universe. The 9-key set is declared as `PROFILE_OWNED_KEYS` (a `frozenset`) in `scripts/setup_environment.py`. These keys are distinct from `USER_SETTINGS_EXCLUDED_KEYS = {'hooks', 'statusLine'}`, which is NOT extended to cover all 9 profile-owned keys -- `user-settings` remains a free-form pass-through for forward compatibility (see [Relationship to Profile-Owned Keys](#relationship-to-profile-owned-keys)).
+The shared pure builder `_build_profile_settings()` performs kebab-to-camel translation (for nested keys like `permissions.default-mode` -> `permissions.defaultMode`) and delegates to `_build_hooks_json()` for the `hooks` universe. The 9-key set is declared as `PROFILE_OWNED_KEYS` (a `frozenset`) in `scripts/setup_environment.py`, and the mapping of YAML kebab-case root keys to camelCase on-disk names is declared as the module-level constant `_YAML_TO_CAMEL_PROFILE_KEYS`. These keys are distinct from `USER_SETTINGS_EXCLUDED_KEYS = {'hooks', 'statusLine'}`, which remains intentionally narrow because `user-settings` must accept arbitrary Claude Code CLI `settings.json` keys for forward compatibility (see [Relationship to Profile-Owned Keys](#relationship-to-profile-owned-keys)).
 
 ### Isolated Mode (command-names present)
 
@@ -1768,56 +1773,95 @@ The launcher script passes `config.json` via the `--settings` flag and sets `CLA
 
 ### Non-Isolated Mode (command-names absent)
 
-When `command-names` is ABSENT, the setup writes to the shared `~/.claude/` directory. BOTH Step 14 and Step 18 target the SAME file (`~/.claude/settings.json`) but with strict step ordering and distinct merge semantics:
+When `command-names` is ABSENT, the setup writes to the shared `~/.claude/` directory. BOTH Step 14 and Step 18 target the SAME file (`~/.claude/settings.json`) and BOTH use the same READ-MERGE-WRITE contract inherited from `_write_merged_json()`:
 
-| File                       | Content                                            | Writer                                  | Step | Semantics                                              |
-|----------------------------|----------------------------------------------------|-----------------------------------------|------|--------------------------------------------------------|
-| `~/.claude/settings.json`  | YAML `user-settings:` (all non-excluded keys)      | `write_user_settings()`                 | 14   | Deep merge + array-union + RFC 7396 null-as-delete     |
-| `~/.claude/settings.json`  | 9 `PROFILE_OWNED_KEYS` delta from YAML root        | `write_profile_settings_to_settings()`  | 18   | Conditional top-level replace                          |
+| File                       | Content                                            | Writer                                  | Step | Semantics                                                                          |
+|----------------------------|----------------------------------------------------|-----------------------------------------|------|------------------------------------------------------------------------------------|
+| `~/.claude/settings.json`  | YAML `user-settings:` (all non-excluded keys)      | `write_user_settings()`                 | 14   | Deep merge + array-union (`permissions.allow/deny/ask`) + RFC 7396 null-as-delete  |
+| `~/.claude/settings.json`  | 9 `PROFILE_OWNED_KEYS` delta from YAML root        | `write_profile_settings_to_settings()`  | 18   | Deep merge + array-union (`permissions.allow/deny/ask`) + RFC 7396 null-as-delete  |
 
-1. **Step 14** deep-merges `user-settings:` into `settings.json`. Existing keys are preserved; merged keys are overridden by the new YAML values; `permissions.allow/deny/ask` arrays are unioned with deduplication; `null` values delete keys via RFC 7396.
-2. **Step 18** applies the profile delta: for each key in the builder delta, REPLACE the entire top-level key value (or DELETE if explicitly `None`). Keys NOT in the delta are PRESERVED.
+1. **Step 14** deep-merges `user-settings:` into `settings.json`. Existing keys are preserved; for leaf conflicts the new YAML values overwrite the existing values; `permissions.allow/deny/ask` arrays are unioned with deduplication; `null` values delete keys via RFC 7396.
+2. **Step 18** deep-merges the profile delta into the same file using the same semantics. Existing keys not in the delta are preserved; existing nested dicts are recursively merged with the delta (leaf conflicts resolved by the delta winning, array-union for `permissions.allow/deny/ask`); top-level or nested `null` in the delta deletes keys.
 
-This preserves the Step 14 contributions (and any user-managed keys outside the YAML) and ensures the shared `settings.json` is never scrubbed of keys the current YAML does not declare.
+Under this contract, the shared `~/.claude/settings.json` is never scrubbed of keys the current YAML does not declare, and contributions from manual user edits, other YAML configurations, the Claude Code CLI itself, and `user-settings.permissions` at Step 14 all survive profile-settings writes at Step 18.
 
 ### Write Semantics Contract
 
-**Design principle:** `~/.claude/settings.json` is a SHARED/COMMON user-facing file, NOT an isolated profile. The toolbox must NOT scrub or delete existing keys merely because the YAML does not declare them. Unexpected deletion of settings the user did not intend to remove is explicitly prohibited.
+**Design principle:** `~/.claude/settings.json` is a SHARED/COMMON user-facing file. The toolbox treats it as a collaborative surface: other writers (the user, the CLI, other YAML configurations) contribute keys the current run knows nothing about, and the profile-settings writer preserves those contributions while still allowing explicit deletion via YAML-level null.
 
-`write_profile_settings_to_settings()` implements three branches for each key in the profile delta:
+`write_profile_settings_to_settings()` delegates to `_write_merged_json()`, which implements the three-step READ-MERGE-WRITE process:
 
-| Branch | YAML root state                         | Builder delta   | On-disk effect                                                          |
-|--------|-----------------------------------------|-----------------|-------------------------------------------------------------------------|
-| 1      | Key present with non-null value         | `{key: value}`  | **REPLACE** entire top-level value (no deep merge, no array-union)      |
-| 2      | Key present with explicit `null` value  | `{key: None}`   | **DELETE** key from file (RFC 7396 null-as-delete via `existing.pop()`) |
-| 3      | Key absent from YAML root               | `{}` (omitted)  | **PRESERVE** existing value unchanged                                   |
+1. **READ** the existing `~/.claude/settings.json` (or start fresh with an empty dict if the file is missing, malformed, or has a non-dict top-level value; a warning is emitted in those cases).
+2. **DEEP MERGE** the builder delta into the existing content via `_merge_recursive()`, which handles:
+   - **Deep recursion** into nested dicts (for example, a delta `permissions: {default-mode: ask}` updates only the `defaultMode` sub-key of `permissions`, leaving `permissions.allow`, `permissions.deny`, and `permissions.ask` intact if not in the delta).
+   - **Array union** at `DEFAULT_ARRAY_UNION_KEYS` paths (`permissions.allow`, `permissions.deny`, `permissions.ask`) -- existing and new arrays are combined, order-preserving, with duplicate elements removed.
+   - **RFC 7396 null-as-delete**: any value of `None` in the delta (top-level or nested) deletes the corresponding key from the target via `target.pop(key, None)`.
+   - **Scalar overwrite** on leaf conflicts (new value wins).
+3. **WRITE** the merged result back to disk with a trailing newline for file-format consistency.
 
-The builder `_build_profile_settings()` OMITS `None` inputs from its returned dict by default -- this means that when you OMIT a key from YAML, it is not represented in the delta at all (branch 3, preserve). To trigger branch 2 (explicit delete), construct the delta directly in code or -- at the YAML level -- set the key to `null` (the merge/validation layers translate this to an explicit `None` passed to the writer for the profile-owned keys that support it).
+The builder `_build_profile_settings()` accepts a `profile_config` dict keyed by the camelCase on-disk names; dict membership encodes the YAML declaration state (present-with-value, present-with-null, or absent) end-to-end so that the downstream writer can apply RFC 7396 null-as-delete to the shared `settings.json` for both top-level and nested YAML nulls. `main()` constructs `profile_config` with a comprehension that iterates `_YAML_TO_CAMEL_PROFILE_KEYS` and includes a key when `yaml_key in config`, which preserves the distinction between "absent from YAML" (key omitted from `profile_config`, on-disk value preserved) and "declared with explicit null" (`profile_config[camel_key] = None`, on-disk value deleted).
+
+**Three merge cases for each key in the delta:**
+
+| Case                       | Builder output            | Writer on-disk effect                                                              |
+|----------------------------|---------------------------|------------------------------------------------------------------------------------|
+| YAML declares `key: value` | `{'key': value}` in delta | Deep-merge new value into existing (leaf wins; permissions.allow/deny/ask unioned) |
+| YAML declares `key: null`  | `{'key': None}` in delta  | DELETE the key from the file (RFC 7396 null-as-delete)                             |
+| YAML omits `key`           | key is absent from delta  | PRESERVE existing value unchanged (writer leaves keys outside its delta intact)    |
+
+**Null-as-delete is supported for all nine profile-owned keys**, both at the top level (`model: null`, `permissions: null`, `hooks: null`, ...) and nested (`permissions: {deny: null}`, `hooks: {PreToolUse: null}`, ...). The top-level and nested cases go through the same `_merge_recursive()` path inside the writer; the top-level path additionally requires the dict-membership threading in `profile_config` to survive main()'s YAML extraction.
 
 **Preservation coverage (what survives profile-settings writes):**
 
-Keys NOT present in the delta are preserved in `~/.claude/settings.json`. This covers:
+Keys absent from the delta are preserved in `~/.claude/settings.json`. This covers:
 
-- Prior-run contributions from `write_profile_settings_to_settings()` itself.
+- Prior contributions from `write_profile_settings_to_settings()` itself across other YAML configurations.
 - Deep-merged contributions from Step 14 `write_user_settings()` (including `user-settings.permissions.allow/deny/ask` array-unions and any free-form `user-settings` keys).
-- User-managed keys outside the toolbox's YAML schema (e.g., `includeGitInstructions`, `apiKeyHelper`, `cleanupPeriodDays`, `outputStyle`, `autoMemoryDirectory`, `sandbox.*`).
-- Auto-injected `env.DISABLE_AUTOUPDATER` (auto-update Target 2) and `env.CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL` (IDE extension Target 2) controls written via `user-settings.env` when YAML has no root-level `env-variables`. In that case, Step 18's builder omits `env` entirely from the delta, and the Step 14 contributions SURVIVE.
+- User-managed keys outside the toolbox's YAML schema (for example, `includeGitInstructions`, `apiKeyHelper`, `cleanupPeriodDays`, `outputStyle`, `autoMemoryDirectory`, `sandbox.*`).
+- Auto-injected `env.DISABLE_AUTOUPDATER` (auto-update Target 2) and `env.CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL` (IDE extension Target 2) controls: because deep-merge recurses into the `env` dict, the injected controls coexist with any user-declared environment variables. When the YAML declares its own `env-variables`, the delta's new env keys are deep-merged on top of the existing env dict rather than replacing it, so the Step 14 Target 2 contributions survive.
 
-**Empty-delta no-op:** If no profile-owned keys are declared at YAML root level, the builder returns `{}` and `write_profile_settings_to_settings()` performs ZERO file I/O -- it neither creates nor touches `~/.claude/settings.json`. A YAML with only `user-settings:`, `global-config:`, `agents:`, etc. will never have Step 18 modify `settings.json`.
+**Empty-delta no-op:** If no profile-owned keys are declared at YAML root level, the builder returns `{}` and `write_profile_settings_to_settings()` performs ZERO file I/O -- it neither creates nor touches `~/.claude/settings.json`. A YAML with only `user-settings:`, `global-config:`, `agents:`, and so on will never have Step 18 modify `settings.json`.
 
-**Malformed or non-dict existing content:** If `~/.claude/settings.json` contains invalid JSON, unreadable content, or a non-dict top-level value (e.g., a bare list), the writer emits a warning (`"Existing ... is not a dict, starting fresh"` or `"Invalid JSON in ..."`) and starts fresh (treats `existing` as `{}`). The written file ends with a trailing newline for file-format consistency with `write_hooks_to_settings()`.
+**Malformed or non-dict existing content:** If `~/.claude/settings.json` contains invalid JSON, unreadable content, or a non-dict top-level value (for example, a bare list), `_write_merged_json()` emits a warning (`"Existing ... is not a dict, starting fresh"` or `"Invalid JSON in ..."`) and starts fresh (treats the existing content as `{}`). The written file ends with a trailing newline for file-format consistency with `write_user_settings()` and `write_global_config()`.
+
+### Null-as-Delete for Profile-Owned Keys (YAML contract)
+
+All nine profile-owned keys support null-as-delete at the YAML root level in non-command-names mode. Examples:
+
+```yaml
+# Delete the entire permissions block (including allow, deny, ask)
+permissions: null
+
+# Delete just the deny sub-key (keep allow and ask)
+permissions:
+    deny: null
+
+# Delete the model, env, and hooks top-level keys in one YAML
+model: null
+env-variables: null
+hooks: null
+```
+
+**Top-level null vs nested null:**
+
+- **Top-level null** (for example, `model: null`): the entire top-level key is removed from `~/.claude/settings.json` via `existing.pop('model', None)`.
+- **Nested null** (for example, `permissions: {deny: null}`): deep-merge recurses into the `permissions` dict, and the `deny` sub-key is removed while other sub-keys (`allow`, `ask`, and so on) are preserved.
+
+Both cases are handled by `_merge_recursive()` inside `_write_merged_json()`. The top-level case additionally requires the dict-membership construction in `main()` and the builder so that the profile_config can carry `None` for top-level YAML nulls -- a plain `config.get('model')` would otherwise erase the distinction between "absent" and "null".
+
+**Re-run semantics:** After `model: null` has been applied, removing the `model: null` line from the YAML (so the key is absent) in a later run preserves the `model` key's then-current state (which is "absent from settings.json", unchanged by the new no-op delta). There is no auto-undelete -- once deleted, a key stays deleted until a subsequent YAML explicitly re-declares it with a non-null value.
 
 ### Deferred Stale-Key Behavior (User-Facing Contract)
 
 This is an INTENTIONAL user-facing contract, not a bug. Understanding this behavior is critical to using `command-names`-absent mode correctly.
 
-**Scenario:** You had `permissions: {allow: [Read]}` at YAML root in a previous setup run. You then remove the entire `permissions` block from your YAML and re-run setup.
+**Scenario:** You had `permissions: {allow: [Read]}` at YAML root in one setup run. You then remove the entire `permissions` block from your YAML and re-run setup.
 
-**Result:** The `permissions` key in `~/.claude/settings.json` RETAINS its previous value (`{allow: [Read]}`). It is NOT deleted.
+**Result:** The `permissions` key in `~/.claude/settings.json` retains its existing on-disk value (`{allow: [Read]}`). It is NOT deleted.
 
 **Why:** `~/.claude/settings.json` is a shared file. Removing a key from YAML is NOT a sufficient signal for the toolbox to delete that key from the shared file, because:
 
-1. The key might have been set by a previous toolbox run with a different YAML.
+1. The key might have been set by a setup run that used a different YAML configuration.
 2. The key might have been set manually by the user or by another tool.
 3. The key might have been set by a teammate's YAML that is managed separately.
 4. The profile-settings writer has no state-tracking sidecar to distinguish keys it wrote in prior runs from user-managed keys.
@@ -1828,16 +1872,23 @@ This is an INTENTIONAL user-facing contract, not a bug. Understanding this behav
    ```yaml
    permissions: null        # Delete entire permissions block from settings.json
    model: null              # Delete model key
-   hooks: null              # Delete hooks block (but see note below)
+   hooks: null              # Delete hooks block
    env-variables: null      # Delete env block from settings.json
+   permissions:
+       deny: null           # Delete only the deny sub-key (keep allow/ask)
    ```
 2. **Manually delete the key** from `~/.claude/settings.json` using a text editor.
 
-Automated YAML-removal-triggered cleanup (a state-tracking sidecar approach, e.g., `~/.claude/toolbox-managed-keys.json` recording which keys the toolbox wrote in the last run) is not implemented. The preservation behavior is the intended design.
+Automated YAML-removal-triggered cleanup (a state-tracking sidecar approach, for example `~/.claude/toolbox-managed-keys.json` recording which keys the toolbox wrote in the last run) is not implemented. The preservation behavior is the intended design.
 
-**Security implication for `permissions.deny`:** If you previously declared `permissions.deny: ['Bash(rm -rf)']` at YAML root and then remove `permissions:` from YAML, the deny rule REMAINS in `~/.claude/settings.json`. This is the INTENDED behavior: removing security rules from YAML should NOT silently remove them from the shared file. If you want to remove deny rules, you must either explicitly set `permissions: {deny: []}` or `permissions: null`, or edit the file manually.
+**Security framing: preventing silent destruction of `permissions.deny`.** Deep-merge with `DEFAULT_ARRAY_UNION_KEYS` array-union for `permissions.allow/deny/ask` is the core mechanism that prevents silent destruction of security rules in the shared `~/.claude/settings.json`. A narrower YAML declaration such as `permissions: {allow: [Read]}` MUST NOT remove `permissions.deny` entries contributed by other writers (manual user edits, the Claude Code CLI, teammate YAMLs, or `user-settings.permissions.deny` at Step 14). Under the unified deep-merge + array-union contract, deny entries accumulate additively across runs and explicit null is the only way to shrink them:
 
-**Note on `hooks` deletion:** Because Step 18 performs top-level replace, setting `hooks: null` at YAML root deletes the entire `hooks` key. Removing individual hook entries requires re-declaring the full `hooks` block with the entries you want to keep.
+- To remove ALL deny entries: `permissions: {deny: null}` (nested null deletes just the `deny` sub-key) or `permissions: null` (top-level null deletes the entire `permissions` block).
+- To remove a specific deny entry: edit `~/.claude/settings.json` manually, because array-union only grows arrays -- declaring `permissions: {deny: [X]}` in YAML will union `[X]` with the existing deny list, not replace it.
+
+Any deny rule preserved on disk is the combined contribution of all writers; losing rules silently on re-run would be a critical security regression, so the toolbox instead requires explicit null to delete them.
+
+**Note on `hooks` deletion:** Setting `hooks: null` at YAML root deletes the entire `hooks` key from `~/.claude/settings.json`. Setting `hooks: {EventName: null}` deletes only that event list while preserving other event names. Because `hooks.{EventName}` is NOT in `DEFAULT_ARRAY_UNION_KEYS`, per-event lists are replaced (not unioned) when both the existing file and the delta declare the same event. Disjoint event names compose additively across the merge.
 
 ### Profile-Scoped MCP Servers in Non-Command-Names Mode (ERROR)
 
@@ -1880,13 +1931,15 @@ Unlike profile-scoped MCP servers (which are a hard error because silently-dropp
 [WARN] Key 'model' specified in both root level and user-settings.
 [WARN]   user-settings value: claude-opus-4
 [WARN]   root-level value: claude-sonnet-4
-[WARN]   Root-level value takes precedence (written last in Step 18).
+[WARN]   Under deep merge semantics, root-level values overwrite user-settings values for scalar keys.
+[WARN]   For dict keys, user-settings and root-level values are deep-merged; for
+[WARN]   permissions.allow/deny/ask, array union applies.
 ```
 
-**Why root-level wins (in both modes):**
+**How the two contributions compose (in both modes):**
 
-- **Isolated mode:** Step 14 writes `user-settings:` to `~/.claude/{cmd}/settings.json` (priority 5), Step 18 writes the profile delta to `~/.claude/{cmd}/config.json` (priority 2). The CLI's native `flagSettings > userSettings` resolution means `config.json` wins at runtime.
-- **Non-isolated mode:** Step 14 writes `user-settings:` to `~/.claude/settings.json` via deep-merge, Step 18 writes the profile delta to the SAME file via top-level replace. Step 18 writes last, so its REPLACE overwrites the Step 14 merge result for the overlapping profile-owned key.
+- **Isolated mode:** Step 14 writes `user-settings:` to `~/.claude/{cmd}/settings.json` (priority 5), Step 18 writes the profile delta to `~/.claude/{cmd}/config.json` (priority 2). The CLI's native `flagSettings > userSettings` resolution means `config.json` wins over `settings.json` at runtime for overlapping keys.
+- **Non-isolated mode:** Step 14 writes `user-settings:` to `~/.claude/settings.json` via deep-merge, then Step 18 deep-merges the profile delta into the same file. For scalar keys, the root-level value overwrites the `user-settings` value. For dict keys, the two contributions are deep-merged: sub-keys declared only on one side are preserved, sub-keys declared on both sides are resolved by the root-level (Step 18) value winning, and `permissions.allow/deny/ask` arrays are unioned across both steps via `DEFAULT_ARRAY_UNION_KEYS`.
 
 The conflict warning ensures users are informed regardless of which mode they use.
 
@@ -1896,9 +1949,9 @@ The conflict warning ensures users are informed regardless of which mode they us
 |----------------------------------------|------------------------------|--------------------------------------------------------------|-------------------------------------------|------------------------------------------------------------------------------------|---------------------|
 | `write_user_settings()`                | `user-settings:`             | `~/.claude/settings.json` OR `~/.claude/{cmd}/settings.json` | ~58 non-excluded CLI keys                 | Deep merge + array-union (`permissions.allow/deny/ask`) + RFC 7396 null-as-delete  | 14                  |
 | `create_profile_config()`              | YAML root profile keys       | `~/.claude/{cmd}/config.json`                                | 9 `PROFILE_OWNED_KEYS`                    | Atomic overwrite (fresh dict each run)                                             | 18 (isolated)       |
-| `write_profile_settings_to_settings()` | YAML root profile keys       | `~/.claude/settings.json`                                    | 9 `PROFILE_OWNED_KEYS` delta              | Conditional top-level replace                                                      | 18 (non-isolated)   |
+| `write_profile_settings_to_settings()` | YAML root profile keys       | `~/.claude/settings.json`                                    | 9 `PROFILE_OWNED_KEYS` delta              | Deep merge + array-union (`permissions.allow/deny/ask`) + RFC 7396 null-as-delete  | 18 (non-isolated)   |
 
-Both Step 18 writers are fed by the shared pure builder `_build_profile_settings()`, which translates kebab-case YAML keys to camelCase JSON keys and delegates to `_build_hooks_json()` for hook events. `create_profile_config()` is a thin wrapper that delegates to the pure builder and atomically writes `config.json`; its output dict is identical to what the builder returns for the same inputs.
+All three shared-file writers (`write_user_settings()`, `write_global_config()`, `write_profile_settings_to_settings()`) delegate to the same `_write_merged_json()` helper, which gives them a single unified deep-merge contract. Both Step 18 writers (`create_profile_config()` and `write_profile_settings_to_settings()`) are fed by the shared pure builder `_build_profile_settings()`, which accepts a `profile_config` dict, translates kebab-case YAML keys to camelCase JSON keys, and delegates to `_build_hooks_json()` for hook events. In isolated mode, `create_profile_config()` atomically rewrites `~/.claude/{cmd}/config.json` from scratch on each run (fully toolbox-owned). In non-isolated mode, `write_profile_settings_to_settings()` deep-merges its delta into the shared `~/.claude/settings.json`, preserving contributions from other writers.
 
 ## Complete Annotated Example
 

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -207,9 +207,12 @@ ROOT_TO_USER_SETTINGS_KEY_MAP: dict[str, str] = {
 # which performs kebab-to-camel translation. Values below are the POST-TRANSLATION
 # camelCase keys as they appear in settings.json / config.json on disk.
 #
-# In non-isolated mode, write_profile_settings_to_settings() performs a
-# conditional top-level replace for only the keys present in the builder
-# delta. Keys not declared at YAML root level are PRESERVED in
+# In non-isolated mode, write_profile_settings_to_settings() deep-merges the
+# builder's delta into the shared ~/.claude/settings.json via
+# _write_merged_json(), inheriting: deep-merge for nested dicts, array-union
+# for permissions.allow/deny/ask, RFC 7396 null-as-delete for top-level and
+# nested None values, and preservation for keys omitted from the delta.
+# Keys not declared at YAML root level are PRESERVED in
 # ~/.claude/settings.json (unchanged by this writer), including any
 # prior-run contributions and any keys written by Step 14
 # write_user_settings() under user-settings:.
@@ -224,6 +227,33 @@ PROFILE_OWNED_KEYS: frozenset[str] = frozenset({
     'statusLine',
     'hooks',
 })
+
+# Mapping from YAML root kebab-case key names to their on-disk camelCase
+# equivalents for the 9 profile-owned keys. Used by main() to build the
+# profile_config dict passed to _build_profile_settings(): dict membership
+# encodes the "declared-vs-absent" distinction (which is lost by
+# config.get() alone), and a YAML-level `model: null` declaration passes
+# through as `profile_config['model'] = None`, which the builder forwards
+# to the writer so _write_merged_json() can apply RFC 7396 null-as-delete
+# to the shared settings.json.
+#
+# The mapping order matches PROFILE_OWNED_KEYS for visual clarity. It is
+# SEPARATE from ROOT_TO_USER_SETTINGS_KEY_MAP (which covers 7 keys and
+# drives detect_settings_conflicts()): this map intentionally includes
+# `status-line` and `hooks` because they are profile-owned keys that
+# participate in the null-as-delete contract even though they are
+# excluded from the user-settings conflict surface.
+_YAML_TO_CAMEL_PROFILE_KEYS: dict[str, str] = {
+    'model': 'model',
+    'permissions': 'permissions',
+    'env-variables': 'env',
+    'attribution': 'attribution',
+    'always-thinking-enabled': 'alwaysThinkingEnabled',
+    'effort-level': 'effortLevel',
+    'company-announcements': 'companyAnnouncements',
+    'status-line': 'statusLine',
+    'hooks': 'hooks',
+}
 
 
 # Platform-specific imports with proper type checking support
@@ -8422,41 +8452,43 @@ def write_profile_settings_to_settings(
     settings_delta: dict[str, Any],
     settings_dir: Path,
 ) -> bool:
-    """Write profile-owned settings delta to ~/.claude/settings.json.
+    """Deep-merge profile-owned settings delta into ~/.claude/settings.json.
 
-    Applies a conditional top-level replace to the shared settings.json
-    file used by the non-command-names mode:
+    The shared ~/.claude/settings.json is a user-facing file written to by
+    the toolbox, the Claude Code CLI, prior toolbox runs with other YAMLs,
+    and (optionally) direct user edits. The writer MUST preserve any key
+    outside the current delta. It MUST NOT destroy nested sub-keys that
+    other contributors supplied. And it MUST honor RFC 7396 null-as-delete
+    so that users can explicitly remove keys via YAML-level null.
 
-    - READS existing settings.json (or starts from empty dict if missing).
-    - For each top-level key in settings_delta:
-        - If value is None: DELETE the key from the existing dict
-          (RFC 7396 null-as-delete semantics).
-        - Otherwise: REPLACE the entire top-level key value with the delta
-          value (no deep-merge, no array-union at this level).
-    - Keys NOT present in settings_delta are PRESERVED unchanged. This is
-      the core preservation guarantee: when YAML omits a profile-owned
-      key, the corresponding key in ~/.claude/settings.json is left
-      alone. The shared settings.json is a user-facing file that may
-      contain manually-edited entries or contributions from other tools;
-      this writer must not delete keys it was not asked to touch.
+    Delegates to ``_write_merged_json()`` to inherit all three semantics
+    from the same helper that powers ``write_user_settings()`` and
+    ``write_global_config()``:
 
-    The delta is expected to be the output of _build_profile_settings(),
-    which contains only the keys explicitly declared at YAML root level
-    (PROFILE_OWNED_KEYS subset).
+    - Deep-merge for nested dicts (dispatched per-key to ``_merge_recursive()``).
+    - Array-union for ``permissions.allow/deny/ask`` (default ``DEFAULT_ARRAY_UNION_KEYS``).
+    - RFC 7396 null-as-delete for any key whose value is ``None`` (top-level or nested).
+    - Preservation for keys omitted from ``settings_delta``.
+
+    The delta is expected to be the output of ``_build_profile_settings()``,
+    which contains one entry per YAML-declared profile-owned key (value
+    for present-with-value keys, ``None`` for present-with-null keys, no
+    entry for absent keys).
 
     IMPORTANT: This function is called ONLY in non-command-names mode. In
-    command-names mode, profile settings are routed to config.json via
-    create_profile_config() with atomic overwrite semantics.
+    command-names mode, profile settings are routed to the isolated
+    ~/.claude/{cmd}/config.json via ``create_profile_config()`` with
+    atomic overwrite semantics (isolated config is fully toolbox-owned).
 
     Args:
         settings_delta: Dict of profile-owned keys to write (output of
-            _build_profile_settings()). May be empty, in which case no
-            file I/O occurs and the function returns True.
+            ``_build_profile_settings()``). May be empty, in which case no
+            file I/O occurs and the function returns ``True``.
         settings_dir: Directory containing settings.json (typically
             ~/.claude/).
 
     Returns:
-        True if the file was written successfully or no-op (empty delta),
+        True on successful write or no-op (empty delta),
         False on read or write failure.
     """
     if not settings_delta:
@@ -8466,228 +8498,247 @@ def write_profile_settings_to_settings(
     settings_file = settings_dir / 'settings.json'
     info('Writing profile settings to settings.json...')
 
-    # Read existing settings.json (or empty dict if missing / malformed)
-    existing: dict[str, Any] = {}
-    if settings_file.exists():
-        try:
-            file_content = settings_file.read_text(encoding='utf-8')
-            if file_content.strip():
-                parsed = json.loads(file_content)
-                if isinstance(parsed, dict):
-                    existing = parsed
-                else:
-                    warning(f'Existing {settings_file} is not a dict, starting fresh')
-        except json.JSONDecodeError as e:
-            warning(f'Invalid JSON in {settings_file}: {e}, starting fresh')
-        except OSError as e:
-            warning(f'Failed to read {settings_file}: {e}, starting fresh')
+    # Delegate to the shared READ-MERGE-WRITE helper. Uses default
+    # array_union_keys (permissions.allow/deny/ask) and the default
+    # ensure_parent=True (creates settings_dir if missing).
+    ok, _ = _write_merged_json(settings_file, settings_delta)
 
-    # Conditional top-level replace: only keys in the delta are touched.
-    # Keys not in the delta are PRESERVED unchanged (Step 14 contributions,
-    # user-managed settings, and prior-run profile keys not re-declared all
-    # remain intact). None values delete keys (RFC 7396 null-as-delete).
-    for key, value in settings_delta.items():
-        if value is None:
-            existing.pop(key, None)
-        else:
-            existing[key] = value
-
-    # Write back
-    try:
-        settings_dir.mkdir(parents=True, exist_ok=True)
-        settings_file.write_text(
-            json.dumps(existing, indent=2, ensure_ascii=False) + '\n',
-            encoding='utf-8',
-        )
+    if ok:
         success(f'Wrote profile settings to {settings_file}')
-        return True
-    except OSError as e:
-        warning(f'Failed to write profile settings to {settings_file}: {e}')
-        return False
+    else:
+        warning(f'Failed to write profile settings to {settings_file}')
+
+    return ok
 
 
 def _build_profile_settings(
-    hooks: dict[str, Any],
+    profile_config: dict[str, Any],
     hooks_dir: Path,
-    model: str | None = None,
-    permissions: dict[str, Any] | None = None,
-    env: dict[str, str] | None = None,
-    always_thinking_enabled: bool | None = None,
-    company_announcements: list[str] | None = None,
-    attribution: dict[str, str] | None = None,
-    status_line: dict[str, Any] | None = None,
-    effort_level: str | None = None,
 ) -> dict[str, Any]:
-    """Build profile settings dict from YAML inputs (pure, zero I/O).
+    """Build profile settings dict from a per-key profile_config dict (pure, zero I/O).
 
-    Produces a dict containing ONLY the keys that were explicitly configured
-    (None inputs are omitted). Values correspond to the 9 PROFILE_OWNED_KEYS
-    in their camelCase form as they appear in settings.json / config.json.
+    The ``profile_config`` parameter is a dict whose keys are the nine
+    camelCase on-disk names (``model``, ``permissions``, ``env``,
+    ``attribution``, ``alwaysThinkingEnabled``, ``effortLevel``,
+    ``companyAnnouncements``, ``statusLine``, ``hooks``). Dict MEMBERSHIP
+    encodes the YAML declaration state (present-with-value, present-with-null,
+    or absent) which is intentionally preserved end-to-end so that the
+    downstream writer can apply RFC 7396 null-as-delete to the shared
+    ``settings.json`` for top-level YAML nulls.
 
-    Performs kebab-to-camel translation for nested permissions keys
-    ('default-mode' -> 'defaultMode', 'additional-directories' ->
-    'additionalDirectories'), builds the statusLine command string with
-    absolute POSIX paths under hooks_dir, and delegates to _build_hooks_json()
-    for the hooks key universe.
+    Three cases per key:
+
+    - **Key absent** -- the builder OMITS the key from its output dict. The
+      writer preserves the existing on-disk value (if any).
+    - **Key present with value None** -- the builder emits
+      ``settings[key] = None`` verbatim. The writer deletes the on-disk key
+      via RFC 7396 null-as-delete semantics in ``_merge_recursive()``.
+    - **Key present with a non-None value** -- the builder performs the
+      usual truthy/empty handling (kebab-to-camel translation for
+      ``permissions``, command-string construction for ``statusLine``,
+      ``_build_hooks_json()`` delegation for ``hooks``) and emits the
+      processed value. Empty dicts or empty lists remain as-is (so an
+      empty ``attribution`` dict is still stored explicitly).
+
+    The ``hooks`` value in ``profile_config`` is either ``None`` (YAML null),
+    absent (YAML omitted), or the full YAML hooks configuration dict with
+    ``files`` / ``events`` keys (which is then processed via
+    ``_build_hooks_json()``).
 
     Args:
-        hooks: Hooks configuration dictionary with 'files' and 'events' keys.
+        profile_config: Dict of profile-owned keys to build settings from.
+            Keys use camelCase on-disk names. Values correspond directly to
+            the YAML-declared values (with pre-translation for ``permissions``
+            kebab-case nested keys and pre-processing for ``statusLine``
+            file references handled inside this function).
         hooks_dir: Absolute directory path where downloaded hook files reside.
-            For isolated mode: ~/.claude/{cmd}/hooks/.
-            For non-isolated mode: ~/.claude/hooks/.
-        model: Optional model alias or custom model name.
-        permissions: Optional permissions configuration dict (kebab-case nested
-            keys are translated to camelCase).
-        env: Optional environment variables dict (keys as-is, values stringified).
-        always_thinking_enabled: Optional flag to enable always-on thinking mode.
-        company_announcements: Optional list of company announcement strings.
-        attribution: Optional dict with 'commit' and 'pr' keys for custom
-            attribution strings. Empty strings hide attribution.
-        status_line: Optional dict with 'file', optional 'config', and optional
-            'padding' keys. 'file' references a script previously downloaded to
-            hooks_dir; its absolute POSIX path is embedded in the generated
-            command string.
-        effort_level: Optional effort level for adaptive reasoning.
-            Valid values: 'low', 'medium', 'high', 'max'.
+            For isolated mode: ``~/.claude/{cmd}/hooks/``.
+            For non-isolated mode: ``~/.claude/hooks/``.
 
     Returns:
-        Dict containing only explicitly-configured PROFILE_OWNED_KEYS, with
-        camelCase keys and all values ready to be serialized to JSON.
+        Dict containing only the keys that were present in ``profile_config``.
+        Keys present with None values propagate through as ``settings[key] =
+        None`` for downstream null-as-delete handling. Keys absent from
+        ``profile_config`` are absent from the result.
 
     Examples:
-        >>> _build_profile_settings({}, Path('/tmp/hooks'), model='sonnet')
+        >>> _build_profile_settings({'model': 'sonnet'}, Path('/tmp/hooks'))
         {'model': 'sonnet'}
 
         >>> _build_profile_settings(
-        ...     {}, Path('/tmp/hooks'),
-        ...     permissions={'default-mode': 'ask', 'allow': ['Read']},
+        ...     {'permissions': {'default-mode': 'ask', 'allow': ['Read']}},
+        ...     Path('/tmp/hooks'),
         ... )
         {'permissions': {'defaultMode': 'ask', 'allow': ['Read']}}
 
         >>> _build_profile_settings({}, Path('/tmp/hooks'))
         {}
+
+        >>> _build_profile_settings({'model': None}, Path('/tmp/hooks'))
+        {'model': None}
     """
     settings: dict[str, Any] = {}
 
-    # Add model if specified
-    if model:
-        settings['model'] = model
-        info(f'Setting model: {model}')
+    # model
+    if 'model' in profile_config:
+        model = profile_config['model']
+        if model is None:
+            settings['model'] = None
+            info('Deleting model via explicit null')
+        elif model:
+            settings['model'] = model
+            info(f'Setting model: {model}')
 
-    # Handle permissions from configuration with kebab-to-camel translation
-    final_permissions: dict[str, Any] = {}
-    if permissions:
-        final_permissions = permissions.copy()
-        if 'default-mode' in final_permissions:
-            final_permissions['defaultMode'] = final_permissions.pop('default-mode')
-        if 'additional-directories' in final_permissions:
-            final_permissions['additionalDirectories'] = final_permissions.pop('additional-directories')
-        info('Using permissions from environment configuration')
+    # permissions (kebab-to-camel translation for nested keys)
+    if 'permissions' in profile_config:
+        permissions = profile_config['permissions']
+        if permissions is None:
+            settings['permissions'] = None
+            info('Deleting permissions via explicit null')
+        elif permissions:
+            final_permissions = permissions.copy()
+            if 'default-mode' in final_permissions:
+                final_permissions['defaultMode'] = final_permissions.pop('default-mode')
+            if 'additional-directories' in final_permissions:
+                final_permissions['additionalDirectories'] = final_permissions.pop('additional-directories')
+            info('Using permissions from environment configuration')
+            settings['permissions'] = final_permissions
 
-    # Add permissions to settings if we have any
-    if final_permissions:
-        settings['permissions'] = final_permissions
+    # env (values stringified)
+    if 'env' in profile_config:
+        env = profile_config['env']
+        if env is None:
+            settings['env'] = None
+            info('Deleting env via explicit null')
+        elif env:
+            settings['env'] = {k: str(v) for k, v in env.items()}
+            info(f'Setting {len(env)} environment variables')
+            for key in env:
+                info(f'  - {key}')
 
-    # Add environment variables if specified
-    if env:
-        settings['env'] = {k: str(v) for k, v in env.items()}
-        info(f'Setting {len(env)} environment variables')
-        for key in env:
-            info(f'  - {key}')
+    # attribution (empty dict is explicit and kept)
+    if 'attribution' in profile_config:
+        attribution = profile_config['attribution']
+        if attribution is None:
+            settings['attribution'] = None
+            info('Deleting attribution via explicit null')
+        else:
+            settings['attribution'] = attribution
+            commit_preview = repr(attribution.get('commit', ''))[:30]
+            pr_preview = repr(attribution.get('pr', ''))[:30]
+            info(f'Setting attribution: commit={commit_preview}, pr={pr_preview}')
 
-    # Handle attribution settings
-    if attribution is not None:
-        settings['attribution'] = attribution
-        commit_preview = repr(attribution.get('commit', ''))[:30]
-        pr_preview = repr(attribution.get('pr', ''))[:30]
-        info(f'Setting attribution: commit={commit_preview}, pr={pr_preview}')
+    # alwaysThinkingEnabled (False is explicit and kept)
+    if 'alwaysThinkingEnabled' in profile_config:
+        always_thinking_enabled = profile_config['alwaysThinkingEnabled']
+        if always_thinking_enabled is None:
+            settings['alwaysThinkingEnabled'] = None
+            info('Deleting alwaysThinkingEnabled via explicit null')
+        else:
+            settings['alwaysThinkingEnabled'] = always_thinking_enabled
+            info(f'Setting alwaysThinkingEnabled: {always_thinking_enabled}')
 
-    # Add alwaysThinkingEnabled if explicitly set (None means not configured, leave as default)
-    if always_thinking_enabled is not None:
-        settings['alwaysThinkingEnabled'] = always_thinking_enabled
-        info(f'Setting alwaysThinkingEnabled: {always_thinking_enabled}')
+    # effortLevel
+    if 'effortLevel' in profile_config:
+        effort_level = profile_config['effortLevel']
+        if effort_level is None:
+            settings['effortLevel'] = None
+            info('Deleting effortLevel via explicit null')
+        else:
+            settings['effortLevel'] = effort_level
+            info(f'Setting effortLevel: {effort_level}')
 
-    # Add effortLevel if explicitly set (None means not configured, leave as default)
-    if effort_level is not None:
-        settings['effortLevel'] = effort_level
-        info(f'Setting effortLevel: {effort_level}')
+    # companyAnnouncements
+    if 'companyAnnouncements' in profile_config:
+        company_announcements = profile_config['companyAnnouncements']
+        if company_announcements is None:
+            settings['companyAnnouncements'] = None
+            info('Deleting companyAnnouncements via explicit null')
+        else:
+            settings['companyAnnouncements'] = company_announcements
+            info(f'Setting companyAnnouncements: {len(company_announcements)} announcement(s)')
 
-    # Add companyAnnouncements if explicitly set (None means not configured, leave as default)
-    if company_announcements is not None:
-        settings['companyAnnouncements'] = company_announcements
-        info(f'Setting companyAnnouncements: {len(company_announcements)} announcement(s)')
+    # statusLine (command-string construction)
+    if 'statusLine' in profile_config:
+        status_line = profile_config['statusLine']
+        if status_line is None:
+            settings['statusLine'] = None
+            info('Deleting statusLine via explicit null')
+        elif isinstance(status_line, dict):
+            status_line_file = status_line.get('file')
+            if status_line_file:
+                # Build absolute path to the hook file in hooks directory
+                # Strip query parameters from filename
+                clean_filename = status_line_file.split('?')[0] if '?' in status_line_file else status_line_file
+                filename = Path(clean_filename).name
+                hook_path = hooks_dir / filename
+                hook_path_str = hook_path.as_posix()
 
-    # Add statusLine if explicitly set (None means not configured, leave as default)
-    if status_line is not None:
-        status_line_file = status_line.get('file')
-        if status_line_file:
-            # Build absolute path to the hook file in hooks directory
-            # Strip query parameters from filename
-            clean_filename = status_line_file.split('?')[0] if '?' in status_line_file else status_line_file
-            filename = Path(clean_filename).name
-            hook_path = hooks_dir / filename
-            hook_path_str = hook_path.as_posix()
+                # Extract optional config file reference
+                status_line_config_file = status_line.get('config')
 
-            # Extract optional config file reference
-            config = status_line.get('config')
+                # Determine command based on file extension
+                if filename.lower().endswith(('.py', '.pyw')):
+                    # Python script - use uv run
+                    status_line_command = f'uv run --no-project --python 3.12 {hook_path_str}'
 
-            # Determine command based on file extension
-            if filename.lower().endswith(('.py', '.pyw')):
-                # Python script - use uv run
-                status_line_command = f'uv run --no-project --python 3.12 {hook_path_str}'
+                    # Append config file path if specified
+                    if status_line_config_file:
+                        # Strip query parameters from config filename
+                        clean_config = (
+                            status_line_config_file.split('?')[0]
+                            if '?' in status_line_config_file
+                            else status_line_config_file
+                        )
+                        config_path = hooks_dir / Path(clean_config).name
+                        config_path_str = config_path.as_posix()
+                        status_line_command = f'{status_line_command} {config_path_str}'
+                else:
+                    # Other file - use path directly
+                    status_line_command = hook_path_str
 
-                # Append config file path if specified
-                if config:
-                    # Strip query parameters from config filename
-                    clean_config = config.split('?')[0] if '?' in config else config
-                    config_path = hooks_dir / Path(clean_config).name
-                    config_path_str = config_path.as_posix()
-                    status_line_command = f'{status_line_command} {config_path_str}'
-            else:
-                # Other file - use path directly
-                status_line_command = hook_path_str
+                    # Append config file path if specified
+                    if status_line_config_file:
+                        # Strip query parameters from config filename
+                        clean_config = (
+                            status_line_config_file.split('?')[0]
+                            if '?' in status_line_config_file
+                            else status_line_config_file
+                        )
+                        config_path = hooks_dir / Path(clean_config).name
+                        config_path_str = config_path.as_posix()
+                        status_line_command = f'{status_line_command} {config_path_str}'
 
-                # Append config file path if specified
-                if config:
-                    # Strip query parameters from config filename
-                    clean_config = config.split('?')[0] if '?' in config else config
-                    config_path = hooks_dir / Path(clean_config).name
-                    config_path_str = config_path.as_posix()
-                    status_line_command = f'{status_line_command} {config_path_str}'
+                status_line_built: dict[str, Any] = {
+                    'type': 'command',
+                    'command': status_line_command,
+                }
 
-            status_line_config: dict[str, Any] = {
-                'type': 'command',
-                'command': status_line_command,
-            }
+                # Add optional padding
+                padding = status_line.get('padding')
+                if padding is not None:
+                    status_line_built['padding'] = padding
 
-            # Add optional padding
-            padding = status_line.get('padding')
-            if padding is not None:
-                status_line_config['padding'] = padding
+                settings['statusLine'] = status_line_built
+                info(f'Setting statusLine: {filename}')
 
-            settings['statusLine'] = status_line_config
-            info(f'Setting statusLine: {filename}')
-
-    # Handle hooks if present
-    if hooks:
-        hooks_json = _build_hooks_json(hooks, hooks_dir)
-        if hooks_json:
-            settings['hooks'] = hooks_json
+    # hooks (delegates to _build_hooks_json for non-null, non-empty values)
+    if 'hooks' in profile_config:
+        hooks = profile_config['hooks']
+        if hooks is None:
+            settings['hooks'] = None
+            info('Deleting hooks via explicit null')
+        elif hooks:
+            hooks_json = _build_hooks_json(hooks, hooks_dir)
+            if hooks_json:
+                settings['hooks'] = hooks_json
 
     return settings
 
 
 def create_profile_config(
-    hooks: dict[str, Any],
+    profile_config: dict[str, Any],
     config_base_dir: Path,
-    model: str | None = None,
-    permissions: dict[str, Any] | None = None,
-    env: dict[str, str] | None = None,
-    always_thinking_enabled: bool | None = None,
-    company_announcements: list[str] | None = None,
-    attribution: dict[str, str] | None = None,
-    status_line: dict[str, Any] | None = None,
-    effort_level: str | None = None,
     hooks_base_dir: Path | None = None,
 ) -> bool:
     """Create config.json (profile configuration) for the isolated environment.
@@ -8697,21 +8748,21 @@ def create_profile_config(
     overwritten on re-run, so YAML removals of keys cleanly propagate to the
     isolated profile (isolated-mode atomic rebuild semantics).
 
+    In isolated mode, the on-disk config.json is fully toolbox-owned: each
+    invocation rebuilds the file from scratch, so the distinction between
+    "YAML key absent" and "YAML key set to null" is cosmetic -- both cases
+    produce a config.json without the key (absent keys are omitted by the
+    builder, and null-valued keys serialize as ``"key": null`` in JSON,
+    which is equivalent to absent for Claude Code's priority-resolution).
+
     Args:
-        hooks: Hooks configuration dictionary with 'files' and 'events' keys.
+        profile_config: Dict of profile-owned keys (camelCase on-disk names).
+            Keys present with values are written; keys present with None are
+            written as JSON null; keys absent are omitted. For the ``hooks``
+            key, the value is the full YAML hooks configuration dict with
+            ``files`` / ``events`` keys.
         config_base_dir: Path to the isolated environment directory
             (e.g., ~/.claude/{cmd}/).
-        model: Optional model alias or custom model name.
-        permissions: Optional permissions configuration dict.
-        env: Optional environment variables dict.
-        always_thinking_enabled: Optional flag to enable always-on thinking mode.
-        company_announcements: Optional list of company announcement strings.
-        attribution: Optional dict with 'commit' and 'pr' keys for custom
-            attribution strings. Empty strings hide attribution.
-        status_line: Optional dict with 'file'/'config'/'padding' keys.
-        effort_level: Optional effort level for adaptive reasoning.
-            Valid values: 'low', 'medium', 'high', 'max'. The 'max' level is
-            only available for Opus models.
         hooks_base_dir: Optional base directory for hook files.
             When provided, hook file paths are resolved relative to this directory
             instead of config_base_dir / 'hooks'.
@@ -8725,18 +8776,7 @@ def create_profile_config(
     info('Creating config.json...')
 
     # Build the profile settings dict via the shared pure builder
-    settings = _build_profile_settings(
-        hooks=hooks,
-        hooks_dir=hooks_dir,
-        model=model,
-        permissions=permissions,
-        env=env,
-        always_thinking_enabled=always_thinking_enabled,
-        company_announcements=company_announcements,
-        attribution=attribution,
-        status_line=status_line,
-        effort_level=effort_level,
-    )
+    settings = _build_profile_settings(profile_config, hooks_dir)
 
     # Save settings (always overwrite) - atomic rebuild semantics
     settings_path = config_base_dir / 'config.json'
@@ -9847,19 +9887,19 @@ def main() -> None:
         # Extract OS-level environment variables configuration
         os_env_variables = config.get('os-env-variables')
 
-        # Extract always_thinking_enabled configuration
-        always_thinking_enabled = config.get('always-thinking-enabled')
-
-        # Extract company_announcements configuration
+        # Extract company_announcements configuration (still consumed by
+        # the summary printout below; profile_config is rebuilt from `config`
+        # directly via _YAML_TO_CAMEL_PROFILE_KEYS in Step 18).
         company_announcements = config.get('company-announcements')
 
-        # Extract attribution configuration
-        attribution = config.get('attribution')
-
-        # Extract status_line configuration
+        # Extract status_line configuration (still consumed by the summary
+        # printout and by download_hook_files() path selection below).
         status_line = config.get('status-line')
 
-        # Extract and validate effort_level configuration
+        # Extract and validate effort_level configuration. When the value is
+        # invalid, remove it from the config dict so that the profile_config
+        # builder (which reads `config` via dict-membership) omits the key
+        # from both the isolated config.json and the shared settings.json.
         effort_level = config.get('effort-level')
         if effort_level is not None:
             valid_effort_levels = ('low', 'medium', 'high', 'max')
@@ -9869,6 +9909,7 @@ def main() -> None:
                     f'Valid values: {", ".join(valid_effort_levels)}. Skipping.',
                 )
                 effort_level = None
+                config.pop('effort-level', None)
 
         # Extract user-settings configuration (global user-level settings)
         user_settings = config.get('user-settings')
@@ -9966,7 +10007,12 @@ def main() -> None:
                 warning(f"Key '{user_key}' specified in both root level and user-settings.")
                 warning(f'  user-settings value: {user_value}')
                 warning(f'  root-level value: {root_value}')
-                warning('  Root-level value takes precedence (written last in Step 18).')
+                warning(
+                    '  Under deep merge semantics, root-level values overwrite '
+                    'user-settings values for scalar keys. For dict keys, '
+                    'user-settings and root-level values are deep-merged; for '
+                    'permissions.allow/deny/ask, array union applies.',
+                )
 
         # Validate: profile-scoped MCP servers require command-names (launcher)
         # In non-command-names mode, profile-scoped servers have no launcher
@@ -10337,22 +10383,22 @@ def main() -> None:
             # Step 18: Create profile configuration
             print()
             print(f'{Colors.CYAN}Step 18: Creating profile configuration...{Colors.NC}')
-            # Cast status_line for type safety
-            status_line_arg: dict[str, Any] | None = None
-            if status_line is not None and isinstance(status_line, dict):
-                status_line_arg = cast(dict[str, Any], status_line)
+
+            # Build profile_config dict from YAML using dict membership to
+            # preserve the "declared-vs-absent" distinction end-to-end. In
+            # isolated mode the distinction is cosmetic (atomic overwrite),
+            # but the uniform construction pattern keeps the two branches
+            # aligned and makes the null-as-delete semantics explicit in
+            # the data flow.
+            profile_config_isolated: dict[str, Any] = {
+                camel_key: config[yaml_key]
+                for yaml_key, camel_key in _YAML_TO_CAMEL_PROFILE_KEYS.items()
+                if yaml_key in config
+            }
 
             create_profile_config(
-                hooks,
+                profile_config_isolated,
                 artifact_base_dir,
-                model,
-                permissions,
-                env_variables,
-                always_thinking_enabled,
-                company_announcements,
-                attribution,
-                status_line_arg,
-                effort_level,
                 hooks_base_dir=hooks_base_dir_arg,
             )
 
@@ -10401,8 +10447,8 @@ def main() -> None:
                 warning('Launcher script was not created')
         else:
             # No command-names: route all profile-owned YAML keys to the
-            # shared ~/.claude/settings.json via conditional top-level
-            # replace. This achieves full feature parity for model,
+            # shared ~/.claude/settings.json via deep-merge with RFC 7396
+            # null-as-delete. This achieves full feature parity for model,
             # permissions, env, attribution, alwaysThinkingEnabled,
             # effortLevel, companyAnnouncements, statusLine, and hooks
             # between command-names present/absent modes.
@@ -10450,29 +10496,32 @@ def main() -> None:
                 print()
                 print(f'{Colors.CYAN}Step 17: Skipping hooks download (none configured)...{Colors.NC}')
 
-            # Step 18: Write profile settings delta to the shared
-            # settings.json via conditional top-level replace.
+            # Step 18: Deep-merge profile settings delta into the shared
+            # settings.json. Unlike isolated mode (which uses atomic
+            # overwrite of a toolbox-owned config.json), the shared
+            # settings.json is a user-facing file that may contain keys
+            # contributed by prior YAMLs, manual user edits, or the
+            # Claude Code CLI itself, so the writer uses deep-merge with
+            # RFC 7396 null-as-delete (via _write_merged_json()) to
+            # preserve non-delta keys while allowing explicit YAML null
+            # to remove keys.
             print()
             print(f'{Colors.CYAN}Step 18: Writing profile settings to settings.json...{Colors.NC}')
 
-            # Cast status_line for type safety (same pattern as isolated branch)
-            status_line_arg_else: dict[str, Any] | None = None
-            if status_line is not None and isinstance(status_line, dict):
-                status_line_arg_else = cast(dict[str, Any], status_line)
+            # Build profile_config dict from YAML using dict membership to
+            # preserve the "declared-vs-absent" distinction. A YAML-level
+            # `key: null` declaration becomes `profile_config[camel_key] =
+            # None`, which the builder forwards as `settings_delta[camel_key]
+            # = None`, which in turn triggers RFC 7396 null-as-delete inside
+            # _write_merged_json() against the shared settings.json.
+            profile_config_shared: dict[str, Any] = {
+                camel_key: config[yaml_key]
+                for yaml_key, camel_key in _YAML_TO_CAMEL_PROFILE_KEYS.items()
+                if yaml_key in config
+            }
 
             # Build the profile settings delta (pure, no I/O)
-            settings_delta = _build_profile_settings(
-                hooks=hooks,
-                hooks_dir=hooks_dir,
-                model=model,
-                permissions=permissions,
-                env=env_variables,
-                always_thinking_enabled=always_thinking_enabled,
-                company_announcements=company_announcements,
-                attribution=attribution,
-                status_line=status_line_arg_else,
-                effort_level=effort_level,
-            )
+            settings_delta = _build_profile_settings(profile_config_shared, hooks_dir)
 
             write_profile_settings_to_settings(settings_delta, claude_user_dir)
 

--- a/tests/e2e/test_artifact_isolation.py
+++ b/tests/e2e/test_artifact_isolation.py
@@ -87,7 +87,7 @@ class TestArtifactIsolationDirectories:
         artifact_base = paths.artifact_base_dir
         artifact_base.mkdir(parents=True, exist_ok=True)
 
-        # Create settings file as create_profile_config() would
+        # Simulate the config.json that create_profile_config writes in isolated mode
         settings: dict[str, Any] = {'model': 'test'}
         config_path = artifact_base / 'config.json'
         config_path.write_text(json.dumps(settings, indent=2))
@@ -128,9 +128,8 @@ class TestConfigDirIsolation:
         env_variables: dict[str, str] = {'MY_VAR': 'test_value'}
 
         result = setup_environment.create_profile_config(
-            golden_config.get('hooks', {}),
+            {'hooks': golden_config.get('hooks', {}), 'env': env_variables},
             artifact_base,
-            env=env_variables,
             hooks_base_dir=hooks_dir,
         )
 
@@ -170,7 +169,7 @@ class TestConfigDirIsolation:
         }
 
         result = setup_environment.create_profile_config(
-            hooks_config,
+            {'hooks': hooks_config},
             artifact_base,
             hooks_base_dir=hooks_dir,
         )
@@ -206,9 +205,8 @@ class TestConfigDirIsolation:
         }
 
         result = setup_environment.create_profile_config(
-            {},
+            {'env': user_env},
             artifact_base,
-            env=user_env,
         )
 
         assert result is True

--- a/tests/e2e/test_auto_update.py
+++ b/tests/e2e/test_auto_update.py
@@ -206,11 +206,7 @@ class TestPinnedVersionProfileConfig:
 
         # Create profile config with injected env_variables
         assert ev is not None
-        setup_environment.create_profile_config(
-            hooks={},
-            config_base_dir=config_dir,
-            env=ev,
-        )
+        setup_environment.create_profile_config({'env': ev}, config_dir)
 
         config_json = config_dir / 'config.json'
         assert config_json.exists()

--- a/tests/e2e/test_bug_fixes.py
+++ b/tests/e2e/test_bug_fixes.py
@@ -80,9 +80,8 @@ class TestBugFixVerification:
         # Create config with custom env vars (but no CLAUDE_CONFIG_DIR)
         env_vars: dict[str, str] = {'MY_VAR': 'val'}
         create_profile_config(
-            golden_config.get('hooks', {}),
+            {'hooks': golden_config.get('hooks', {}), 'env': env_vars},
             artifact_base_dir,
-            env=env_vars,
             hooks_base_dir=hooks_dir,
         )
 
@@ -137,9 +136,8 @@ class TestBugFixVerification:
         hooks_dir.mkdir(parents=True, exist_ok=True)
 
         create_profile_config(
-            {},
+            {'env': env_variables},
             isolated_config_dir,
-            env=env_variables,
             hooks_base_dir=hooks_dir,
         )
 

--- a/tests/e2e/test_file_reorganization.py
+++ b/tests/e2e/test_file_reorganization.py
@@ -58,9 +58,8 @@ class TestFileReorganization:
 
         # Create profile config (config.json)
         create_profile_config(
-            golden_config.get('hooks', {}),
+            {'hooks': golden_config.get('hooks', {}), 'model': golden_config.get('model')},
             artifact_base_dir,
-            model=golden_config.get('model'),
             hooks_base_dir=hooks_dir,
         )
 
@@ -194,16 +193,18 @@ class TestFileReorganization:
             env_vars[k] = str(v)
 
         create_profile_config(
-            golden_config.get('hooks', {}),
+            {
+                'hooks': golden_config.get('hooks', {}),
+                'model': golden_config.get('model'),
+                'permissions': golden_config.get('permissions'),
+                'env': env_vars,
+                'alwaysThinkingEnabled': golden_config.get('always-thinking-enabled'),
+                'companyAnnouncements': golden_config.get('company-announcements'),
+                'attribution': golden_config.get('attribution'),
+                'statusLine': golden_config.get('status-line'),
+                'effortLevel': golden_config.get('effort-level'),
+            },
             artifact_base_dir,
-            model=golden_config.get('model'),
-            permissions=golden_config.get('permissions'),
-            env=env_vars,
-            always_thinking_enabled=golden_config.get('always-thinking-enabled'),
-            company_announcements=golden_config.get('company-announcements'),
-            attribution=golden_config.get('attribution'),
-            status_line=golden_config.get('status-line'),
-            effort_level=golden_config.get('effort-level'),
             hooks_base_dir=hooks_dir,
         )
 

--- a/tests/e2e/test_full_setup.py
+++ b/tests/e2e/test_full_setup.py
@@ -82,17 +82,18 @@ class TestE2EFullSetup:
 
         # Create config.json in artifact base dir
         create_profile_config(
-            hooks=golden_config.get('hooks', {}),
-            config_base_dir=artifact_base_dir,
-            model=golden_config.get('model'),
-            permissions=golden_config.get('permissions'),
-            env=golden_config.get('env-variables'),
-
-            always_thinking_enabled=golden_config.get('always-thinking-enabled'),
-            company_announcements=golden_config.get('company-announcements'),
-            attribution=golden_config.get('attribution'),
-            status_line=golden_config.get('status-line'),
-            effort_level=golden_config.get('effort-level'),
+            {
+                'hooks': golden_config.get('hooks', {}),
+                'model': golden_config.get('model'),
+                'permissions': golden_config.get('permissions'),
+                'env': golden_config.get('env-variables'),
+                'alwaysThinkingEnabled': golden_config.get('always-thinking-enabled'),
+                'companyAnnouncements': golden_config.get('company-announcements'),
+                'attribution': golden_config.get('attribution'),
+                'statusLine': golden_config.get('status-line'),
+                'effortLevel': golden_config.get('effort-level'),
+            },
+            artifact_base_dir,
         )
 
         # Create MCP config file in artifact base dir
@@ -142,12 +143,12 @@ class TestE2EFullSetup:
         e2e_isolated_home: dict[str, Path],
         golden_config: dict[str, Any],
     ) -> None:
-        """Verify create_profile_config() writes ALL profile-owned keys to config.json.
+        """Verify create_profile_config writes ALL profile-owned keys to config.json.
 
         This test validates the isolated-mode writer:
         - model, permissions, env, attribution, alwaysThinkingEnabled, effortLevel,
           companyAnnouncements, statusLine, hooks are all present in config.json
-          (the file written by create_profile_config() when command-names is set).
+          (the file written by create_profile_config when command-names is set).
 
         NOTE: This test covers ONLY the isolated mode writer. For the non-
         command-names mode, where write_profile_settings_to_settings()
@@ -159,17 +160,18 @@ class TestE2EFullSetup:
 
         # Create settings with ALL config keys
         create_profile_config(
-            hooks=golden_config.get('hooks', {}),
-            config_base_dir=claude_dir,
-            model=golden_config.get('model'),
-            permissions=golden_config.get('permissions'),
-            env=golden_config.get('env-variables'),
-
-            always_thinking_enabled=golden_config.get('always-thinking-enabled'),
-            company_announcements=golden_config.get('company-announcements'),
-            attribution=golden_config.get('attribution'),
-            status_line=golden_config.get('status-line'),
-            effort_level=golden_config.get('effort-level'),
+            {
+                'hooks': golden_config.get('hooks', {}),
+                'model': golden_config.get('model'),
+                'permissions': golden_config.get('permissions'),
+                'env': golden_config.get('env-variables'),
+                'alwaysThinkingEnabled': golden_config.get('always-thinking-enabled'),
+                'companyAnnouncements': golden_config.get('company-announcements'),
+                'attribution': golden_config.get('attribution'),
+                'statusLine': golden_config.get('status-line'),
+                'effortLevel': golden_config.get('effort-level'),
+            },
+            claude_dir,
         )
 
         # Verify settings file exists (written to config_base_dir as config.json)

--- a/tests/e2e/test_hooks_settings_routing.py
+++ b/tests/e2e/test_hooks_settings_routing.py
@@ -277,16 +277,18 @@ class TestHooksToConfigJsonRegression:
 
         hooks = golden_config.get('hooks', {})
         create_profile_config(
-            hooks=hooks,
-            config_base_dir=artifact_dir,
-            model=golden_config.get('model'),
-            permissions=golden_config.get('permissions'),
-            env=golden_config.get('env-variables'),
-            always_thinking_enabled=golden_config.get('always-thinking-enabled'),
-            company_announcements=golden_config.get('company-announcements'),
-            attribution=golden_config.get('attribution'),
-            status_line=golden_config.get('status-line'),
-            effort_level=golden_config.get('effort-level'),
+            {
+                'hooks': hooks,
+                'model': golden_config.get('model'),
+                'permissions': golden_config.get('permissions'),
+                'env': golden_config.get('env-variables'),
+                'alwaysThinkingEnabled': golden_config.get('always-thinking-enabled'),
+                'companyAnnouncements': golden_config.get('company-announcements'),
+                'attribution': golden_config.get('attribution'),
+                'statusLine': golden_config.get('status-line'),
+                'effortLevel': golden_config.get('effort-level'),
+            },
+            artifact_dir,
         )
 
         config_path = artifact_dir / 'config.json'
@@ -715,7 +717,7 @@ class TestBuildHooksJsonParity:
         hooks = golden_config.get('hooks', {})
 
         # Generate via create_profile_config
-        create_profile_config(hooks=hooks, config_base_dir=artifact_dir)
+        create_profile_config({'hooks': hooks}, artifact_dir)
         config_data = json.loads((artifact_dir / 'config.json').read_text())
         config_hooks = config_data.get('hooks', {})
 

--- a/tests/e2e/test_javascript_hooks.py
+++ b/tests/e2e/test_javascript_hooks.py
@@ -29,19 +29,7 @@ class TestJavaScriptHooks:
         hooks_dir = claude_dir / 'hooks'
         hooks_dir.mkdir(parents=True, exist_ok=True)
 
-        create_profile_config(
-            hooks=golden_config.get('hooks', {}),
-            config_base_dir=claude_dir,
-            model=None,
-            permissions=None,
-            env=None,
-
-            always_thinking_enabled=None,
-            company_announcements=None,
-            attribution=None,
-            status_line=None,
-            effort_level=None,
-        )
+        create_profile_config({'hooks': golden_config.get('hooks', {})}, claude_dir)
 
         settings_path = claude_dir / 'config.json'
         data = json.loads(settings_path.read_text())
@@ -75,19 +63,7 @@ class TestJavaScriptHooks:
         hooks_dir = claude_dir / 'hooks'
         hooks_dir.mkdir(parents=True, exist_ok=True)
 
-        create_profile_config(
-            hooks=golden_config.get('hooks', {}),
-            config_base_dir=claude_dir,
-            model=None,
-            permissions=None,
-            env=None,
-
-            always_thinking_enabled=None,
-            company_announcements=None,
-            attribution=None,
-            status_line=None,
-            effort_level=None,
-        )
+        create_profile_config({'hooks': golden_config.get('hooks', {})}, claude_dir)
 
         settings_path = claude_dir / 'config.json'
         data = json.loads(settings_path.read_text())
@@ -116,19 +92,7 @@ class TestJavaScriptHooks:
         hooks_dir = claude_dir / 'hooks'
         hooks_dir.mkdir(parents=True, exist_ok=True)
 
-        create_profile_config(
-            hooks=golden_config.get('hooks', {}),
-            config_base_dir=claude_dir,
-            model=None,
-            permissions=None,
-            env=None,
-
-            always_thinking_enabled=None,
-            company_announcements=None,
-            attribution=None,
-            status_line=None,
-            effort_level=None,
-        )
+        create_profile_config({'hooks': golden_config.get('hooks', {})}, claude_dir)
 
         settings_path = claude_dir / 'config.json'
         data = json.loads(settings_path.read_text())
@@ -157,19 +121,7 @@ class TestJavaScriptHooks:
         hooks_dir = claude_dir / 'hooks'
         hooks_dir.mkdir(parents=True, exist_ok=True)
 
-        create_profile_config(
-            hooks=golden_config.get('hooks', {}),
-            config_base_dir=claude_dir,
-            model=None,
-            permissions=None,
-            env=None,
-
-            always_thinking_enabled=None,
-            company_announcements=None,
-            attribution=None,
-            status_line=None,
-            effort_level=None,
-        )
+        create_profile_config({'hooks': golden_config.get('hooks', {})}, claude_dir)
 
         settings_path = claude_dir / 'config.json'
         data = json.loads(settings_path.read_text())
@@ -210,19 +162,7 @@ class TestJavaScriptHooks:
         hooks_dir = claude_dir / 'hooks'
         hooks_dir.mkdir(parents=True, exist_ok=True)
 
-        create_profile_config(
-            hooks=golden_config.get('hooks', {}),
-            config_base_dir=claude_dir,
-            model=None,
-            permissions=None,
-            env=None,
-
-            always_thinking_enabled=None,
-            company_announcements=None,
-            attribution=None,
-            status_line=None,
-            effort_level=None,
-        )
+        create_profile_config({'hooks': golden_config.get('hooks', {})}, claude_dir)
 
         settings_path = claude_dir / 'config.json'
         data = json.loads(settings_path.read_text())
@@ -264,19 +204,7 @@ class TestJavaScriptHooks:
         hooks_dir = claude_dir / 'hooks'
         hooks_dir.mkdir(parents=True, exist_ok=True)
 
-        create_profile_config(
-            hooks=golden_config.get('hooks', {}),
-            config_base_dir=claude_dir,
-            model=None,
-            permissions=None,
-            env=None,
-
-            always_thinking_enabled=None,
-            company_announcements=None,
-            attribution=None,
-            status_line=None,
-            effort_level=None,
-        )
+        create_profile_config({'hooks': golden_config.get('hooks', {})}, claude_dir)
 
         settings_path = claude_dir / 'config.json'
         data = json.loads(settings_path.read_text())

--- a/tests/e2e/test_output_files.py
+++ b/tests/e2e/test_output_files.py
@@ -41,17 +41,18 @@ class TestOutputFiles:
 
         # Create settings
         create_profile_config(
-            hooks=golden_config.get('hooks', {}),
-            config_base_dir=claude_dir,
-            model=golden_config.get('model'),
-            permissions=golden_config.get('permissions'),
-            env=golden_config.get('env-variables'),
-
-            always_thinking_enabled=golden_config.get('always-thinking-enabled'),
-            company_announcements=golden_config.get('company-announcements'),
-            attribution=golden_config.get('attribution'),
-            status_line=golden_config.get('status-line'),
-            effort_level=golden_config.get('effort-level'),
+            {
+                'hooks': golden_config.get('hooks', {}),
+                'model': golden_config.get('model'),
+                'permissions': golden_config.get('permissions'),
+                'env': golden_config.get('env-variables'),
+                'alwaysThinkingEnabled': golden_config.get('always-thinking-enabled'),
+                'companyAnnouncements': golden_config.get('company-announcements'),
+                'attribution': golden_config.get('attribution'),
+                'statusLine': golden_config.get('status-line'),
+                'effortLevel': golden_config.get('effort-level'),
+            },
+            claude_dir,
         )
 
         # File is written to config_base_dir as config.json
@@ -75,17 +76,18 @@ class TestOutputFiles:
 
         # Create settings
         create_profile_config(
-            hooks=golden_config.get('hooks', {}),
-            config_base_dir=claude_dir,
-            model=golden_config.get('model'),
-            permissions=golden_config.get('permissions'),
-            env=golden_config.get('env-variables'),
-
-            always_thinking_enabled=golden_config.get('always-thinking-enabled'),
-            company_announcements=golden_config.get('company-announcements'),
-            attribution=golden_config.get('attribution'),
-            status_line=golden_config.get('status-line'),
-            effort_level=golden_config.get('effort-level'),
+            {
+                'hooks': golden_config.get('hooks', {}),
+                'model': golden_config.get('model'),
+                'permissions': golden_config.get('permissions'),
+                'env': golden_config.get('env-variables'),
+                'alwaysThinkingEnabled': golden_config.get('always-thinking-enabled'),
+                'companyAnnouncements': golden_config.get('company-announcements'),
+                'attribution': golden_config.get('attribution'),
+                'statusLine': golden_config.get('status-line'),
+                'effortLevel': golden_config.get('effort-level'),
+            },
+            claude_dir,
         )
 
         # File is written to config_base_dir as config.json
@@ -196,19 +198,7 @@ class TestOutputFiles:
         paths = e2e_isolated_home
         claude_dir = paths['claude_dir']
 
-        create_profile_config(
-            hooks={},
-            config_base_dir=claude_dir,
-            model=None,
-            permissions=golden_config.get('permissions'),
-            env=None,
-
-            always_thinking_enabled=None,
-            company_announcements=None,
-            attribution=None,
-            status_line=None,
-            effort_level=None,
-        )
+        create_profile_config({'permissions': golden_config.get('permissions')}, claude_dir)
 
         # File is written to config_base_dir as config.json
         settings_path = claude_dir / 'config.json'

--- a/tests/e2e/test_path_handling.py
+++ b/tests/e2e/test_path_handling.py
@@ -100,17 +100,18 @@ class TestTildeExpansion:
 
         # Create settings
         create_profile_config(
-            hooks=golden_config.get('hooks', {}),
-            config_base_dir=claude_dir,
-            model=golden_config.get('model'),
-            permissions=golden_config.get('permissions'),
-            env=golden_config.get('env-variables'),
-
-            always_thinking_enabled=golden_config.get('always-thinking-enabled'),
-            company_announcements=golden_config.get('company-announcements'),
-            attribution=golden_config.get('attribution'),
-            status_line=golden_config.get('status-line'),
-            effort_level=golden_config.get('effort-level'),
+            {
+                'hooks': golden_config.get('hooks', {}),
+                'model': golden_config.get('model'),
+                'permissions': golden_config.get('permissions'),
+                'env': golden_config.get('env-variables'),
+                'alwaysThinkingEnabled': golden_config.get('always-thinking-enabled'),
+                'companyAnnouncements': golden_config.get('company-announcements'),
+                'attribution': golden_config.get('attribution'),
+                'statusLine': golden_config.get('status-line'),
+                'effortLevel': golden_config.get('effort-level'),
+            },
+            claude_dir,
         )
 
         # File is written to claude_user_dir (= claude_dir)
@@ -223,19 +224,7 @@ class TestTildeExpansion:
             return
 
         # Create settings with hooks
-        create_profile_config(
-            hooks=hooks_config,
-            config_base_dir=claude_dir,
-            model=None,
-            permissions=None,
-            env=None,
-
-            always_thinking_enabled=None,
-            company_announcements=None,
-            attribution=None,
-            status_line=None,
-            effort_level=None,
-        )
+        create_profile_config({'hooks': hooks_config}, claude_dir)
 
         # File is written to claude_user_dir (= claude_dir)
         settings_path = claude_dir / 'config.json'
@@ -278,19 +267,7 @@ class TestTildeExpansion:
             return
 
         # Create settings with status line
-        create_profile_config(
-            hooks={},
-            config_base_dir=claude_dir,
-            model=None,
-            permissions=None,
-            env=None,
-
-            always_thinking_enabled=None,
-            company_announcements=None,
-            attribution=None,
-            status_line=status_line_config,
-            effort_level=None,
-        )
+        create_profile_config({'statusLine': status_line_config}, claude_dir)
 
         # File is written to claude_user_dir (= claude_dir)
         settings_path = claude_dir / 'config.json'

--- a/tests/e2e/test_path_normalization.py
+++ b/tests/e2e/test_path_normalization.py
@@ -284,19 +284,7 @@ class TestPathSeparatorConsistency:
             return
 
         # Create settings with hooks
-        create_profile_config(
-            hooks=hooks_config,
-            config_base_dir=claude_dir,
-            model=None,
-            permissions=None,
-            env=None,
-
-            always_thinking_enabled=None,
-            company_announcements=None,
-            attribution=None,
-            status_line=None,
-            effort_level=None,
-        )
+        create_profile_config({'hooks': hooks_config}, claude_dir)
 
         settings_path = claude_dir / 'config.json'
         data = json.loads(settings_path.read_text())
@@ -347,19 +335,7 @@ class TestPathSeparatorConsistency:
             return
 
         # Create settings with status line
-        create_profile_config(
-            hooks={},
-            config_base_dir=claude_dir,
-            model=None,
-            permissions=None,
-            env=None,
-
-            always_thinking_enabled=None,
-            company_announcements=None,
-            attribution=None,
-            status_line=status_line_config,
-            effort_level=None,
-        )
+        create_profile_config({'statusLine': status_line_config}, claude_dir)
 
         settings_path = claude_dir / 'config.json'
         data = json.loads(settings_path.read_text())
@@ -397,17 +373,18 @@ class TestPathSeparatorConsistency:
 
         # Create full settings
         create_profile_config(
-            hooks=golden_config.get('hooks', {}),
-            config_base_dir=claude_dir,
-            model=golden_config.get('model'),
-            permissions=golden_config.get('permissions'),
-            env=golden_config.get('env-variables'),
-
-            always_thinking_enabled=golden_config.get('always-thinking-enabled'),
-            company_announcements=golden_config.get('company-announcements'),
-            attribution=golden_config.get('attribution'),
-            status_line=golden_config.get('status-line'),
-            effort_level=golden_config.get('effort-level'),
+            {
+                'hooks': golden_config.get('hooks', {}),
+                'model': golden_config.get('model'),
+                'permissions': golden_config.get('permissions'),
+                'env': golden_config.get('env-variables'),
+                'alwaysThinkingEnabled': golden_config.get('always-thinking-enabled'),
+                'companyAnnouncements': golden_config.get('company-announcements'),
+                'attribution': golden_config.get('attribution'),
+                'statusLine': golden_config.get('status-line'),
+                'effortLevel': golden_config.get('effort-level'),
+            },
+            claude_dir,
         )
 
         settings_path = claude_dir / 'config.json'

--- a/tests/e2e/test_profile_settings_routing.py
+++ b/tests/e2e/test_profile_settings_routing.py
@@ -4,20 +4,24 @@ Verifies that when `command-names` is absent, all profile-owned keys
 (model, permissions, env, attribution, alwaysThinkingEnabled, effortLevel,
 companyAnnouncements, statusLine, hooks) are correctly routed to
 ~/.claude/settings.json via write_profile_settings_to_settings(), which
-applies a conditional top-level replace: keys present in the delta are
-overwritten (or deleted when set to None), and keys not present in the
-delta are preserved unchanged.
+deep-merges the delta into the existing file: nested dicts are recursively
+merged, permissions.allow/deny/ask arrays are unioned,
+RFC 7396 null (both top-level and nested) deletes keys, and keys not in
+the delta are preserved unchanged.
 
 Test coverage matrix:
-- Happy path: all 9 profile-owned keys routed correctly
-- Partial config: only subset of keys declared, rest omitted
-- Preservation: pre-existing settings.json keys survive
+- Happy path: all 9 profile-owned keys deep-merged correctly
+- Partial config: only subset of keys declared, rest preserved
+- Deep-merge preservation: pre-existing settings.json sub-keys survive
 - Step 14/18 interaction: user-settings contributions preserved
+- permissions array union: user-settings + root-level deny rules accumulate
 - Conflict detection: warnings fire in non-command-names mode
+- Top-level null-as-delete: model/permissions/env/hooks/... all removable via null
+- Nested null-as-delete: permissions.deny=None removes just the deny sub-key
 - Re-invocation across configurations: a second invocation updates values
   written by the first invocation when keys are re-declared
-- Stale-key preservation: when an invocation omits a previously-written
-  key, the existing value is left in place
+- Stale-key preservation: when an invocation omits a key already on disk,
+  the existing value is left in place
 - Profile-scoped MCP validation: exit 1 with 4-option message
 - System-prompt warning: warning emitted, setup continues
 - Empty profile delta: settings.json untouched when no profile keys
@@ -43,16 +47,18 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------------
-# Test Class 1: Conditional Top-Level Replace Filesystem Semantics
+# Test Class 1: Deep-Merge Writer Filesystem Semantics
 # ---------------------------------------------------------------------------
 
 
-class TestConditionalReplaceWriterFilesystem:
+class TestDeepMergeWriterFilesystem:
     """Filesystem-level tests of write_profile_settings_to_settings().
 
-    Verifies the conditional top-level replace semantics on the real
-    filesystem: only keys present in the delta are written; keys not in
-    the delta are preserved unchanged; None values delete keys.
+    Verifies that the shared settings.json writer applies deep-merge via
+    delegation to _write_merged_json(): nested dicts are recursively
+    merged, permissions.allow/deny/ask arrays are unioned,
+    RFC 7396 null-as-delete works for both top-level keys and nested
+    sub-keys, and keys not present in the delta are preserved unchanged.
     """
 
     def test_happy_path_all_nine_keys(self, tmp_path: Path) -> None:
@@ -61,17 +67,19 @@ class TestConditionalReplaceWriterFilesystem:
         hooks_dir.mkdir()
 
         delta = _build_profile_settings(
-            hooks={'events': [{'event': 'PreToolUse', 'matcher': 'Bash',
-                               'type': 'command', 'command': 'test.sh'}]},
-            hooks_dir=hooks_dir,
-            model='sonnet',
-            permissions={'allow': ['Read'], 'deny': ['Bash(rm -rf)']},
-            env={'FOO': 'bar'},
-            always_thinking_enabled=True,
-            company_announcements=['Welcome'],
-            attribution={'commit': 'cm', 'pr': 'pr'},
-            status_line={'file': 'status.py'},
-            effort_level='high',
+            {
+                'hooks': {'events': [{'event': 'PreToolUse', 'matcher': 'Bash',
+                                      'type': 'command', 'command': 'test.sh'}]},
+                'model': 'sonnet',
+                'permissions': {'allow': ['Read'], 'deny': ['Bash(rm -rf)']},
+                'env': {'FOO': 'bar'},
+                'alwaysThinkingEnabled': True,
+                'companyAnnouncements': ['Welcome'],
+                'attribution': {'commit': 'cm', 'pr': 'pr'},
+                'statusLine': {'file': 'status.py'},
+                'effortLevel': 'high',
+            },
+            hooks_dir,
         )
 
         write_profile_settings_to_settings(delta, tmp_path)
@@ -81,9 +89,8 @@ class TestConditionalReplaceWriterFilesystem:
     def test_partial_delta_only_specified_keys_written(self, tmp_path: Path) -> None:
         """YAML with only model and permissions writes only those two keys."""
         delta = _build_profile_settings(
-            hooks={}, hooks_dir=tmp_path / 'hooks',
-            model='sonnet',
-            permissions={'allow': ['Read']},
+            {'model': 'sonnet', 'permissions': {'allow': ['Read']}},
+            tmp_path / 'hooks',
         )
         write_profile_settings_to_settings(delta, tmp_path)
         content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
@@ -99,7 +106,7 @@ class TestConditionalReplaceWriterFilesystem:
             'cleanupPeriodDays': 30,
         }), encoding='utf-8')
 
-        delta = _build_profile_settings(hooks={}, hooks_dir=tmp_path / 'hooks', model='sonnet')
+        delta = _build_profile_settings({'model': 'sonnet'}, tmp_path / 'hooks')
         write_profile_settings_to_settings(delta, tmp_path)
         content = json.loads(settings_file.read_text(encoding='utf-8'))
         assert content['language'] == 'english'
@@ -114,7 +121,7 @@ class TestConditionalReplaceWriterFilesystem:
         """A profile key that the new delta does not declare survives unchanged.
 
         The shared settings.json is a user-facing file, so the writer must
-        not silently scrub previously-written profile keys when the current
+        not silently scrub profile keys already on disk when the current
         configuration omits them. To delete a key, the user must declare it
         explicitly as None in the delta or remove it manually.
         """
@@ -126,7 +133,7 @@ class TestConditionalReplaceWriterFilesystem:
         }), encoding='utf-8')
 
         # New invocation declares ONLY model (permissions and effortLevel omitted)
-        delta = _build_profile_settings(hooks={}, hooks_dir=tmp_path / 'hooks', model='opus')
+        delta = _build_profile_settings({'model': 'opus'}, tmp_path / 'hooks')
         write_profile_settings_to_settings(delta, tmp_path)
         content = json.loads(settings_file.read_text(encoding='utf-8'))
 
@@ -144,22 +151,22 @@ class TestConditionalReplaceWriterFilesystem:
             'permissions': {'allow': ['Read']},
         }), encoding='utf-8')
 
-        # Note: _build_profile_settings() does not currently emit None values
-        # for profile keys (it omits None inputs). For null-as-delete coverage,
-        # construct the delta directly.
         write_profile_settings_to_settings({'model': None}, tmp_path)
         content = json.loads(settings_file.read_text(encoding='utf-8'))
         assert 'model' not in content
         # Unrelated profile key PRESERVED
         assert content['permissions'] == {'allow': ['Read']}
 
-    def test_top_level_replace_not_deep_merge(self, tmp_path: Path) -> None:
-        """The writer fully replaces a delta key value (no deep-merge).
+    def test_deep_merge_preserves_unrelated_permissions_subkeys(self, tmp_path: Path) -> None:
+        """Deep-merge preserves permissions sub-keys not declared in the delta.
 
-        When a profile-owned key already exists in settings.json and the
-        delta provides a new value for it, the writer must overwrite the
-        entire top-level value rather than recursively merging the two
-        dicts. Sub-keys not present in the new value disappear from disk.
+        When the delta carries a partial permissions dict (e.g., only 'allow'),
+        existing sub-keys ('deny', 'ask') declared by other contributors must
+        be preserved. This is the headline security guarantee: a narrower
+        permissions: {allow: [Read]} YAML declaration MUST NOT destroy
+        permissions.deny entries set by prior runs, user manual edits, or the
+        Claude Code CLI itself. The 'allow' sub-key is unioned via
+        DEFAULT_ARRAY_UNION_KEYS, so existing and new allow entries accumulate.
         """
         settings_file = tmp_path / 'settings.json'
         settings_file.write_text(json.dumps({
@@ -170,12 +177,130 @@ class TestConditionalReplaceWriterFilesystem:
             },
         }), encoding='utf-8')
 
-        # YAML declares narrower permissions
-        delta: dict[str, Any] = {'permissions': {'allow': ['Read']}}
+        # YAML declares a narrower permissions dict (only 'allow')
+        delta: dict[str, Any] = {'permissions': {'allow': ['Grep']}}
         write_profile_settings_to_settings(delta, tmp_path)
         content = json.loads(settings_file.read_text(encoding='utf-8'))
 
-        # Full replacement (not merge): 'deny' and 'ask' are GONE
+        # 'allow' array-unioned (order-preserving, deduped)
+        assert set(content['permissions']['allow']) == {'Read', 'Write', 'Glob', 'Grep'}
+        # 'deny' and 'ask' PRESERVED intact
+        assert content['permissions']['deny'] == ['Bash(rm -rf)']
+        assert content['permissions']['ask'] == ['Edit']
+
+    def test_permissions_deny_preserved_across_yaml_runs(self, tmp_path: Path) -> None:
+        """Security guarantee: permissions.deny entries accumulate across runs.
+
+        Flagship security test. A pre-existing settings.json with enterprise
+        deny rules is updated by a narrower YAML declaration; the deny rules
+        must survive and accumulate rather than being silently destroyed.
+        """
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'permissions': {'deny': ['Bash(rm -rf *)', 'Bash(sudo *)']},
+        }), encoding='utf-8')
+
+        # First YAML run adds allow entries
+        delta1 = _build_profile_settings(
+            {'permissions': {'allow': ['Read']}}, tmp_path / 'hooks',
+        )
+        write_profile_settings_to_settings(delta1, tmp_path)
+
+        # Second YAML run adds an additional deny rule
+        delta2 = _build_profile_settings(
+            {'permissions': {'deny': ['Bash(curl *)']}}, tmp_path / 'hooks',
+        )
+        write_profile_settings_to_settings(delta2, tmp_path)
+
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        # All 3 deny rules present, union preserved
+        assert set(content['permissions']['deny']) == {
+            'Bash(rm -rf *)', 'Bash(sudo *)', 'Bash(curl *)',
+        }
+        # 'allow' from first run still present
+        assert content['permissions']['allow'] == ['Read']
+
+    def test_env_deep_merge_preserves_auto_update_injection(self, tmp_path: Path) -> None:
+        """env dict deep-merges, preserving Target 2 auto-update injection.
+
+        Pre-populate with DISABLE_AUTOUPDATER (the state after Step 14 runs
+        with an auto-update-pinned YAML). Write a delta with a new env key.
+        Both keys must be present in the result.
+        """
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'env': {'DISABLE_AUTOUPDATER': '1'},
+        }), encoding='utf-8')
+
+        delta = _build_profile_settings(
+            {'env': {'MY_VAR': 'x'}}, tmp_path / 'hooks',
+        )
+        write_profile_settings_to_settings(delta, tmp_path)
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        # Both keys present
+        assert content['env']['DISABLE_AUTOUPDATER'] == '1'
+        assert content['env']['MY_VAR'] == 'x'
+
+    def test_top_level_null_permissions_deletes_block(self, tmp_path: Path) -> None:
+        """Top-level None for permissions deletes the entire permissions block."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'permissions': {'allow': ['Read'], 'deny': ['Bash']},
+            'model': 'sonnet',
+        }), encoding='utf-8')
+
+        write_profile_settings_to_settings({'permissions': None}, tmp_path)
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert content == {'model': 'sonnet'}
+
+    def test_top_level_null_hooks_deletes_block(self, tmp_path: Path) -> None:
+        """Top-level None for hooks deletes the entire hooks block."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'hooks': {'PreToolUse': [{'matcher': '', 'hooks': []}]},
+            'model': 'sonnet',
+        }), encoding='utf-8')
+
+        write_profile_settings_to_settings({'hooks': None}, tmp_path)
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert content == {'model': 'sonnet'}
+
+    def test_top_level_null_all_profile_keys_deletes_all(self, tmp_path: Path) -> None:
+        """All nine profile-owned keys set to None deletes them all."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'model': 'sonnet',
+            'permissions': {'allow': ['Read']},
+            'env': {'FOO': 'bar'},
+            'attribution': {'commit': 'x'},
+            'alwaysThinkingEnabled': True,
+            'effortLevel': 'high',
+            'companyAnnouncements': ['msg'],
+            'statusLine': {'type': 'command', 'command': 'a'},
+            'hooks': {'PreToolUse': []},
+            'language': 'english',  # Unrelated key, should be preserved
+        }), encoding='utf-8')
+
+        delta: dict[str, Any] = dict.fromkeys(PROFILE_OWNED_KEYS)
+        write_profile_settings_to_settings(delta, tmp_path)
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        # All nine profile-owned keys deleted; unrelated key preserved
+        assert content == {'language': 'english'}
+
+    def test_nested_null_permissions_deny_only_deletes_sub_key(
+        self, tmp_path: Path,
+    ) -> None:
+        """Nested None (permissions.deny) deletes only the deny sub-key."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'permissions': {'allow': ['Read'], 'deny': ['Bash']},
+        }), encoding='utf-8')
+
+        write_profile_settings_to_settings(
+            {'permissions': {'deny': None}}, tmp_path,
+        )
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        # 'allow' preserved, 'deny' deleted
         assert content['permissions'] == {'allow': ['Read']}
 
 
@@ -201,10 +326,11 @@ class TestStep14Step18Interaction:
 
         Step 14 write_user_settings() runs first and writes
         user-settings.permissions into settings.json via deep-merge. Step
-        18 write_profile_settings_to_settings() then runs against an
-        empty profile delta (root YAML has no permissions). The Step 14
-        permissions entry must remain in the file because the writer
-        only touches keys present in its own delta.
+        18 write_profile_settings_to_settings() then runs against a
+        profile delta that does not contain 'permissions' (root YAML has
+        no permissions declaration, so the builder omits the key). The
+        Step 14 permissions entry remains intact because the deep-merge
+        writer only touches keys present in its own delta.
         """
         # Simulate Step 14 having written user-settings.permissions
         settings_file = tmp_path / 'settings.json'
@@ -214,7 +340,7 @@ class TestStep14Step18Interaction:
         }), encoding='utf-8')
 
         # Step 18: delta has NO 'permissions' (YAML root lacks it)
-        delta = _build_profile_settings(hooks={}, hooks_dir=tmp_path / 'hooks', model='sonnet')
+        delta = _build_profile_settings({'model': 'sonnet'}, tmp_path / 'hooks')
         assert 'permissions' not in delta
 
         write_profile_settings_to_settings(delta, tmp_path)
@@ -227,26 +353,45 @@ class TestStep14Step18Interaction:
         # Profile delta model ADDED
         assert content['model'] == 'sonnet'
 
-    def test_root_permissions_wins_over_user_settings_permissions(
+    def test_root_permissions_union_with_user_settings_permissions(
         self, tmp_path: Path,
     ) -> None:
-        """Root-level permissions REPLACES user-settings.permissions via step order."""
+        """Step 14 user-settings.permissions and Step 18 root permissions accumulate via union.
+
+        With deep-merge + DEFAULT_ARRAY_UNION_KEYS, both Step 14
+        (write_user_settings writing user-settings) and Step 18
+        (write_profile_settings_to_settings writing root-level permissions)
+        contribute additively to permissions.allow, permissions.deny,
+        permissions.ask. This is a deliberate security property: a team's
+        shared user-settings 'deny' rules compose with a per-run YAML's
+        additional 'deny' rules rather than one destroying the other.
+        """
         # Step 14 wrote user-settings.permissions
         settings_file = tmp_path / 'settings.json'
         settings_file.write_text(json.dumps({
-            'permissions': {'allow': ['Read']},
+            'permissions': {
+                'allow': ['Read'],
+                'deny': ['Bash(sudo *)'],
+            },
         }), encoding='utf-8')
 
-        # Step 18 has root-level permissions (takes precedence)
+        # Step 18 has root-level permissions (different but overlapping rules)
         delta = _build_profile_settings(
-            hooks={}, hooks_dir=tmp_path / 'hooks',
-            permissions={'allow': ['Write', 'Edit']},
+            {
+                'permissions': {
+                    'allow': ['Write', 'Edit'],
+                    'deny': ['Bash(rm -rf)'],
+                },
+            },
+            tmp_path / 'hooks',
         )
         write_profile_settings_to_settings(delta, tmp_path)
         content = json.loads(settings_file.read_text(encoding='utf-8'))
 
-        # Root-level won (full replace)
-        assert content['permissions'] == {'allow': ['Write', 'Edit']}
+        # Both 'allow' sets are array-unioned (Read + Write + Edit)
+        assert set(content['permissions']['allow']) == {'Read', 'Write', 'Edit'}
+        # Both 'deny' sets are array-unioned (sudo rule + rm -rf rule)
+        assert set(content['permissions']['deny']) == {'Bash(sudo *)', 'Bash(rm -rf)'}
 
 
 # ---------------------------------------------------------------------------
@@ -330,8 +475,9 @@ class TestConflictDetectionInNonCommandNamesMode:
         captured = capsys.readouterr()
         # Warning text identifies the conflicting key and both surfaces
         assert "Key 'model' specified in both root level and user-settings" in captured.out
-        # Precedence message indicates Step 18 writes last, so the root-level value wins
-        assert 'Root-level value takes precedence (written last in Step 18)' in captured.out
+        # Composite deep-merge precedence message
+        assert 'Under deep merge semantics' in captured.out
+        assert 'permissions.allow/deny/ask, array union applies' in captured.out
 
 
 # ---------------------------------------------------------------------------
@@ -395,7 +541,7 @@ class TestProfileMcpValidationError:
              pytest.raises(SystemExit) as excinfo:
             setup_environment.main()
 
-        # sys.exit(1) was called
+        # sys.exit(1) invoked
         assert excinfo.value.code == 1
 
         # error() messages go to stderr
@@ -660,18 +806,22 @@ class TestGoldenConfigNoCommandNames:
 
         cfg = golden_config_no_command_names
 
-        delta = _build_profile_settings(
-            hooks=cfg.get('hooks', {}),
-            hooks_dir=hooks_dir,
-            model=cfg.get('model'),
-            permissions=cfg.get('permissions'),
-            env=cfg.get('env-variables'),
-            always_thinking_enabled=cfg.get('always-thinking-enabled'),
-            company_announcements=cfg.get('company-announcements'),
-            attribution=cfg.get('attribution'),
-            status_line=cfg.get('status-line'),
-            effort_level=cfg.get('effort-level'),
-        )
+        profile_config = {
+            camel_key: cfg[yaml_key]
+            for yaml_key, camel_key in {
+                'hooks': 'hooks',
+                'model': 'model',
+                'permissions': 'permissions',
+                'env-variables': 'env',
+                'always-thinking-enabled': 'alwaysThinkingEnabled',
+                'company-announcements': 'companyAnnouncements',
+                'attribution': 'attribution',
+                'status-line': 'statusLine',
+                'effort-level': 'effortLevel',
+            }.items()
+            if yaml_key in cfg
+        }
+        delta = _build_profile_settings(profile_config, hooks_dir)
 
         write_profile_settings_to_settings(delta, claude_dir)
 
@@ -696,9 +846,8 @@ class TestGoldenConfigNoCommandNames:
         cfg = golden_config_no_command_names
 
         delta = _build_profile_settings(
-            hooks=cfg.get('hooks', {}),
-            hooks_dir=hooks_dir,
-            model=cfg.get('model'),
+            {'hooks': cfg.get('hooks', {}), 'model': cfg.get('model')},
+            hooks_dir,
         )
         write_profile_settings_to_settings(delta, claude_dir)
 
@@ -723,9 +872,11 @@ class TestGoldenConfigNoCommandNames:
         cfg = golden_config_no_command_names
 
         delta = _build_profile_settings(
-            hooks=cfg.get('hooks', {}),
-            hooks_dir=hooks_dir,
-            status_line=cfg.get('status-line'),
+            {
+                'hooks': cfg.get('hooks', {}),
+                'statusLine': cfg.get('status-line'),
+            },
+            hooks_dir,
         )
         write_profile_settings_to_settings(delta, claude_dir)
 
@@ -753,8 +904,8 @@ class TestRepeatedInvocationSemantics:
     def test_initial_invocation_populates_declared_keys(self, tmp_path: Path) -> None:
         """First invocation against an empty file writes all declared keys."""
         delta = _build_profile_settings(
-            hooks={}, hooks_dir=tmp_path / 'hooks',
-            model='sonnet', permissions={'allow': ['Read']},
+            {'model': 'sonnet', 'permissions': {'allow': ['Read']}},
+            tmp_path / 'hooks',
         )
         write_profile_settings_to_settings(delta, tmp_path)
         content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
@@ -764,20 +915,22 @@ class TestRepeatedInvocationSemantics:
         """Re-declaring a key with a new value overwrites the previous value."""
         # First invocation
         delta1 = _build_profile_settings(
-            hooks={}, hooks_dir=tmp_path / 'hooks',
-            model='sonnet', permissions={'allow': ['Read']},
+            {'model': 'sonnet', 'permissions': {'allow': ['Read']}},
+            tmp_path / 'hooks',
         )
         write_profile_settings_to_settings(delta1, tmp_path)
 
-        # Second invocation (same keys, different values)
+        # Second invocation (same keys, different values; deep-merge unions
+        # permissions.allow)
         delta2 = _build_profile_settings(
-            hooks={}, hooks_dir=tmp_path / 'hooks',
-            model='opus', permissions={'allow': ['Write']},
+            {'model': 'opus', 'permissions': {'allow': ['Write']}},
+            tmp_path / 'hooks',
         )
         write_profile_settings_to_settings(delta2, tmp_path)
         content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
         assert content['model'] == 'opus'
-        assert content['permissions'] == {'allow': ['Write']}
+        # Array-union semantics: both 'Read' and 'Write' accumulate
+        assert set(content['permissions']['allow']) == {'Read', 'Write'}
 
     def test_omitting_key_preserves_previous_value(self, tmp_path: Path) -> None:
         """Omitting a key on a later invocation preserves the previous value.
@@ -789,16 +942,13 @@ class TestRepeatedInvocationSemantics:
         """
         # First invocation: both model and permissions
         delta1 = _build_profile_settings(
-            hooks={}, hooks_dir=tmp_path / 'hooks',
-            model='sonnet', permissions={'allow': ['Read']},
+            {'model': 'sonnet', 'permissions': {'allow': ['Read']}},
+            tmp_path / 'hooks',
         )
         write_profile_settings_to_settings(delta1, tmp_path)
 
         # Second invocation: only model (permissions omitted)
-        delta2 = _build_profile_settings(
-            hooks={}, hooks_dir=tmp_path / 'hooks',
-            model='opus',
-        )
+        delta2 = _build_profile_settings({'model': 'opus'}, tmp_path / 'hooks')
         write_profile_settings_to_settings(delta2, tmp_path)
         content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
 
@@ -811,8 +961,8 @@ class TestRepeatedInvocationSemantics:
         # First invocation: model + permissions
         write_profile_settings_to_settings(
             _build_profile_settings(
-                hooks={}, hooks_dir=tmp_path / 'hooks',
-                model='sonnet', permissions={'allow': ['Read']},
+                {'model': 'sonnet', 'permissions': {'allow': ['Read']}},
+                tmp_path / 'hooks',
             ),
             tmp_path,
         )
@@ -820,8 +970,8 @@ class TestRepeatedInvocationSemantics:
         # Second invocation: add env (model re-declared, permissions omitted)
         write_profile_settings_to_settings(
             _build_profile_settings(
-                hooks={}, hooks_dir=tmp_path / 'hooks',
-                model='opus', env={'FOO': 'bar'},
+                {'model': 'opus', 'env': {'FOO': 'bar'}},
+                tmp_path / 'hooks',
             ),
             tmp_path,
         )
@@ -829,15 +979,15 @@ class TestRepeatedInvocationSemantics:
         # Third invocation: add effort_level (previous keys all omitted)
         write_profile_settings_to_settings(
             _build_profile_settings(
-                hooks={}, hooks_dir=tmp_path / 'hooks',
-                effort_level='high',
+                {'effortLevel': 'high'},
+                tmp_path / 'hooks',
             ),
             tmp_path,
         )
 
         content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
         # Accumulated: permissions from the first invocation, env from the
-        # second, effortLevel from the third. Model was re-declared in the
+        # second, effortLevel from the third. Model gets re-declared in the
         # second invocation, so it ends up as 'opus'.
         assert content['model'] == 'opus'
         assert content['permissions'] == {'allow': ['Read']}
@@ -875,7 +1025,7 @@ class TestAutoUpdateTarget2Survival:
         }), encoding='utf-8')
 
         # Step 18: delta has no 'env' key (YAML has no env-variables)
-        delta = _build_profile_settings(hooks={}, hooks_dir=tmp_path / 'hooks', model='sonnet')
+        delta = _build_profile_settings({'model': 'sonnet'}, tmp_path / 'hooks')
         assert 'env' not in delta
 
         write_profile_settings_to_settings(delta, tmp_path)
@@ -883,22 +1033,40 @@ class TestAutoUpdateTarget2Survival:
         assert content['env']['DISABLE_AUTOUPDATER'] == '1'
         assert content['model'] == 'sonnet'
 
-    def test_root_env_variables_replace_existing_env_value(self, tmp_path: Path) -> None:
-        """When YAML declares env-variables, root-level env replaces the existing 'env' value."""
+    def test_root_env_variables_deep_merge_preserves_existing_env_keys(
+        self, tmp_path: Path,
+    ) -> None:
+        """Deep-merge preserves existing env keys not declared in the delta.
+
+        When the YAML declares env-variables with a narrow set of keys, any
+        existing env entries written by prior steps (e.g., DISABLE_AUTOUPDATER
+        from auto-update Target 2, CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL from IDE
+        Target 2) MUST survive. Deep-merge recurses into the 'env' dict so the
+        delta's new keys are added and existing keys are preserved; keys also
+        declared in the delta are overwritten by the delta value.
+        """
         settings_file = tmp_path / 'settings.json'
         settings_file.write_text(json.dumps({
-            'env': {'DISABLE_AUTOUPDATER': '1', 'STALE': 'x'},
+            'env': {
+                'DISABLE_AUTOUPDATER': '1',
+                'CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL': 'true',
+                'KEEP_ME': 'preserved',
+            },
         }), encoding='utf-8')
 
-        # The delta carries a root-level env value
+        # The delta carries a root-level env value adding a new key
         delta = _build_profile_settings(
-            hooks={}, hooks_dir=tmp_path / 'hooks',
-            env={'FOO': 'bar'},
+            {'env': {'FOO': 'bar'}}, tmp_path / 'hooks',
         )
         write_profile_settings_to_settings(delta, tmp_path)
         content = json.loads(settings_file.read_text(encoding='utf-8'))
-        # Full replacement
-        assert content['env'] == {'FOO': 'bar'}
+
+        # Existing env keys PRESERVED
+        assert content['env']['DISABLE_AUTOUPDATER'] == '1'
+        assert content['env']['CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL'] == 'true'
+        assert content['env']['KEEP_ME'] == 'preserved'
+        # New env key ADDED
+        assert content['env']['FOO'] == 'bar'
 
 
 # ---------------------------------------------------------------------------
@@ -924,3 +1092,72 @@ class TestEmptyDeltaNoOp:
 
         content = json.loads(settings_file.read_text(encoding='utf-8'))
         assert content == original
+
+
+# ---------------------------------------------------------------------------
+# Test Class 10: YAML Null Propagation End-to-End
+# ---------------------------------------------------------------------------
+
+
+class TestBuildProfileSettingsNullPropagation:
+    """Verify YAML null declarations propagate to settings.json deletions end-to-end.
+
+    These tests construct a mock YAML config dict (with explicit None
+    values for profile-owned keys), compute the profile_config dict the
+    same way main() does via _YAML_TO_CAMEL_PROFILE_KEYS, invoke
+    _build_profile_settings() with that dict, and verify
+    write_profile_settings_to_settings() deletes the corresponding keys
+    from a pre-populated settings.json.
+    """
+
+    @pytest.mark.parametrize(
+        ('yaml_key', 'camel_key', 'initial_value'),
+        [
+            ('model', 'model', 'sonnet'),
+            ('permissions', 'permissions', {'allow': ['Read']}),
+            ('env-variables', 'env', {'FOO': 'bar'}),
+            ('attribution', 'attribution', {'commit': 'x', 'pr': 'y'}),
+            ('always-thinking-enabled', 'alwaysThinkingEnabled', True),
+            ('effort-level', 'effortLevel', 'high'),
+            ('company-announcements', 'companyAnnouncements', ['Welcome']),
+            ('status-line', 'statusLine', {'type': 'command', 'command': 'x'}),
+            ('hooks', 'hooks', {'PreToolUse': []}),
+        ],
+    )
+    def test_yaml_null_deletes_key_end_to_end(
+        self,
+        tmp_path: Path,
+        yaml_key: str,
+        camel_key: str,
+        initial_value: object,
+    ) -> None:
+        """A YAML-level `key: null` declaration deletes the on-disk key."""
+        from scripts.setup_environment import _YAML_TO_CAMEL_PROFILE_KEYS
+
+        # Pre-populate settings.json with the key
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(
+            json.dumps({camel_key: initial_value}), encoding='utf-8',
+        )
+
+        # Mock YAML config with an explicit null for the key
+        mock_config = {yaml_key: None}
+
+        # Replicate the main() call site logic: build profile_config dict
+        profile_config = {
+            ck: mock_config[yk]
+            for yk, ck in _YAML_TO_CAMEL_PROFILE_KEYS.items()
+            if yk in mock_config
+        }
+        assert profile_config == {camel_key: None}
+
+        # Invoke the builder
+        delta = _build_profile_settings(profile_config, tmp_path / 'hooks')
+        assert delta == {camel_key: None}
+
+        # Apply the delta via the writer
+        write_profile_settings_to_settings(delta, tmp_path)
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+
+        # The key has been deleted
+        assert camel_key not in content

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -3127,9 +3127,8 @@ class TestCreateSettings:
             claude_dir = Path(tmpdir)
 
             result = setup_environment.create_profile_config(
-                {},
+                {'model': 'claude-3-opus'},
                 claude_dir,
-                model='claude-3-opus',
             )
 
             assert result is True
@@ -3170,9 +3169,8 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                {},
+                {'permissions': permissions},
                 claude_dir,
-                permissions=permissions,
             )
 
             assert result is True
@@ -3216,7 +3214,7 @@ class TestCreateSettings:
 
             # Then create settings
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
             )
 
@@ -3250,7 +3248,7 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
             )
 
@@ -3289,7 +3287,7 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
             )
 
@@ -3324,7 +3322,7 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
             )
 
@@ -3360,7 +3358,7 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
             )
 
@@ -3402,7 +3400,7 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
             )
 
@@ -3443,7 +3441,7 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
             )
 
@@ -3460,9 +3458,8 @@ class TestCreateSettings:
             claude_dir = Path(tmpdir)
 
             result = setup_environment.create_profile_config(
-                {},
+                {'alwaysThinkingEnabled': True},
                 claude_dir,
-                always_thinking_enabled=True,
             )
 
             assert result is True
@@ -3478,9 +3475,8 @@ class TestCreateSettings:
             claude_dir = Path(tmpdir)
 
             result = setup_environment.create_profile_config(
-                {},
+                {'alwaysThinkingEnabled': False},
                 claude_dir,
-                always_thinking_enabled=False,
             )
 
             assert result is True
@@ -3491,14 +3487,13 @@ class TestCreateSettings:
             assert settings['alwaysThinkingEnabled'] is False
 
     def test_create_profile_config_always_thinking_enabled_none_not_included(self):
-        """Test alwaysThinkingEnabled not included when None."""
+        """Test alwaysThinkingEnabled not included when absent from profile_config."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
             result = setup_environment.create_profile_config(
                 {},
                 claude_dir,
-                always_thinking_enabled=None,
             )
 
             assert result is True
@@ -3513,9 +3508,8 @@ class TestCreateSettings:
             claude_dir = Path(tmpdir)
 
             result = setup_environment.create_profile_config(
-                {},
+                {'effortLevel': 'low'},
                 claude_dir,
-                effort_level='low',
             )
 
             assert result is True
@@ -3531,9 +3525,8 @@ class TestCreateSettings:
             claude_dir = Path(tmpdir)
 
             result = setup_environment.create_profile_config(
-                {},
+                {'effortLevel': 'medium'},
                 claude_dir,
-                effort_level='medium',
             )
 
             assert result is True
@@ -3549,9 +3542,8 @@ class TestCreateSettings:
             claude_dir = Path(tmpdir)
 
             result = setup_environment.create_profile_config(
-                {},
+                {'effortLevel': 'high'},
                 claude_dir,
-                effort_level='high',
             )
 
             assert result is True
@@ -3567,9 +3559,8 @@ class TestCreateSettings:
             claude_dir = Path(tmpdir)
 
             result = setup_environment.create_profile_config(
-                {},
+                {'effortLevel': 'max'},
                 claude_dir,
-                effort_level='max',
             )
 
             assert result is True
@@ -3580,14 +3571,13 @@ class TestCreateSettings:
             assert settings['effortLevel'] == 'max'
 
     def test_create_profile_config_effort_level_none_not_included(self):
-        """Test effortLevel not included when None."""
+        """Test effortLevel not included when absent from profile_config."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
             result = setup_environment.create_profile_config(
                 {},
                 claude_dir,
-                effort_level=None,
             )
 
             assert result is True
@@ -3606,9 +3596,8 @@ class TestCreateSettings:
             ]
 
             result = setup_environment.create_profile_config(
-                {},
+                {'companyAnnouncements': announcements},
                 claude_dir,
-                company_announcements=announcements,
             )
 
             assert result is True
@@ -3626,9 +3615,8 @@ class TestCreateSettings:
             announcements = ['Single announcement']
 
             result = setup_environment.create_profile_config(
-                {},
+                {'companyAnnouncements': announcements},
                 claude_dir,
-                company_announcements=announcements,
             )
 
             assert result is True
@@ -3644,9 +3632,8 @@ class TestCreateSettings:
             claude_dir = Path(tmpdir)
 
             result = setup_environment.create_profile_config(
-                {},
+                {'companyAnnouncements': []},
                 claude_dir,
-                company_announcements=[],
             )
 
             assert result is True
@@ -3658,14 +3645,13 @@ class TestCreateSettings:
             assert settings['companyAnnouncements'] == []
 
     def test_create_profile_config_company_announcements_none_not_included(self):
-        """Test companyAnnouncements not included when None."""
+        """Test companyAnnouncements not included when absent from profile_config."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
             result = setup_environment.create_profile_config(
                 {},
                 claude_dir,
-                company_announcements=None,
             )
 
             assert result is True
@@ -3684,9 +3670,8 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                {},
+                {'attribution': attribution},
                 claude_dir,
-                attribution=attribution,
             )
 
             assert result is True
@@ -3704,9 +3689,8 @@ class TestCreateSettings:
             attribution = {'commit': '', 'pr': ''}
 
             result = setup_environment.create_profile_config(
-                {},
+                {'attribution': attribution},
                 claude_dir,
-                attribution=attribution,
             )
 
             assert result is True
@@ -3716,14 +3700,13 @@ class TestCreateSettings:
             assert settings['attribution'] == {'commit': '', 'pr': ''}
 
     def test_create_profile_config_attribution_none_not_included(self):
-        """Test attribution not included when None."""
+        """Test attribution not included when absent from profile_config."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
             result = setup_environment.create_profile_config(
                 {},
                 claude_dir,
-                attribution=None,
             )
 
             assert result is True
@@ -3746,9 +3729,8 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                {},
+                {'statusLine': status_line},
                 claude_dir,
-                status_line=status_line,
             )
 
             assert result is True
@@ -3773,9 +3755,8 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                {},
+                {'statusLine': status_line},
                 claude_dir,
-                status_line=status_line,
             )
 
             assert result is True
@@ -3789,14 +3770,13 @@ class TestCreateSettings:
             assert 'padding' not in settings['statusLine']
 
     def test_create_profile_config_status_line_none_not_included(self):
-        """Test statusLine not included when None."""
+        """Test statusLine not included when absent from profile_config."""
         with tempfile.TemporaryDirectory() as tmpdir:
             claude_dir = Path(tmpdir)
 
             result = setup_environment.create_profile_config(
                 {},
                 claude_dir,
-                status_line=None,
             )
 
             assert result is True
@@ -3817,9 +3797,8 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                {},
+                {'statusLine': status_line},
                 claude_dir,
-                status_line=status_line,
             )
 
             assert result is True
@@ -3848,9 +3827,8 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                {},
+                {'statusLine': status_line},
                 claude_dir,
-                status_line=status_line,
             )
 
             assert result is True
@@ -3881,9 +3859,8 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                {},
+                {'statusLine': status_line},
                 claude_dir,
-                status_line=status_line,
             )
 
             assert result is True
@@ -3911,9 +3888,8 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                {},
+                {'statusLine': status_line},
                 claude_dir,
-                status_line=status_line,
             )
 
             assert result is True
@@ -3941,9 +3917,8 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                {},
+                {'statusLine': status_line},
                 claude_dir,
-                status_line=status_line,
             )
 
             assert result is True
@@ -3975,7 +3950,7 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
             )
 
@@ -4012,7 +3987,7 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
             )
 
@@ -4046,7 +4021,7 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
             )
 
@@ -4085,7 +4060,7 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
             )
 
@@ -4121,7 +4096,7 @@ class TestCreateSettings:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
             )
 
@@ -4187,7 +4162,7 @@ class TestArtifactIsolation:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
                 hooks_base_dir=isolated_hooks,
             )
@@ -4217,7 +4192,7 @@ class TestArtifactIsolation:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
             )
 
@@ -4257,10 +4232,8 @@ class TestArtifactIsolation:
             env_vars['CLAUDE_CONFIG_DIR'] = '~/.claude/my-env'
 
             result = setup_environment.create_profile_config(
-                {},
+                {'env': env_vars},
                 claude_dir,
-                'my-env',
-                env=env_vars,
             )
 
             assert result is True
@@ -4279,10 +4252,8 @@ class TestArtifactIsolation:
             env_vars = {'CLAUDE_CONFIG_DIR': '/custom/path'}
 
             result = setup_environment.create_profile_config(
-                {},
+                {'env': env_vars},
                 claude_dir,
-                'my-env',
-                env=env_vars,
             )
 
             assert result is True
@@ -4302,10 +4273,8 @@ class TestArtifactIsolation:
             env_vars = {'CLAUDE_CONFIG_DIR': '~/.claude/my-env'}
 
             result = setup_environment.create_profile_config(
-                {},
+                {'env': env_vars},
                 claude_dir,
-                'my-env',
-                env=env_vars,
             )
 
             assert result is True
@@ -4323,10 +4292,8 @@ class TestArtifactIsolation:
             env_vars = {'CLAUDE_CONFIG_DIR': r'C:\Users\test\.claude\my-env'}
 
             result = setup_environment.create_profile_config(
-                {},
+                {'env': env_vars},
                 claude_dir,
-                'my-env',
-                env=env_vars,
             )
 
             assert result is True
@@ -4342,9 +4309,8 @@ class TestArtifactIsolation:
             isolated_hooks.mkdir(parents=True)
 
             result = setup_environment.create_profile_config(
-                {},
+                {'statusLine': {'file': 'statusline.py', 'padding': 0}},
                 claude_dir,
-                status_line={'file': 'statusline.py', 'padding': 0},
                 hooks_base_dir=isolated_hooks,
             )
 
@@ -4372,7 +4338,7 @@ class TestArtifactIsolation:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
                 hooks_base_dir=isolated_hooks,
             )
@@ -4402,7 +4368,7 @@ class TestArtifactIsolation:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
                 hooks_base_dir=isolated_hooks,
             )
@@ -4586,7 +4552,7 @@ class TestBuildHooksJson:
             hooks_dir = config_dir / 'hooks'
 
             # Get result from create_profile_config
-            setup_environment.create_profile_config(hooks, config_dir)
+            setup_environment.create_profile_config({'hooks': hooks}, config_dir)
             config_json = json.loads((config_dir / 'config.json').read_text())
             config_hooks = config_json.get('hooks', {})
 
@@ -5162,12 +5128,14 @@ class TestMainFunction:
         assert 'Invalid effort-level value' in captured.out
         assert "'extreme'" in captured.out
 
-        # Verify create_profile_config was called with effort_level=None
-        # (the invalid value should have been reset to None)
+        # Verify create_profile_config receives a profile_config without
+        # an effortLevel entry (invalid values are stripped from config
+        # before profile_config construction).
         mock_settings.assert_called_once()
         call_args = mock_settings.call_args
-        # effort_level is the 10th positional argument (0-indexed: position 9)
-        assert call_args[0][9] is None
+        # profile_config is the first positional argument
+        profile_config = call_args[0][0]
+        assert 'effortLevel' not in profile_config
 
 
 class TestDownloadFailureTracking:
@@ -6862,27 +6830,33 @@ class TestProfileOwnedKeys:
 
 
 class TestBuildProfileSettings:
-    """Unit tests for _build_profile_settings() pure builder."""
+    """Unit tests for _build_profile_settings() pure builder.
 
-    def test_all_none_returns_empty_dict(self, tmp_path: Path) -> None:
-        """All None inputs produce an empty dict (no side effects)."""
-        result = setup_environment._build_profile_settings(
-            hooks={}, hooks_dir=tmp_path,
-        )
+    The builder accepts a single ``profile_config: dict[str, Any]`` parameter
+    keyed by camelCase on-disk names. Dict membership encodes the YAML
+    declaration state: keys absent from ``profile_config`` are OMITTED from
+    the output; keys present with ``None`` are emitted verbatim for downstream
+    RFC 7396 null-as-delete handling; keys present with non-None values are
+    processed (kebab-to-camel translation, command-string construction, etc.).
+    """
+
+    def test_empty_config_returns_empty_dict(self, tmp_path: Path) -> None:
+        """Empty profile_config produces an empty dict (no side effects)."""
+        result = setup_environment._build_profile_settings({}, tmp_path)
         assert result == {}
 
     def test_model_only(self, tmp_path: Path) -> None:
         """Only model set -> only 'model' key in result."""
         result = setup_environment._build_profile_settings(
-            hooks={}, hooks_dir=tmp_path, model='sonnet',
+            {'model': 'sonnet'}, tmp_path,
         )
         assert result == {'model': 'sonnet'}
 
     def test_permissions_kebab_to_camel(self, tmp_path: Path) -> None:
         """'default-mode' translated to 'defaultMode'."""
         result = setup_environment._build_profile_settings(
-            hooks={}, hooks_dir=tmp_path,
-            permissions={'default-mode': 'ask', 'allow': ['Read']},
+            {'permissions': {'default-mode': 'ask', 'allow': ['Read']}},
+            tmp_path,
         )
         assert 'defaultMode' in result['permissions']
         assert 'default-mode' not in result['permissions']
@@ -6891,8 +6865,8 @@ class TestBuildProfileSettings:
     def test_permissions_additional_directories_translation(self, tmp_path: Path) -> None:
         """'additional-directories' translated to 'additionalDirectories'."""
         result = setup_environment._build_profile_settings(
-            hooks={}, hooks_dir=tmp_path,
-            permissions={'additional-directories': ['/tmp/test']},
+            {'permissions': {'additional-directories': ['/tmp/test']}},
+            tmp_path,
         )
         assert 'additionalDirectories' in result['permissions']
         assert 'additional-directories' not in result['permissions']
@@ -6900,8 +6874,8 @@ class TestBuildProfileSettings:
     def test_env_values_stringified(self, tmp_path: Path) -> None:
         """Env values are preserved as strings in the output env dict."""
         result = setup_environment._build_profile_settings(
-            hooks={}, hooks_dir=tmp_path,
-            env={'FOO': 'bar', 'HELLO': 'world'},
+            {'env': {'FOO': 'bar', 'HELLO': 'world'}},
+            tmp_path,
         )
         assert result['env']['FOO'] == 'bar'
         assert result['env']['HELLO'] == 'world'
@@ -6910,51 +6884,50 @@ class TestBuildProfileSettings:
         """Attribution dict passed through unchanged."""
         attr = {'commit': 'Test commit', 'pr': 'Test PR'}
         result = setup_environment._build_profile_settings(
-            hooks={}, hooks_dir=tmp_path, attribution=attr,
+            {'attribution': attr}, tmp_path,
         )
         assert result['attribution'] == attr
 
     def test_attribution_empty_dict_not_omitted(self, tmp_path: Path) -> None:
         """Empty attribution dict is kept (not same as None)."""
         result = setup_environment._build_profile_settings(
-            hooks={}, hooks_dir=tmp_path, attribution={},
+            {'attribution': {}}, tmp_path,
         )
         assert 'attribution' in result
         assert result['attribution'] == {}
 
     def test_always_thinking_enabled_true(self, tmp_path: Path) -> None:
-        """always_thinking_enabled=True stored under alwaysThinkingEnabled."""
+        """alwaysThinkingEnabled=True stored under alwaysThinkingEnabled."""
         result = setup_environment._build_profile_settings(
-            hooks={}, hooks_dir=tmp_path, always_thinking_enabled=True,
+            {'alwaysThinkingEnabled': True}, tmp_path,
         )
         assert result == {'alwaysThinkingEnabled': True}
 
     def test_always_thinking_enabled_false_not_omitted(self, tmp_path: Path) -> None:
-        """always_thinking_enabled=False is explicit and kept."""
+        """alwaysThinkingEnabled=False is explicit and kept."""
         result = setup_environment._build_profile_settings(
-            hooks={}, hooks_dir=tmp_path, always_thinking_enabled=False,
+            {'alwaysThinkingEnabled': False}, tmp_path,
         )
         assert result == {'alwaysThinkingEnabled': False}
 
     def test_effort_level(self, tmp_path: Path) -> None:
-        """effort_level stored under effortLevel."""
+        """effortLevel stored under effortLevel."""
         result = setup_environment._build_profile_settings(
-            hooks={}, hooks_dir=tmp_path, effort_level='high',
+            {'effortLevel': 'high'}, tmp_path,
         )
         assert result == {'effortLevel': 'high'}
 
     def test_company_announcements_list(self, tmp_path: Path) -> None:
-        """company_announcements list stored under companyAnnouncements."""
+        """companyAnnouncements list stored under companyAnnouncements."""
         result = setup_environment._build_profile_settings(
-            hooks={}, hooks_dir=tmp_path, company_announcements=['msg1', 'msg2'],
+            {'companyAnnouncements': ['msg1', 'msg2']}, tmp_path,
         )
         assert result == {'companyAnnouncements': ['msg1', 'msg2']}
 
     def test_status_line_python_script(self, tmp_path: Path) -> None:
-        """status_line with .py file builds uv run command with absolute path."""
+        """statusLine with .py file builds uv run command with absolute path."""
         result = setup_environment._build_profile_settings(
-            hooks={}, hooks_dir=tmp_path,
-            status_line={'file': 'status.py'},
+            {'statusLine': {'file': 'status.py'}}, tmp_path,
         )
         sl = result['statusLine']
         assert sl['type'] == 'command'
@@ -6966,30 +6939,29 @@ class TestBuildProfileSettings:
         assert expected_path in sl['command']
 
     def test_status_line_with_config(self, tmp_path: Path) -> None:
-        """status_line with config appends config path to command."""
+        """statusLine with config appends config path to command."""
         result = setup_environment._build_profile_settings(
-            hooks={}, hooks_dir=tmp_path,
-            status_line={'file': 'status.py', 'config': 'status.yaml'},
+            {'statusLine': {'file': 'status.py', 'config': 'status.yaml'}},
+            tmp_path,
         )
         sl = result['statusLine']
         config_path = (tmp_path / 'status.yaml').as_posix()
         assert config_path in sl['command']
 
     def test_status_line_non_python_direct_path(self, tmp_path: Path) -> None:
-        """status_line with non-.py file uses direct path (no uv run)."""
+        """statusLine with non-.py file uses direct path (no uv run)."""
         result = setup_environment._build_profile_settings(
-            hooks={}, hooks_dir=tmp_path,
-            status_line={'file': 'status.sh'},
+            {'statusLine': {'file': 'status.sh'}}, tmp_path,
         )
         sl = result['statusLine']
         assert 'uv run' not in sl['command']
         assert 'status.sh' in sl['command']
 
     def test_status_line_padding_included(self, tmp_path: Path) -> None:
-        """status_line padding is included in the result."""
+        """statusLine padding is included in the result."""
         result = setup_environment._build_profile_settings(
-            hooks={}, hooks_dir=tmp_path,
-            status_line={'file': 'status.py', 'padding': 2},
+            {'statusLine': {'file': 'status.py', 'padding': 2}},
+            tmp_path,
         )
         assert result['statusLine']['padding'] == 2
 
@@ -7001,7 +6973,7 @@ class TestBuildProfileSettings:
             ],
         }
         result = setup_environment._build_profile_settings(
-            hooks=hooks_input, hooks_dir=tmp_path,
+            {'hooks': hooks_input}, tmp_path,
         )
         assert 'hooks' in result
         assert 'PreToolUse' in result['hooks']
@@ -7009,34 +6981,184 @@ class TestBuildProfileSettings:
     def test_hooks_empty_events_omitted(self, tmp_path: Path) -> None:
         """hooks with empty events is omitted from result."""
         result = setup_environment._build_profile_settings(
-            hooks={'events': []}, hooks_dir=tmp_path,
+            {'hooks': {'events': []}}, tmp_path,
         )
         assert 'hooks' not in result
 
     def test_all_nine_keys_together(self, tmp_path: Path) -> None:
         """All nine keys provided simultaneously produce full delta."""
         result = setup_environment._build_profile_settings(
-            hooks={'events': [{'event': 'PreToolUse', 'matcher': 'Bash',
-                               'type': 'command', 'command': 'test.sh'}]},
-            hooks_dir=tmp_path,
-            model='sonnet',
-            permissions={'allow': ['Read']},
-            env={'FOO': 'bar'},
-            always_thinking_enabled=True,
-            company_announcements=['Welcome'],
-            attribution={'commit': 'x', 'pr': 'y'},
-            status_line={'file': 'status.py'},
-            effort_level='high',
+            {
+                'model': 'sonnet',
+                'permissions': {'allow': ['Read']},
+                'env': {'FOO': 'bar'},
+                'attribution': {'commit': 'x', 'pr': 'y'},
+                'alwaysThinkingEnabled': True,
+                'effortLevel': 'high',
+                'companyAnnouncements': ['Welcome'],
+                'statusLine': {'file': 'status.py'},
+                'hooks': {'events': [{'event': 'PreToolUse', 'matcher': 'Bash',
+                                      'type': 'command', 'command': 'test.sh'}]},
+            },
+            tmp_path,
         )
         assert set(result.keys()) == setup_environment.PROFILE_OWNED_KEYS
+
+    def test_absent_keys_omitted_from_result(self, tmp_path: Path) -> None:
+        """Keys absent from profile_config are absent from result.
+
+        The builder does NOT backfill the 9-key universe with Nones or empty
+        values. Absent means absent. Present-with-value means included.
+        Present-with-None means included-as-None (for downstream null-as-delete).
+        """
+        result = setup_environment._build_profile_settings(
+            {'model': 'sonnet', 'permissions': {'allow': ['Read']}},
+            tmp_path,
+        )
+        # Only 'model' and 'permissions' present; none of the other keys
+        assert set(result.keys()) == {'model', 'permissions'}
+
+
+class TestYamlToCamelProfileKeysParity:
+    """Enforce parity between _YAML_TO_CAMEL_PROFILE_KEYS and PROFILE_OWNED_KEYS."""
+
+    def test_mapping_values_cover_all_profile_keys(self) -> None:
+        """Every PROFILE_OWNED_KEYS entry has a corresponding YAML key mapping."""
+        mapped_camel_keys = frozenset(setup_environment._YAML_TO_CAMEL_PROFILE_KEYS.values())
+        assert mapped_camel_keys == setup_environment.PROFILE_OWNED_KEYS
+
+    def test_mapping_yaml_keys_match_known_config_keys(self) -> None:
+        """Every YAML-side key in the mapping is a KNOWN_CONFIG_KEYS entry."""
+        for yaml_key in setup_environment._YAML_TO_CAMEL_PROFILE_KEYS:
+            assert yaml_key in setup_environment.KNOWN_CONFIG_KEYS, (
+                f"YAML key '{yaml_key}' in _YAML_TO_CAMEL_PROFILE_KEYS is not in KNOWN_CONFIG_KEYS"
+            )
+
+
+class TestBuildProfileSettingsExplicitNulls:
+    """Unit tests for propagating explicit YAML-null declarations through the builder.
+
+    When a profile-owned key is present in ``profile_config`` with value
+    ``None``, the builder emits ``settings[camel_key] = None`` verbatim (bypassing
+    the usual truthy/non-None guards). This lets the downstream writer apply
+    RFC 7396 null-as-delete to the shared settings.json when YAML declares
+    ``key: null`` at the root level.
+    """
+
+    def test_explicit_null_model_emits_none(self, tmp_path: Path) -> None:
+        result = setup_environment._build_profile_settings({'model': None}, tmp_path)
+        assert result == {'model': None}
+
+    def test_explicit_null_permissions_emits_none(self, tmp_path: Path) -> None:
+        result = setup_environment._build_profile_settings({'permissions': None}, tmp_path)
+        assert result == {'permissions': None}
+
+    def test_explicit_null_env_emits_none(self, tmp_path: Path) -> None:
+        result = setup_environment._build_profile_settings({'env': None}, tmp_path)
+        assert result == {'env': None}
+
+    def test_explicit_null_attribution_emits_none(self, tmp_path: Path) -> None:
+        result = setup_environment._build_profile_settings({'attribution': None}, tmp_path)
+        assert result == {'attribution': None}
+
+    def test_explicit_null_always_thinking_enabled_emits_none(self, tmp_path: Path) -> None:
+        result = setup_environment._build_profile_settings(
+            {'alwaysThinkingEnabled': None}, tmp_path,
+        )
+        assert result == {'alwaysThinkingEnabled': None}
+
+    def test_explicit_null_effort_level_emits_none(self, tmp_path: Path) -> None:
+        result = setup_environment._build_profile_settings({'effortLevel': None}, tmp_path)
+        assert result == {'effortLevel': None}
+
+    def test_explicit_null_company_announcements_emits_none(self, tmp_path: Path) -> None:
+        result = setup_environment._build_profile_settings(
+            {'companyAnnouncements': None}, tmp_path,
+        )
+        assert result == {'companyAnnouncements': None}
+
+    def test_explicit_null_status_line_emits_none(self, tmp_path: Path) -> None:
+        result = setup_environment._build_profile_settings({'statusLine': None}, tmp_path)
+        assert result == {'statusLine': None}
+
+    def test_explicit_null_hooks_emits_none(self, tmp_path: Path) -> None:
+        result = setup_environment._build_profile_settings({'hooks': None}, tmp_path)
+        assert result == {'hooks': None}
+
+    def test_absent_key_omitted_even_when_other_key_is_null(self, tmp_path: Path) -> None:
+        """Absent keys remain OMITTED even when another key is explicitly null."""
+        result = setup_environment._build_profile_settings(
+            {'permissions': None},
+            tmp_path,
+        )
+        # Only 'permissions' is in result (as None); model is OMITTED
+        assert result == {'permissions': None}
+        assert 'model' not in result
+
+    def test_multiple_explicit_nulls_together(self, tmp_path: Path) -> None:
+        """Multiple keys declared null all emit None simultaneously."""
+        result = setup_environment._build_profile_settings(
+            {
+                'model': None,
+                'permissions': None,
+                'env': None,
+                'attribution': None,
+                'alwaysThinkingEnabled': None,
+                'effortLevel': None,
+                'companyAnnouncements': None,
+                'statusLine': None,
+                'hooks': None,
+            },
+            tmp_path,
+        )
+        assert result == {
+            'model': None,
+            'permissions': None,
+            'env': None,
+            'attribution': None,
+            'alwaysThinkingEnabled': None,
+            'effortLevel': None,
+            'companyAnnouncements': None,
+            'statusLine': None,
+            'hooks': None,
+        }
+
+    def test_explicit_null_statusline_does_not_attempt_file_path_build(
+        self, tmp_path: Path,
+    ) -> None:
+        """Null statusLine short-circuits before command-string building.
+
+        Regression guard: the status-line block walks ``status_line['file']`` to
+        build the command string. If ``statusLine`` in ``profile_config`` is
+        ``None``, the short-circuit must emit ``None`` without crashing on the
+        dict access.
+        """
+        result = setup_environment._build_profile_settings({'statusLine': None}, tmp_path)
+        assert result == {'statusLine': None}
+
+    def test_explicit_null_hooks_does_not_call_build_hooks_json(self, tmp_path: Path) -> None:
+        """Null hooks short-circuits before _build_hooks_json() is invoked."""
+        result = setup_environment._build_profile_settings({'hooks': None}, tmp_path)
+        assert result == {'hooks': None}
+
+    def test_mixed_null_and_value(self, tmp_path: Path) -> None:
+        """Null and non-null keys can coexist in the same profile_config."""
+        result = setup_environment._build_profile_settings(
+            {'model': 'sonnet', 'permissions': None},
+            tmp_path,
+        )
+        assert result == {'model': 'sonnet', 'permissions': None}
 
 
 class TestWriteProfileSettingsToSettings:
     """Unit tests for write_profile_settings_to_settings().
 
-    Verifies the conditional top-level replace semantics applied when
-    writing profile-owned keys to the shared ~/.claude/settings.json
-    file in non-command-names mode.
+    Verifies the deep-merge + RFC 7396 null-as-delete semantics the
+    writer inherits from ``_write_merged_json()`` when writing the nine
+    profile-owned keys to the shared ~/.claude/settings.json file in
+    non-command-names mode. Keys not present in the delta are
+    preserved; nested dicts are deep-merged; ``permissions.allow/deny/ask``
+    arrays are unioned; and top-level ``None`` values delete keys.
     """
 
     def test_empty_delta_no_op(self, tmp_path: Path) -> None:
@@ -7061,7 +7183,7 @@ class TestWriteProfileSettingsToSettings:
         """Existing unrelated keys are preserved across the write.
 
         The writer must only touch keys explicitly present in the delta;
-        keys the writer was not asked to update must survive unchanged.
+        any key outside the delta must survive unchanged.
         """
         settings_file = tmp_path / 'settings.json'
         settings_file.write_text(json.dumps({
@@ -7087,10 +7209,10 @@ class TestWriteProfileSettingsToSettings:
         """Profile-owned keys NOT in the delta are preserved.
 
         If YAML declares only 'model' at root level and settings.json already
-        has 'permissions' from a previous invocation (or from Step 14
+        has 'permissions' from an earlier invocation (or from Step 14
         write_user_settings()), the 'permissions' key MUST survive. The writer
-        preserves any profile-owned key it was not asked to update, so that
-        previously-written values and Step 14 contributions are never silently
+        preserves any profile-owned key outside the current delta, so that
+        prior-run values and Step 14 contributions are never silently
         destroyed.
         """
         settings_file = tmp_path / 'settings.json'
@@ -7111,21 +7233,189 @@ class TestWriteProfileSettingsToSettings:
         assert content['permissions'] == {'allow': ['Read'], 'deny': ['Bash(rm -rf)']}
         assert content['env'] == {'FOO': 'bar'}
 
-    def test_top_level_replace_not_deep_merge(self, tmp_path: Path) -> None:
-        """Delta key value fully replaces existing value (no deep merge)."""
+    def test_deep_merge_preserves_unrelated_permissions_subkeys(self, tmp_path: Path) -> None:
+        """Deep-merge preserves permissions sub-keys not declared in the delta.
+
+        When the delta carries a partial permissions dict (e.g., only 'allow'),
+        existing sub-keys ('deny', 'ask') declared by other contributors
+        (manual user edits, Step 14 user-settings, or prior runs) MUST be
+        preserved. Deep-merge recurses into the 'permissions' dict and only
+        overwrites leaf conflicts, while 'permissions.allow' additionally
+        applies array-union.
+        """
         settings_file = tmp_path / 'settings.json'
         settings_file.write_text(json.dumps({
-            'permissions': {'allow': ['Read', 'Write'], 'deny': ['Bash']},
+            'permissions': {
+                'allow': ['Read', 'Write'],
+                'deny': ['Bash(rm -rf)'],
+                'ask': ['Edit'],
+            },
         }), encoding='utf-8')
 
-        # Delta permissions has only 'allow' (no 'deny')
+        result = setup_environment.write_profile_settings_to_settings(
+            {'permissions': {'allow': ['Glob']}}, tmp_path,
+        )
+        assert result is True
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        # Array-union on 'allow': {'Read', 'Write', 'Glob'}
+        assert set(content['permissions']['allow']) == {'Read', 'Write', 'Glob'}
+        # 'deny' and 'ask' PRESERVED
+        assert content['permissions']['deny'] == ['Bash(rm -rf)']
+        assert content['permissions']['ask'] == ['Edit']
+
+    def test_deep_merge_preserves_env_subkeys(self, tmp_path: Path) -> None:
+        """Deep-merge preserves env sub-keys not declared in the delta."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'env': {'DISABLE_AUTOUPDATER': '1', 'KEEP_ME': 'yes'},
+        }), encoding='utf-8')
+
+        result = setup_environment.write_profile_settings_to_settings(
+            {'env': {'FOO': 'bar'}}, tmp_path,
+        )
+        assert result is True
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        # All three keys present after merge
+        assert content['env']['DISABLE_AUTOUPDATER'] == '1'
+        assert content['env']['KEEP_ME'] == 'yes'
+        assert content['env']['FOO'] == 'bar'
+
+    def test_deep_merge_null_sub_key_delete_in_permissions(self, tmp_path: Path) -> None:
+        """Nested null in permissions deletes only that sub-key via RFC 7396."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'permissions': {'allow': ['Read'], 'deny': ['Bash']},
+        }), encoding='utf-8')
+
+        result = setup_environment.write_profile_settings_to_settings(
+            {'permissions': {'deny': None}}, tmp_path,
+        )
+        assert result is True
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        # 'allow' preserved, 'deny' deleted
+        assert content['permissions'] == {'allow': ['Read']}
+
+    def test_deep_merge_permissions_array_union_idempotent(self, tmp_path: Path) -> None:
+        """Array union with identical values is idempotent (no duplication)."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'permissions': {'allow': ['Read']},
+        }), encoding='utf-8')
+
         result = setup_environment.write_profile_settings_to_settings(
             {'permissions': {'allow': ['Read']}}, tmp_path,
         )
         assert result is True
         content = json.loads(settings_file.read_text(encoding='utf-8'))
-        # Full replacement: 'allow' is [Read] only, 'deny' is GONE
         assert content['permissions'] == {'allow': ['Read']}
+
+    def test_top_level_null_model_deletes_key(self, tmp_path: Path) -> None:
+        """Top-level None model deletes the key from settings.json via RFC 7396."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'model': 'sonnet',
+            'permissions': {'allow': ['Read']},
+        }), encoding='utf-8')
+
+        result = setup_environment.write_profile_settings_to_settings(
+            {'model': None}, tmp_path,
+        )
+        assert result is True
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert content == {'permissions': {'allow': ['Read']}}
+
+    def test_top_level_null_permissions_deletes_entire_block(self, tmp_path: Path) -> None:
+        """Top-level None permissions deletes the entire permissions block."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'permissions': {'allow': ['Read'], 'deny': ['Bash']},
+            'model': 'sonnet',
+        }), encoding='utf-8')
+
+        result = setup_environment.write_profile_settings_to_settings(
+            {'permissions': None}, tmp_path,
+        )
+        assert result is True
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert content == {'model': 'sonnet'}
+
+    def test_top_level_null_hooks_deletes_entire_block(self, tmp_path: Path) -> None:
+        """Top-level None hooks deletes the entire hooks block."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'hooks': {'PreToolUse': [{'matcher': '', 'hooks': []}]},
+            'model': 'sonnet',
+        }), encoding='utf-8')
+
+        result = setup_environment.write_profile_settings_to_settings(
+            {'hooks': None}, tmp_path,
+        )
+        assert result is True
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert content == {'model': 'sonnet'}
+
+    def test_top_level_null_env_deletes_key(self, tmp_path: Path) -> None:
+        """Top-level None env deletes the entire env block."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'env': {'FOO': 'bar', 'DISABLE_AUTOUPDATER': '1'},
+            'model': 'sonnet',
+        }), encoding='utf-8')
+
+        result = setup_environment.write_profile_settings_to_settings(
+            {'env': None}, tmp_path,
+        )
+        assert result is True
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert content == {'model': 'sonnet'}
+
+    def test_top_level_null_all_nine_keys_deletes_all(self, tmp_path: Path) -> None:
+        """All nine profile-owned keys set to None deletes them all."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'model': 'sonnet',
+            'permissions': {'allow': ['Read']},
+            'env': {'FOO': 'bar'},
+            'attribution': {'commit': 'x'},
+            'alwaysThinkingEnabled': True,
+            'effortLevel': 'high',
+            'companyAnnouncements': ['msg'],
+            'statusLine': {'type': 'command', 'command': 'a'},
+            'hooks': {'PreToolUse': []},
+        }), encoding='utf-8')
+
+        delta = dict.fromkeys(setup_environment.PROFILE_OWNED_KEYS)
+        result = setup_environment.write_profile_settings_to_settings(delta, tmp_path)
+        assert result is True
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        # All nine keys deleted
+        assert content == {}
+
+    def test_deep_merge_preserves_unrelated_top_level_keys_via_delegate(
+        self, tmp_path: Path,
+    ) -> None:
+        """Writer delegates to _write_merged_json() and preserves unrelated keys.
+
+        Regression guard: verify the delegation behaves identically to
+        write_user_settings() for the unrelated-key preservation case.
+        """
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(json.dumps({
+            'language': 'english',
+            'theme': 'dark',
+            'permissions': {'allow': ['Read']},
+        }), encoding='utf-8')
+
+        result = setup_environment.write_profile_settings_to_settings(
+            {'permissions': {'allow': ['Write']}}, tmp_path,
+        )
+        assert result is True
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        # Unrelated top-level keys preserved
+        assert content['language'] == 'english'
+        assert content['theme'] == 'dark'
+        # permissions.allow unioned
+        assert set(content['permissions']['allow']) == {'Read', 'Write'}
 
     def test_none_value_deletes_key(self, tmp_path: Path) -> None:
         """None value in delta deletes key from existing settings.json."""
@@ -7202,28 +7492,22 @@ class TestCreateProfileConfigDelegation:
                 {'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'command', 'command': 'test.sh'},
             ],
         }
+        profile_config = {
+            'hooks': hooks,
+            'model': 'sonnet',
+            'permissions': {'allow': ['Read']},
+            'env': {'FOO': 'bar'},
+            'alwaysThinkingEnabled': True,
+            'effortLevel': 'high',
+        }
 
         # Call create_profile_config (writes to config.json)
-        setup_environment.create_profile_config(
-            hooks=hooks,
-            config_base_dir=config_dir,
-            model='sonnet',
-            permissions={'allow': ['Read']},
-            env={'FOO': 'bar'},
-            always_thinking_enabled=True,
-            effort_level='high',
-        )
+        setup_environment.create_profile_config(profile_config, config_dir)
         on_disk = json.loads((config_dir / 'config.json').read_text(encoding='utf-8'))
 
         # Call builder directly (use same hooks dir create_profile_config would use)
         expected = setup_environment._build_profile_settings(
-            hooks=hooks,
-            hooks_dir=config_dir / 'hooks',
-            model='sonnet',
-            permissions={'allow': ['Read']},
-            env={'FOO': 'bar'},
-            always_thinking_enabled=True,
-            effort_level='high',
+            profile_config, config_dir / 'hooks',
         )
 
         # Must match
@@ -10653,10 +10937,11 @@ class TestUserSettingsIntegration:
 
         # Write profile settings (simulating settings file behavior)
         result2 = setup_environment.create_profile_config(
-            hooks={},  # Empty hooks
-            config_base_dir=claude_dir,
-            model=profile_settings['model'],
-            permissions=profile_settings['permissions'],
+            {
+                'model': profile_settings['model'],
+                'permissions': profile_settings['permissions'],
+            },
+            claude_dir,
         )
         assert result2 is True
 

--- a/tests/test_setup_environment_additional.py
+++ b/tests/test_setup_environment_additional.py
@@ -947,10 +947,8 @@ class TestCreateSettingsComplex:
             }
 
             result = setup_environment.create_profile_config(
-                {},
+                {'permissions': permissions},
                 claude_dir,
-                'test',
-                permissions=permissions,
             )
 
             assert result is True
@@ -972,10 +970,8 @@ class TestCreateSettingsComplex:
             permissions = {'deny': ['mcp__blocked_server']}
 
             setup_environment.create_profile_config(
-                {},
+                {'permissions': permissions},
                 claude_dir,
-                'test',
-                permissions=permissions,
             )
 
             settings_file = claude_dir / 'config.json'
@@ -995,10 +991,8 @@ class TestCreateSettingsComplex:
             permissions = {'ask': ['mcp__ask_server']}
 
             setup_environment.create_profile_config(
-                {},
+                {'permissions': permissions},
                 claude_dir,
-                'test',
-                permissions=permissions,
             )
 
             settings_file = claude_dir / 'config.json'
@@ -1018,10 +1012,8 @@ class TestCreateSettingsComplex:
             }
 
             setup_environment.create_profile_config(
-                {},
+                {'env': env_vars},
                 claude_dir,
-                'test',
-                env=env_vars,
             )
 
             settings_file = claude_dir / 'config.json'
@@ -1043,9 +1035,8 @@ class TestCreateSettingsComplex:
             }
 
             setup_environment.create_profile_config(
-                {},
+                {'env': env_vars},
                 claude_dir,
-                env=env_vars,
             )
 
             settings_file = claude_dir / 'config.json'
@@ -1089,9 +1080,8 @@ class TestCreateSettingsComplex:
             }
 
             setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
-                'test',
             )
 
             settings_file = claude_dir / 'config.json'
@@ -1137,9 +1127,8 @@ class TestCreateSettingsComplex:
 
             # Then create settings
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
-                'test',
             )
 
             assert result is True
@@ -1161,9 +1150,8 @@ class TestCreateSettingsComplex:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
-                'test',
             )
 
             # Should still succeed but skip invalid hook
@@ -1186,9 +1174,8 @@ class TestCreateSettingsComplex:
             }
 
             setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
-                'test',
             )
 
             settings_file = claude_dir / 'config.json'
@@ -1211,7 +1198,6 @@ class TestCreateSettingsComplex:
                 result = setup_environment.create_profile_config(
                     {},
                     claude_dir,
-                    'test',
                 )
 
             assert result is False
@@ -2633,9 +2619,8 @@ class TestHookConfigFileSupport:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
-                'test',
             )
 
             assert result is True
@@ -2672,9 +2657,8 @@ class TestHookConfigFileSupport:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
-                'test',
             )
 
             assert result is True
@@ -2716,9 +2700,8 @@ class TestHookConfigFileSupport:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
-                'test',
             )
 
             assert result is True
@@ -2756,9 +2739,8 @@ class TestHookConfigFileSupport:
             }
 
             result = setup_environment.create_profile_config(
-                hooks,
+                {'hooks': hooks},
                 claude_dir,
-                'test',
             )
 
             assert result is True


### PR DESCRIPTION
Replace the conditional top-level replace semantics in write_profile_settings_to_settings() with a thin delegation to _write_merged_json() so that the shared ~/.claude/settings.json writer for the nine profile-owned keys uses unified deep-merge, array-union for permissions.allow/deny/ask, and RFC 7396 null-as-delete at both top level and nested levels. The previous top-level replace silently destroyed nested sub-keys contributed by other sources (manual edits, Claude Code CLI writes, prior YAML runs, and Step 14 write_user_settings() deep-merge results), with security-critical impact on permissions.deny.

Restructure _build_profile_settings() and create_profile_config() to accept a single profile_config dict and introduce the _YAML_TO_CAMEL_PROFILE_KEYS mapping so dict membership encodes the declared-vs-absent distinction. This allows YAML-level model: null (and any other profile-owned key set to null) to propagate through the builder to the writer, where _merge_recursive() applies null-as-delete to the on-disk file.

Keep isolated mode semantics unchanged: create_profile_config() still produces an atomic overwrite of ~/.claude/{cmd}/config.json from the builder output.

Update unit and E2E tests extensively to assert deep-merge preservation of unrelated sub-keys, array-union for permissions, end-to-end null-as-delete coverage across all nine keys, and parity between the builder and the writer. Rename TestConditionalReplaceWriterFilesystem to TestDeepMergeWriterFilesystem and realign conflict-warning wording in detect_settings_conflicts().

Update docs/environment-configuration-guide.md to document the three-writer deep-merge model, remove top-level replace terminology, and expand null-as-delete examples including permissions: {deny: null} and hooks: {EventName: null}.