### PR TITLE
Union every array in shared Claude Code settings files

### DIFF
--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -794,12 +794,12 @@ command-defaults:
 
 #### `user-settings`
 
-Free-form settings merged into `~/.claude/settings.json`. Uses deep merge with array union for `permissions.allow`, `permissions.deny`, and `permissions.ask`.
+Free-form settings merged into `~/.claude/settings.json`. Uses deep merge with universal array union: every list at every depth is unioned with structural dedupe, matching [Claude Code CLI's cross-scope merge semantics](https://code.claude.com/docs/en/settings) ("arrays are concatenated and deduplicated, not replaced").
 
 - **Type:** `UserSettings | None`
 - **Default:** `None`
 - **Excluded keys:** `hooks` and `statusLine` (these require dedicated write logic with path resolution and type processing, and must be configured at the root level of the YAML configuration)
-- **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: deep recursive merge using `deep_merge_settings()` with `DEFAULT_ARRAY_UNION_KEYS` (`permissions.allow`, `permissions.deny`, `permissions.ask` arrays are unioned with deduplication). Child keys override matching parent keys; `null` values delete keys.
+- **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: deep recursive merge using `deep_merge_settings()` with `DEFAULT_ARRAY_UNION_KEYS` (`permissions.allow`, `permissions.deny`, `permissions.ask` arrays are unioned with deduplication; other arrays use child-replaces-parent semantics in the YAML inheritance layer). Child keys override matching parent keys; `null` values delete keys. **Note:** YAML inheritance semantics are intentionally separate from on-disk write semantics. The on-disk writer (`write_user_settings()` -> `_write_merged_json()`) uses universal array union at every depth for all keys; `DEFAULT_ARRAY_UNION_KEYS` applies only inside the YAML composition layer.
 - **Example:**
 
 ```yaml
@@ -837,7 +837,7 @@ user-settings:
 
 **Precedence rule for the 9 profile-owned keys:**
 
-If you declare a profile-owned key (for example, `permissions`) at BOTH YAML root level AND under `user-settings:`, Step 18 `write_profile_settings_to_settings()` runs AFTER Step 14 `write_user_settings()` and deep-merges its delta on top of the Step 14 result. For scalar keys, the root-level value overwrites the `user-settings` value. For dict keys (such as `permissions`), the two contributions are deep-merged: sub-keys declared only on one side are preserved, sub-keys declared on both sides are resolved by the root-level value winning, and `permissions.allow/deny/ask` arrays are unioned (deduplicated) across both sources. A warning from `detect_settings_conflicts()` is emitted during validation to make the contract explicit. The warning fires in BOTH command-names-present and command-names-absent modes.
+If you declare a profile-owned key (for example, `permissions`) at BOTH YAML root level AND under `user-settings:`, Step 18 `write_profile_settings_to_settings()` runs AFTER Step 14 `write_user_settings()` and deep-merges its delta on top of the Step 14 result. For scalar keys, the root-level value overwrites the `user-settings` value. For dict keys (such as `permissions`), the two contributions are deep-merged: sub-keys declared only on one side are preserved, sub-keys declared on both sides are resolved by the root-level value winning, and every list-valued sub-key at any depth (including `permissions.allow`, `permissions.deny`, `permissions.ask`, `permissions.additionalDirectories`) is unioned with structural dedupe across both sources under the universal array-union contract. A warning from `detect_settings_conflicts()` is emitted during validation to make the contract explicit. The warning fires in BOTH command-names-present and command-names-absent modes.
 
 **Why the two surfaces coexist:**
 
@@ -853,16 +853,16 @@ These two keys are blocked by `check_excluded_keys` in the `UserSettings` Pydant
 
 **Preservation contract for `user-settings`:**
 
-Keys that you put under `user-settings:` are preserved even when you re-run the setup with a different YAML that omits them, because Step 14 `write_user_settings()` uses deep-merge semantics and never deletes keys unless you set them to `null`. Additionally, Step 18 `write_profile_settings_to_settings()` only touches keys that appear in the profile delta; all other keys (including your `user-settings` contributions and any user-managed keys outside the YAML) remain intact. This is the deliberate shared-file semantics: the toolbox does NOT surprise-delete anything from the shared `~/.claude/settings.json`. See [Profile-Level Settings Routing](#profile-level-settings-routing) below for the full write semantics contract and the deferred stale-key behavior.
+Keys that you put under `user-settings:` are preserved even when you re-run the setup with a different YAML that omits them, because Step 14 `write_user_settings()` uses deep-merge semantics and never deletes keys unless you set them to `null`. Additionally, Step 18 `write_profile_settings_to_settings()` only touches keys that appear in the profile delta; all other keys (including your `user-settings` contributions and any user-managed keys outside the YAML) remain intact. List-valued keys (at any depth) accumulate additively across runs under the universal array-union contract, so elements you wrote in earlier runs are never silently deleted. This is the deliberate shared-file semantics: the toolbox does NOT surprise-delete anything from the shared `~/.claude/settings.json`. See [Profile-Level Settings Routing](#profile-level-settings-routing) below for the full write semantics contract and the deferred stale-key behavior.
 
 #### `global-config`
 
-Settings merged into `~/.claude.json` (the Claude Code global configuration file). When `command-names` is present, additionally written to `~/.claude/{cmd}/.claude.json` for isolated environments (Claude Code CLI resolves `getGlobalClaudeFile()` via `CLAUDE_CONFIG_DIR` with no fallback to the home directory). Uses deep merge with no array union (arrays are replaced, not merged).
+Settings merged into `~/.claude.json` (the Claude Code global configuration file). When `command-names` is present, additionally written to `~/.claude/{cmd}/.claude.json` for isolated environments (Claude Code CLI resolves `getGlobalClaudeFile()` via `CLAUDE_CONFIG_DIR` with no fallback to the home directory). Uses deep merge with universal array union: every list at every depth is unioned with structural dedupe, matching [Claude Code CLI's cross-scope merge semantics](https://code.claude.com/docs/en/settings) and preserving CLI-managed state at runtime (OAuth tokens, per-project trust decisions, user-scoped MCP server approvals via `/mcp approve`, `enabledPlugins`, `enabledMcpjsonServers`/`disabledMcpjsonServers`).
 
 - **Type:** `GlobalConfig | None`
 - **Default:** `None`
 - **Excluded keys:** `oauthAccount` cannot be set to non-null values (OAuth credentials must not appear in YAML configuration files). Set `oauthAccount: null` to clear authentication state.
-- **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: deep recursive merge using `deep_merge_settings()` with `array_union_keys=set()` (arrays are replaced, not unioned). Child keys override matching parent keys; `null` values delete keys (RFC 7396).
+- **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: deep recursive merge using `deep_merge_settings()` with `array_union_keys=set()` (arrays are replaced in the YAML inheritance layer for child-overrides-parent composition). Child keys override matching parent keys; `null` values delete keys (RFC 7396). **Note:** YAML inheritance semantics are intentionally separate from on-disk write semantics. The on-disk writer (`write_global_config()` -> `_write_merged_json()`) uses universal array union at every depth; the `set()` form applies only inside the YAML composition layer.
 - **Example:**
 
 ```yaml
@@ -1204,9 +1204,9 @@ Hooks are routed to different target files based on whether `command-names` is s
 | `command-names` present | `~/.claude/{cmd}/config.json`  | `create_profile_config()` (atomic overwrite)           | `~/.claude/{cmd}/hooks/` |
 | `command-names` absent  | `~/.claude/settings.json`      | `write_profile_settings_to_settings()` (deep-merge)    | `~/.claude/hooks/`       |
 
-When `command-names` is absent, the setup writes hooks to the global `~/.claude/settings.json` via `write_profile_settings_to_settings()` as part of the 9-key `PROFILE_OWNED_KEYS` delta. The writer delegates to `_write_merged_json()`, which deep-merges the `hooks` dict into the existing file: disjoint event names (in the delta but not on disk, and vice versa) compose additively, and overlapping event names have their per-event lists replaced at the leaf (because `hooks.{EventName}` is NOT in `DEFAULT_ARRAY_UNION_KEYS`). All other keys -- user-managed keys, other profile-owned keys not in the current delta, and Step 14 `user-settings` contributions -- are preserved. See [Profile-Level Settings Routing](#profile-level-settings-routing) for the full contract.
+When `command-names` is absent, the setup writes hooks to the global `~/.claude/settings.json` via `write_profile_settings_to_settings()` as part of the 9-key `PROFILE_OWNED_KEYS` delta. The writer delegates to `_write_merged_json()`, which deep-merges the `hooks` dict into the existing file: disjoint event names (in the delta but not on disk, and vice versa) compose additively, and the per-event matcher-group lists are unioned with structural dedupe across runs (every list at every depth is unioned under the universal array-union contract). All other keys -- user-managed keys, other profile-owned keys not in the current delta, and Step 14 `user-settings` contributions -- are preserved. See [Profile-Level Settings Routing](#profile-level-settings-routing) for the full contract.
 
-**Re-run behavior:** When the YAML re-declares `hooks`, the deep-merge writer recurses into the existing `hooks` dict. Disjoint event names compose additively across runs. Overlapping event names have their per-event lists replaced at the leaf, so manually-added events under new event names survive, while manually-added events under event names that the YAML re-declares are replaced by the YAML's new entries. To fully clear stale events for a specific event name, either re-declare the event name with the desired list in YAML, or set `hooks: {EventName: null}` to delete just that event list.
+**Re-run behavior:** When the YAML re-declares `hooks`, the deep-merge writer recurses into the existing `hooks` dict. Disjoint event names compose additively across runs. For the same event name, matcher groups accumulate: two matcher groups with the same `matcher` string but different inner handlers from different runs coexist as separate entries (naive structural dedupe -- they are not structurally equal, so neither is discarded). Structurally identical matcher groups collapse to one, making repeat runs with the same YAML idempotent. This matches [Claude Code's native cross-scope merge semantics](https://code.claude.com/docs/en/settings); at runtime, Claude Code deduplicates command hooks by command string and HTTP hooks by URL (per the [Claude Code hooks documentation](https://code.claude.com/docs/en/hooks): "Command hooks are deduplicated by command string, and HTTP hooks are deduplicated by URL"), so on-disk consolidation is unnecessary. To fully clear stale events for a specific event name, set `hooks: {EventName: null}` to delete just that event list; declaring a new list under the same event name unions with existing entries rather than replacing them.
 
 **Deleting hooks:** Setting `hooks: null` at YAML root level deletes the entire `hooks` key from `~/.claude/settings.json` via RFC 7396 null-as-delete. Setting `hooks: {EventName: null}` deletes just that event list while preserving the other events under `hooks`. OMITTING `hooks` entirely from a subsequent YAML run does NOT delete it (per [Deferred Stale-Key Behavior](#deferred-stale-key-behavior-user-facing-contract)); the prior-run `hooks` content is preserved.
 
@@ -1469,16 +1469,18 @@ If all levels 2-4 use merge: `[A, B, C, D, E]`.
 
 #### Merge Strategies by Key Type
 
-| Type                   | Keys                                | Strategy                                                                             |
-|------------------------|-------------------------------------|--------------------------------------------------------------------------------------|
-| String list            | `agents`, `slash-commands`, `rules` | Concatenate parent + child; deduplicate by string equality; parent items first       |
-| Named list (by `name`) | `mcp-servers`, `skills`             | Identity-based: child overrides parent in-position; new items appended               |
-| Named list (by `dest`) | `files-to-download`                 | Identity-based: child overrides parent in-position; new items appended               |
-| Per-platform dict      | `dependencies`                      | Per-platform sub-key list concatenation with deduplication                           |
-| Composite              | `hooks`                             | `files`: concat + dedup by full path; `events`: concat (no dedup)                    |
-| Deep dict              | `global-config`                     | `deep_merge_settings()` with no array union                                          |
-| Deep dict              | `user-settings`                     | `deep_merge_settings()` with `permissions.*` array union                             |
-| Shallow dict           | `env-variables`, `os-env-variables` | Shallow merge; child overrides; `null` deletes (RFC 7396)                            |
+| Type                   | Keys                                | Strategy                                                                              |
+|------------------------|-------------------------------------|---------------------------------------------------------------------------------------|
+| String list            | `agents`, `slash-commands`, `rules` | Concatenate parent + child; deduplicate by string equality; parent items first        |
+| Named list (by `name`) | `mcp-servers`, `skills`             | Identity-based: child overrides parent in-position; new items appended                |
+| Named list (by `dest`) | `files-to-download`                 | Identity-based: child overrides parent in-position; new items appended                |
+| Per-platform dict      | `dependencies`                      | Per-platform sub-key list concatenation with deduplication                            |
+| Composite              | `hooks`                             | `files`: concat + dedup by full path; `events`: concat (no dedup)                     |
+| Deep dict              | `global-config`                     | `deep_merge_settings()` with `array_union_keys=set()` (YAML inheritance layer only)   |
+| Deep dict              | `user-settings`                     | `deep_merge_settings()` with `DEFAULT_ARRAY_UNION_KEYS` (YAML inheritance layer only) |
+| Shallow dict           | `env-variables`, `os-env-variables` | Shallow merge; child overrides; `null` deletes (RFC 7396)                             |
+
+> **Note:** The `global-config` and `user-settings` rows above describe the YAML inheritance layer only -- how `merge-keys` composes parent and child configurations before the writer touches disk. The on-disk writers (`write_global_config()`, `write_user_settings()`, `write_profile_settings_to_settings()`) use the universal array-union contract: every list at every depth is unioned with structural dedupe, independent of `DEFAULT_ARRAY_UNION_KEYS`. See [Profile-Level Settings Routing](#profile-level-settings-routing) for the on-disk write contract.
 
 #### Non-Mergeable Keys
 
@@ -1731,7 +1733,7 @@ Here is a conceptual overview of what the setup script does when you run it with
 15. **Write global config** -- Merges `global-config` into `~/.claude.json`.
 16. **Cleanup stale controls** -- Sweeps all filesystem locations for stale auto-update and IDE extension artifacts from prior configurations.
 17. **Download hooks** -- Downloads hook script files to `~/.claude/{cmd}/hooks/` (with `command-names`) or `~/.claude/hooks/` (without). In non-command-names mode, Step 17 runs when ANY of the following are declared: `hooks.events` non-empty, `hooks.files` non-empty, or `status-line.file` set.
-18. **Write profile settings** -- Writes all nine profile-owned keys (`model`, `permissions`, `env`, `attribution`, `alwaysThinkingEnabled`, `effortLevel`, `companyAnnouncements`, `statusLine`, `hooks`) as camelCase keys on disk. With `command-names`: writes to `~/.claude/{cmd}/config.json` via `create_profile_config()` (atomic overwrite -- fresh dict each run). Without `command-names`: writes to `~/.claude/settings.json` via `write_profile_settings_to_settings()`, which delegates to `_write_merged_json()` for **deep-merge, array-union for `permissions.allow/deny/ask`, and RFC 7396 null-as-delete** (preserves non-delta keys; see [Profile-Level Settings Routing](#profile-level-settings-routing)).
+18. **Write profile settings** -- Writes all nine profile-owned keys (`model`, `permissions`, `env`, `attribution`, `alwaysThinkingEnabled`, `effortLevel`, `companyAnnouncements`, `statusLine`, `hooks`) as camelCase keys on disk. With `command-names`: writes to `~/.claude/{cmd}/config.json` via `create_profile_config()` (atomic overwrite -- fresh dict each run). Without `command-names`: writes to `~/.claude/settings.json` via `write_profile_settings_to_settings()`, which delegates to `_write_merged_json()` for **deep-merge, universal array union at every depth, and RFC 7396 null-as-delete** (preserves non-delta keys; see [Profile-Level Settings Routing](#profile-level-settings-routing)).
 19. **Write manifest** -- Creates an installation tracking manifest. (Only if `command-names` is specified.)
 20. **Create launcher** -- Creates the launcher script for the command. (Only if `command-names` is specified.)
 21. **Register commands** -- Creates global command wrappers. (Only if `command-names` is specified.)
@@ -1764,61 +1766,65 @@ The shared pure builder `_build_profile_settings()` performs kebab-to-camel tran
 
 When `command-names` is specified, the setup creates an isolated directory `~/.claude/{cmd}/` containing:
 
-| File            | Priority (CLI)   | Content                                                 | Writer                    | Step | Semantics                                                                         |
-|-----------------|------------------|---------------------------------------------------------|---------------------------|------|-----------------------------------------------------------------------------------|
-| `settings.json` | 5 (userSettings) | YAML `user-settings:` (all non-excluded keys)           | `write_user_settings()`   | 14   | Deep merge + array-union (`permissions.allow/deny/ask`) + RFC 7396 null-as-delete |
-| `config.json`   | 2 (flagSettings) | 9 `PROFILE_OWNED_KEYS` from YAML root                   | `create_profile_config()` | 18   | Atomic overwrite (fresh dict each run)                                            |
+| File            | Priority (CLI)   | Content                                                 | Writer                    | Step | Semantics                                                                            |
+|-----------------|------------------|---------------------------------------------------------|---------------------------|------|--------------------------------------------------------------------------------------|
+| `settings.json` | 5 (userSettings) | YAML `user-settings:` (all non-excluded keys)           | `write_user_settings()`   | 14   | Deep merge + universal array union at every depth + RFC 7396 null-as-delete          |
+| `config.json`   | 2 (flagSettings) | 9 `PROFILE_OWNED_KEYS` from YAML root                   | `create_profile_config()` | 18   | Atomic overwrite (fresh dict each run, fully toolbox-owned)                          |
 
-The launcher script passes `config.json` via the `--settings` flag and sets `CLAUDE_CONFIG_DIR` to the isolated directory. Claude Code CLI's native priority resolution (`flagSettings (2) > userSettings (5)`) ensures `config.json` wins over `settings.json` for overlapping keys at runtime. In isolated mode, stale-key accumulation is NOT a concern because `create_profile_config()` uses atomic overwrite: every run produces a fresh `config.json` containing only the currently-declared keys, so removing a key from YAML cleanly removes it from `config.json` on the next run.
+The launcher script passes `config.json` via the `--settings` flag and sets `CLAUDE_CONFIG_DIR` to the isolated directory. Claude Code CLI's native priority resolution (`flagSettings (2) > userSettings (5)`) ensures `config.json` wins over `settings.json` for overlapping keys at runtime. In isolated mode, stale-key accumulation in `config.json` is NOT a concern because `create_profile_config()` uses atomic overwrite: every run produces a fresh `config.json` containing only the currently-declared keys, so removing a key from YAML cleanly removes it from `config.json` on the next run. The isolated `settings.json` (written by `write_user_settings()`) follows the universal shared-settings merge contract and preserves contributions from prior runs and manual edits.
 
 ### Non-Isolated Mode (command-names absent)
 
 When `command-names` is ABSENT, the setup writes to the shared `~/.claude/` directory. BOTH Step 14 and Step 18 target the SAME file (`~/.claude/settings.json`) and BOTH use the same READ-MERGE-WRITE contract inherited from `_write_merged_json()`:
 
-| File                       | Content                                            | Writer                                  | Step | Semantics                                                                          |
-|----------------------------|----------------------------------------------------|-----------------------------------------|------|------------------------------------------------------------------------------------|
-| `~/.claude/settings.json`  | YAML `user-settings:` (all non-excluded keys)      | `write_user_settings()`                 | 14   | Deep merge + array-union (`permissions.allow/deny/ask`) + RFC 7396 null-as-delete  |
-| `~/.claude/settings.json`  | 9 `PROFILE_OWNED_KEYS` delta from YAML root        | `write_profile_settings_to_settings()`  | 18   | Deep merge + array-union (`permissions.allow/deny/ask`) + RFC 7396 null-as-delete  |
+| File                       | Content                                            | Writer                                  | Step | Semantics                                                                    |
+|----------------------------|----------------------------------------------------|-----------------------------------------|------|------------------------------------------------------------------------------|
+| `~/.claude/settings.json`  | YAML `user-settings:` (all non-excluded keys)      | `write_user_settings()`                 | 14   | Deep merge + universal array union at every depth + RFC 7396 null-as-delete  |
+| `~/.claude/settings.json`  | 9 `PROFILE_OWNED_KEYS` delta from YAML root        | `write_profile_settings_to_settings()`  | 18   | Deep merge + universal array union at every depth + RFC 7396 null-as-delete  |
 
-1. **Step 14** deep-merges `user-settings:` into `settings.json`. Existing keys are preserved; for leaf conflicts the new YAML values overwrite the existing values; `permissions.allow/deny/ask` arrays are unioned with deduplication; `null` values delete keys via RFC 7396.
-2. **Step 18** deep-merges the profile delta into the same file using the same semantics. Existing keys not in the delta are preserved; existing nested dicts are recursively merged with the delta (leaf conflicts resolved by the delta winning, array-union for `permissions.allow/deny/ask`); top-level or nested `null` in the delta deletes keys.
+1. **Step 14** deep-merges `user-settings:` into `settings.json`. Existing keys are preserved; for leaf scalar conflicts the new YAML values overwrite the existing values; every list at every depth is unioned with structural dedupe; `null` values delete keys via RFC 7396.
+2. **Step 18** deep-merges the profile delta into the same file using the same semantics. Existing keys not in the delta are preserved; existing nested dicts are recursively merged with the delta; every list at every depth is unioned with structural dedupe across both steps; top-level or nested `null` in the delta deletes keys.
 
-Under this contract, the shared `~/.claude/settings.json` is never scrubbed of keys the current YAML does not declare, and contributions from manual user edits, other YAML configurations, the Claude Code CLI itself, and `user-settings.permissions` at Step 14 all survive profile-settings writes at Step 18.
+Under this contract, the shared `~/.claude/settings.json` is never scrubbed of keys the current YAML does not declare, and contributions from manual user edits, other YAML configurations, the Claude Code CLI itself, and `user-settings.permissions` at Step 14 all survive profile-settings writes at Step 18. List-valued keys (such as `permissions.allow/deny/ask/additionalDirectories`, `companyAnnouncements`, `hooks.<EventName>` matcher-group lists, `sandbox.filesystem.*` path lists, `disabledMcpjsonServers`/`enabledMcpjsonServers`) accumulate additively across runs, matching [Claude Code CLI's documented cross-scope merge semantics](https://code.claude.com/docs/en/settings): "arrays are concatenated and deduplicated, not replaced".
 
 ### Write Semantics Contract
 
-**Design principle:** `~/.claude/settings.json` is a SHARED/COMMON user-facing file. The toolbox treats it as a collaborative surface: other writers (the user, the CLI, other YAML configurations) contribute keys the current run knows nothing about, and the profile-settings writer preserves those contributions while still allowing explicit deletion via YAML-level null.
+**Design principle:** `~/.claude/settings.json` is a SHARED/COMMON user-facing file. The toolbox treats it as a collaborative surface: other writers (the user, the CLI, other YAML configurations) contribute keys the current run knows nothing about, and the shared-settings writers preserve those contributions while still allowing explicit deletion via YAML-level null. Matches [Claude Code CLI's documented cross-scope merge semantics](https://code.claude.com/docs/en/settings): "arrays are concatenated and deduplicated, not replaced".
 
 `write_profile_settings_to_settings()` delegates to `_write_merged_json()`, which implements the three-step READ-MERGE-WRITE process:
 
 1. **READ** the existing `~/.claude/settings.json` (or start fresh with an empty dict if the file is missing, malformed, or has a non-dict top-level value; a warning is emitted in those cases).
 2. **DEEP MERGE** the builder delta into the existing content via `_merge_recursive()`, which handles:
-   - **Deep recursion** into nested dicts (for example, a delta `permissions: {default-mode: ask}` updates only the `defaultMode` sub-key of `permissions`, leaving `permissions.allow`, `permissions.deny`, and `permissions.ask` intact if not in the delta).
-   - **Array union** at `DEFAULT_ARRAY_UNION_KEYS` paths (`permissions.allow`, `permissions.deny`, `permissions.ask`) -- existing and new arrays are combined, order-preserving, with duplicate elements removed.
+   - **Deep recursion** into nested dicts (for example, a delta `permissions: {default-mode: ask}` updates only the `defaultMode` sub-key of `permissions`, leaving `permissions.allow`, `permissions.deny`, `permissions.ask`, and any other sub-keys intact if not in the delta).
+   - **Universal array union** at every depth via Python structural equality -- existing and new arrays are combined, order-preserving (existing elements first), with duplicate elements removed. Applies to every list-valued key at any nesting level, matching Claude Code CLI's cross-scope merge semantics.
    - **RFC 7396 null-as-delete**: any value of `None` in the delta (top-level or nested) deletes the corresponding key from the target via `target.pop(key, None)`.
    - **Scalar overwrite** on leaf conflicts (new value wins).
 3. **WRITE** the merged result back to disk with a trailing newline for file-format consistency.
 
 The builder `_build_profile_settings()` accepts a `profile_config` dict keyed by the camelCase on-disk names; dict membership encodes the YAML declaration state (present-with-value, present-with-null, or absent) end-to-end so that the downstream writer can apply RFC 7396 null-as-delete to the shared `settings.json` for both top-level and nested YAML nulls. `main()` constructs `profile_config` with a comprehension that iterates `_YAML_TO_CAMEL_PROFILE_KEYS` and includes a key when `yaml_key in config`, which preserves the distinction between "absent from YAML" (key omitted from `profile_config`, on-disk value preserved) and "declared with explicit null" (`profile_config[camel_key] = None`, on-disk value deleted).
 
-**Three merge cases for each key in the delta:**
+**Merge cases for each key in the delta:**
 
-| Case                       | Builder output            | Writer on-disk effect                                                              |
-|----------------------------|---------------------------|------------------------------------------------------------------------------------|
-| YAML declares `key: value` | `{'key': value}` in delta | Deep-merge new value into existing (leaf wins; permissions.allow/deny/ask unioned) |
-| YAML declares `key: null`  | `{'key': None}` in delta  | DELETE the key from the file (RFC 7396 null-as-delete)                             |
-| YAML omits `key`           | key is absent from delta  | PRESERVE existing value unchanged (writer leaves keys outside its delta intact)    |
+| Case                           | Builder output            | Writer on-disk effect                                                                           |
+|--------------------------------|---------------------------|-------------------------------------------------------------------------------------------------|
+| YAML declares `key: scalar`    | `{'key': scalar}`         | Scalar overwrite (leaf wins)                                                                    |
+| YAML declares `key: {nested}`  | `{'key': {nested}}`       | Deep-merge (recurse into sub-keys; nested lists also unioned at every depth)                    |
+| YAML declares `key: [list]`    | `{'key': [list]}`         | Union with structural dedupe at every depth (elements added additively, duplicates removed)     |
+| YAML declares `key: []`        | `{'key': []}`             | No-op under union semantics (empty list adds nothing; use `null` to clear)                      |
+| YAML declares `key: null`      | `{'key': None}`           | DELETE the key from the file (RFC 7396 null-as-delete)                                          |
+| YAML omits `key`               | key absent from delta     | PRESERVE existing value unchanged                                                               |
 
-**Null-as-delete is supported for all nine profile-owned keys**, both at the top level (`model: null`, `permissions: null`, `hooks: null`, ...) and nested (`permissions: {deny: null}`, `hooks: {PreToolUse: null}`, ...). The top-level and nested cases go through the same `_merge_recursive()` path inside the writer; the top-level path additionally requires the dict-membership threading in `profile_config` to survive main()'s YAML extraction.
+**Null-as-delete is supported for all nine profile-owned keys**, and for every key written by the shared-settings writers, both at the top level (`model: null`, `permissions: null`, `hooks: null`, ...) and nested (`permissions: {deny: null}`, `hooks: {PreToolUse: null}`, ...). The top-level and nested cases go through the same `_merge_recursive()` path inside the writer; the top-level path additionally requires the dict-membership threading in `profile_config` to survive main()'s YAML extraction.
 
-**Preservation coverage (what survives profile-settings writes):**
+**Preservation coverage (what survives shared-settings writes):**
 
 Keys absent from the delta are preserved in `~/.claude/settings.json`. This covers:
 
-- Prior contributions from `write_profile_settings_to_settings()` itself across other YAML configurations.
-- Deep-merged contributions from Step 14 `write_user_settings()` (including `user-settings.permissions.allow/deny/ask` array-unions and any free-form `user-settings` keys).
-- User-managed keys outside the toolbox's YAML schema (for example, `includeGitInstructions`, `apiKeyHelper`, `cleanupPeriodDays`, `outputStyle`, `autoMemoryDirectory`, `sandbox.*`).
+- Prior contributions from `write_profile_settings_to_settings()` itself across other YAML configurations, including list-valued keys (which accumulate additively under the universal array-union contract).
+- Deep-merged contributions from Step 14 `write_user_settings()` (including any free-form `user-settings` keys, all list-valued keys unioned with structural dedupe across Step 14 and Step 18).
+- User-managed keys outside the toolbox's YAML schema (for example, `includeGitInstructions`, `apiKeyHelper`, `cleanupPeriodDays`, `outputStyle`, `autoMemoryDirectory`, `sandbox.*`, user-managed array-valued keys like `companyAnnouncements` or `permissions.additionalDirectories`).
 - Auto-injected `env.DISABLE_AUTOUPDATER` (auto-update Target 2) and `env.CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL` (IDE extension Target 2) controls: because deep-merge recurses into the `env` dict, the injected controls coexist with any user-declared environment variables. When the YAML declares its own `env-variables`, the delta's new env keys are deep-merged on top of the existing env dict rather than replacing it, so the Step 14 Target 2 contributions survive.
+- Elements written to list-valued keys by any prior contributor (manual user edits, the Claude Code CLI, teammate YAMLs): new elements from the current YAML are unioned with the existing list rather than replacing it.
 
 **Empty-delta no-op:** If no profile-owned keys are declared at YAML root level, the builder returns `{}` and `write_profile_settings_to_settings()` performs ZERO file I/O -- it neither creates nor touches `~/.claude/settings.json`. A YAML with only `user-settings:`, `global-config:`, `agents:`, and so on will never have Step 18 modify `settings.json`.
 
@@ -1881,14 +1887,14 @@ This is an INTENTIONAL user-facing contract, not a bug. Understanding this behav
 
 Automated YAML-removal-triggered cleanup (a state-tracking sidecar approach, for example `~/.claude/toolbox-managed-keys.json` recording which keys the toolbox wrote in the last run) is not implemented. The preservation behavior is the intended design.
 
-**Security framing: preventing silent destruction of `permissions.deny`.** Deep-merge with `DEFAULT_ARRAY_UNION_KEYS` array-union for `permissions.allow/deny/ask` is the core mechanism that prevents silent destruction of security rules in the shared `~/.claude/settings.json`. A narrower YAML declaration such as `permissions: {allow: [Read]}` MUST NOT remove `permissions.deny` entries contributed by other writers (manual user edits, the Claude Code CLI, teammate YAMLs, or `user-settings.permissions.deny` at Step 14). Under the unified deep-merge + array-union contract, deny entries accumulate additively across runs and explicit null is the only way to shrink them:
+**Security framing: preventing silent destruction of user state.** Deep-merge with universal array-union at every depth is the core mechanism that prevents silent destruction of security rules and user state in the shared `~/.claude/settings.json`. The contract applies uniformly to every list-valued key at any depth: `permissions.allow/deny/ask/additionalDirectories`, `companyAnnouncements`, `hooks.<EventName>` matcher-group lists, `sandbox.filesystem.*` path lists, `disabledMcpjsonServers`/`enabledMcpjsonServers`, `projects.<path>.allowedTools`, and every other list-valued key. A narrower YAML declaration such as `permissions: {allow: [Read]}` MUST NOT remove `permissions.deny` entries, `permissions.additionalDirectories`, `companyAnnouncements` entries, or any other user-managed state contributed by other writers (manual user edits, the Claude Code CLI, teammate YAMLs, or `user-settings.permissions.deny` at Step 14). Under the unified deep-merge + universal-array-union contract, list entries accumulate additively across runs and explicit null is the only way to shrink them:
 
-- To remove ALL deny entries: `permissions: {deny: null}` (nested null deletes just the `deny` sub-key) or `permissions: null` (top-level null deletes the entire `permissions` block).
-- To remove a specific deny entry: edit `~/.claude/settings.json` manually, because array-union only grows arrays -- declaring `permissions: {deny: [X]}` in YAML will union `[X]` with the existing deny list, not replace it.
+- To remove ALL entries under a list-valued sub-key: nest-null the sub-key (`permissions: {deny: null}` deletes just the `deny` sub-key) or top-level-null the parent (`permissions: null` deletes the entire `permissions` block).
+- To remove a specific element: edit `~/.claude/settings.json` manually, because array union only grows lists -- declaring `permissions: {deny: [X]}` in YAML unions `[X]` with the existing deny list, not replaces it.
 
-Any deny rule preserved on disk is the combined contribution of all writers; losing rules silently on re-run would be a critical security regression, so the toolbox instead requires explicit null to delete them.
+Any rule or entry preserved on disk is the combined contribution of all writers; losing rules silently on re-run would be a critical security regression, so the toolbox instead requires explicit null to delete them. This matches [Claude Code CLI's documented cross-scope merge semantics](https://code.claude.com/docs/en/settings) for shared settings files.
 
-**Note on `hooks` deletion:** Setting `hooks: null` at YAML root deletes the entire `hooks` key from `~/.claude/settings.json`. Setting `hooks: {EventName: null}` deletes only that event list while preserving other event names. Because `hooks.{EventName}` is NOT in `DEFAULT_ARRAY_UNION_KEYS`, per-event lists are replaced (not unioned) when both the existing file and the delta declare the same event. Disjoint event names compose additively across the merge.
+**Note on `hooks` deletion and composition:** Setting `hooks: null` at YAML root deletes the entire `hooks` key from `~/.claude/settings.json`. Setting `hooks: {EventName: null}` deletes only that event list while preserving other event names. Under the universal array-union contract, per-event matcher lists are unioned across runs via Python structural equality: disjoint event names compose additively, and for the same event name, matcher groups accumulate. Two matcher groups with the same `matcher` string but different inner handlers from different contributions coexist as separate entries (naive structural dedupe -- they are not structurally equal, so neither is discarded); structurally identical matcher groups collapse to one (idempotent re-run). This matches Claude Code's native cross-scope merge behavior; at runtime, [Claude Code deduplicates command hooks by command string and HTTP hooks by URL](https://code.claude.com/docs/en/hooks) ("Command hooks are deduplicated by command string, and HTTP hooks are deduplicated by URL"), so on-disk consolidation is unnecessary.
 
 ### Profile-Scoped MCP Servers in Non-Command-Names Mode (ERROR)
 
@@ -1932,26 +1938,31 @@ Unlike profile-scoped MCP servers (which are a hard error because silently-dropp
 [WARN]   user-settings value: claude-opus-4
 [WARN]   root-level value: claude-sonnet-4
 [WARN]   Under deep merge semantics, root-level values overwrite user-settings values for scalar keys.
-[WARN]   For dict keys, user-settings and root-level values are deep-merged; for
-[WARN]   permissions.allow/deny/ask, array union applies.
+[WARN]   For dict keys, user-settings and root-level values are deep-merged.
+[WARN]   For ALL array-valued keys at any depth, array union with structural dedupe applies
+[WARN]   (matching Claude Code CLI's cross-scope merge: "arrays are concatenated and
+[WARN]   deduplicated, not replaced").
 ```
 
 **How the two contributions compose (in both modes):**
 
 - **Isolated mode:** Step 14 writes `user-settings:` to `~/.claude/{cmd}/settings.json` (priority 5), Step 18 writes the profile delta to `~/.claude/{cmd}/config.json` (priority 2). The CLI's native `flagSettings > userSettings` resolution means `config.json` wins over `settings.json` at runtime for overlapping keys.
-- **Non-isolated mode:** Step 14 writes `user-settings:` to `~/.claude/settings.json` via deep-merge, then Step 18 deep-merges the profile delta into the same file. For scalar keys, the root-level value overwrites the `user-settings` value. For dict keys, the two contributions are deep-merged: sub-keys declared only on one side are preserved, sub-keys declared on both sides are resolved by the root-level (Step 18) value winning, and `permissions.allow/deny/ask` arrays are unioned across both steps via `DEFAULT_ARRAY_UNION_KEYS`.
+- **Non-isolated mode:** Step 14 writes `user-settings:` to `~/.claude/settings.json` via deep-merge, then Step 18 deep-merges the profile delta into the same file. For scalar keys, the root-level (Step 18) value overwrites the `user-settings` (Step 14) value. For dict keys, the two contributions are deep-merged: sub-keys declared only on one side are preserved, sub-keys declared on both sides are resolved by the root-level value winning. For list-valued keys at any depth, both contributions are unioned with structural dedupe under the universal array-union contract.
 
 The conflict warning ensures users are informed regardless of which mode they use.
 
 ### Three-Writer Architectural Model Summary
 
-| Writer                                 | YAML Source                  | Target                                                       | Key Universe                              | Semantics                                                                          | Step                |
-|----------------------------------------|------------------------------|--------------------------------------------------------------|-------------------------------------------|------------------------------------------------------------------------------------|---------------------|
-| `write_user_settings()`                | `user-settings:`             | `~/.claude/settings.json` OR `~/.claude/{cmd}/settings.json` | ~58 non-excluded CLI keys                 | Deep merge + array-union (`permissions.allow/deny/ask`) + RFC 7396 null-as-delete  | 14                  |
-| `create_profile_config()`              | YAML root profile keys       | `~/.claude/{cmd}/config.json`                                | 9 `PROFILE_OWNED_KEYS`                    | Atomic overwrite (fresh dict each run)                                             | 18 (isolated)       |
-| `write_profile_settings_to_settings()` | YAML root profile keys       | `~/.claude/settings.json`                                    | 9 `PROFILE_OWNED_KEYS` delta              | Deep merge + array-union (`permissions.allow/deny/ask`) + RFC 7396 null-as-delete  | 18 (non-isolated)   |
+| Writer                                 | YAML Source                  | Target                                                            | Key Universe                              | Semantics                                                                    | Step                |
+|----------------------------------------|------------------------------|-------------------------------------------------------------------|-------------------------------------------|------------------------------------------------------------------------------|---------------------|
+| `write_user_settings()`                | `user-settings:`             | `~/.claude/settings.json` OR `~/.claude/{cmd}/settings.json`      | ~58 non-excluded CLI keys                 | Deep merge + universal array union at every depth + RFC 7396 null-as-delete  | 14                  |
+| `write_global_config()`                | `global-config:`             | `~/.claude.json` (+ `~/.claude/{cmd}/.claude.json` when isolated) | Free-form CLI keys                        | Deep merge + universal array union at every depth + RFC 7396 null-as-delete  | 15                  |
+| `create_profile_config()`              | YAML root profile keys       | `~/.claude/{cmd}/config.json`                                     | 9 `PROFILE_OWNED_KEYS`                    | Atomic overwrite (fresh dict each run, fully toolbox-owned)                  | 18 (isolated)       |
+| `write_profile_settings_to_settings()` | YAML root profile keys       | `~/.claude/settings.json`                                         | 9 `PROFILE_OWNED_KEYS` delta              | Deep merge + universal array union at every depth + RFC 7396 null-as-delete  | 18 (non-isolated)   |
 
-All three shared-file writers (`write_user_settings()`, `write_global_config()`, `write_profile_settings_to_settings()`) delegate to the same `_write_merged_json()` helper, which gives them a single unified deep-merge contract. Both Step 18 writers (`create_profile_config()` and `write_profile_settings_to_settings()`) are fed by the shared pure builder `_build_profile_settings()`, which accepts a `profile_config` dict, translates kebab-case YAML keys to camelCase JSON keys, and delegates to `_build_hooks_json()` for hook events. In isolated mode, `create_profile_config()` atomically rewrites `~/.claude/{cmd}/config.json` from scratch on each run (fully toolbox-owned). In non-isolated mode, `write_profile_settings_to_settings()` deep-merges its delta into the shared `~/.claude/settings.json`, preserving contributions from other writers.
+All three shared-file writers (`write_user_settings()`, `write_global_config()`, `write_profile_settings_to_settings()`) delegate to the same `_write_merged_json()` helper with `array_union_keys=None` (the default), which gives them a single unified universal deep-merge contract: every list at every depth is unioned with structural dedupe, matching [Claude Code CLI's cross-scope merge semantics](https://code.claude.com/docs/en/settings) ("arrays are concatenated and deduplicated, not replaced"). Both Step 18 writers (`create_profile_config()` and `write_profile_settings_to_settings()`) are fed by the shared pure builder `_build_profile_settings()`, which accepts a `profile_config` dict, translates kebab-case YAML keys to camelCase JSON keys, and delegates to `_build_hooks_json()` for hook events. In isolated mode, `create_profile_config()` atomically rewrites `~/.claude/{cmd}/config.json` from scratch on each run (fully toolbox-owned). In non-isolated mode, `write_profile_settings_to_settings()` deep-merges its delta into the shared `~/.claude/settings.json`, preserving contributions from other writers and accumulating list elements additively across runs.
+
+**YAML inheritance layer is separate.** The per-path whitelist mechanism in `deep_merge_settings()` (`DEFAULT_ARRAY_UNION_KEYS` and explicit `set[str]` arguments) applies only to the YAML composition layer (`_resolve_single_key` call sites): `array_union_keys=set()` for `global-config` inheritance (child replaces parent for arrays) and `array_union_keys=DEFAULT_ARRAY_UNION_KEYS` for `user-settings` inheritance (union only for `permissions.allow/deny/ask`, replace for other arrays). On-disk shared-file writers are decoupled from YAML composition by intent; they always use the universal default.
 
 ## Complete Annotated Example
 

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -156,8 +156,14 @@ OS_ENV_VARIABLES_KEY = 'os-env-variables'
 ENV_VAR_MARKER_START = '# >>> claude-code-toolbox >>>'
 ENV_VAR_MARKER_END = '# <<< claude-code-toolbox <<<'
 
-# Default keys where arrays should be unioned during deep merge
-# These correspond to permissions arrays in Claude Code settings
+# Per-path union whitelist used ONLY by the YAML inheritance layer
+# (_resolve_single_key at lines 4331 and 4337) for child-overrides-parent
+# composition semantics. On-disk writers (write_user_settings(),
+# write_profile_settings_to_settings(), write_global_config()) use the
+# default universal union-all-arrays semantics via
+# _write_merged_json(array_union_keys=None) -- every array at every depth
+# is unioned with structural dedupe, matching Claude Code CLI's
+# cross-scope merge behavior.
 DEFAULT_ARRAY_UNION_KEYS: set[str] = {
     'permissions.allow',
     'permissions.deny',
@@ -1327,7 +1333,7 @@ def _deep_copy_value(value: JsonValue) -> JsonValue:
 def _merge_recursive(
     target: dict[str, JsonValue],
     source: dict[str, JsonValue],
-    array_union_keys: set[str],
+    array_union_keys: set[str] | None,
     current_path: str,
 ) -> None:
     """Recursively merge source into target in-place.
@@ -1337,10 +1343,26 @@ def _merge_recursive(
     This applies only to object keys -- None values inside arrays
     are not treated as deletion signals.
 
+    Array merge policy:
+    - array_union_keys is None (default): every list is unioned with the
+      existing list, preserving order-of-first-appearance and
+      deduplicating elements via Python structural equality. This matches
+      Claude Code's cross-scope merge semantics: "arrays are concatenated
+      and deduplicated, not replaced".
+    - array_union_keys is a set[str]: per-path whitelist -- only the
+      dot-notation paths in the set are unioned; all other lists are
+      replaced wholesale. This mode is preserved for the YAML inheritance
+      layer (_resolve_single_key -> deep_merge_settings) which has
+      different trust semantics from on-disk writers.
+    - array_union_keys is set() (empty): no paths are unioned; every list
+      is replaced. Used by the YAML inheritance layer for global-config
+      child-replaces-parent composition.
+
     Args:
         target: Target dict to merge into (mutated in-place).
         source: Source dict to merge from.
-        array_union_keys: Set of dot-notation paths for array union behavior.
+        array_union_keys: None to union every list at any depth, or a
+            set of dot-notation paths to restrict union behavior.
         current_path: Current dot-notation path for tracking nested location.
     """
     for key, value in source.items():
@@ -1361,12 +1383,22 @@ def _merge_recursive(
                 array_union_keys,
                 key_path,
             )
-        elif key_path in array_union_keys and isinstance(value, list) and isinstance(target[key], list):
-            # Array union: combine and deduplicate (preserve order, add new items)
-            existing = cast(list[JsonValue], target[key])
-            new_items = value
-            combined = existing + [item for item in new_items if item not in existing]
-            target[key] = combined
+        elif isinstance(value, list) and isinstance(target[key], list):
+            # Lists: union when array_union_keys is None (universal default)
+            # or when key_path is in the explicit whitelist.
+            should_union = (
+                array_union_keys is None
+                or key_path in array_union_keys
+            )
+            if should_union:
+                existing = cast(list[JsonValue], target[key])
+                new_items = value
+                combined = existing + [
+                    item for item in new_items if item not in existing
+                ]
+                target[key] = combined
+            else:
+                target[key] = _deep_copy_value(value)
         else:
             # Scalar or type mismatch - update wins (deep copy)
             target[key] = _deep_copy_value(value)
@@ -1377,48 +1409,50 @@ def deep_merge_settings(
     updates: dict[str, Any],
     array_union_keys: set[str] | None = None,
 ) -> dict[str, Any]:
-    """Deep merge updates into base dict, with array union for specified keys.
+    """Deep merge updates into base dict with universal array-union.
 
-    Performs recursive merging where nested dicts are merged (not replaced),
-    and arrays at specified key paths are unioned (with deduplication).
+    Performs recursive merging where nested dicts are merged (not
+    replaced), arrays are unioned and deduplicated at every depth (by
+    default), scalars are overwritten on conflict, and RFC 7396
+    null-as-delete is honored.
 
     Key behaviors:
-    - Keys NOT in updates: PRESERVED unchanged from base
-    - Keys IN updates: UPDATED or ADDED
-    - Keys with None/null value in updates: DELETED from result (RFC 7396)
-    - Nested dicts: Recursively merged (not replaced entirely)
-    - Arrays at array_union_keys: Additive union with deduplication
+    - Keys NOT in updates: PRESERVED unchanged from base.
+    - Keys IN updates: UPDATED or ADDED.
+    - Keys with None value in updates: DELETED from result (RFC 7396).
+    - Nested dicts: Recursively merged (not replaced entirely).
+    - Arrays: Union with structural dedupe when array_union_keys is None
+      (the default). Matches Claude Code CLI's cross-scope merge
+      semantics: "arrays are concatenated and deduplicated, not replaced".
 
     Args:
         base: Existing settings dict to merge into. Not modified.
         updates: New settings values to merge.
-        array_union_keys: Set of dot-notation keys where arrays should be unioned
-                         (e.g., {"permissions.allow", "permissions.deny"}).
-                         Defaults to DEFAULT_ARRAY_UNION_KEYS if None.
+        array_union_keys: None (default) unions every array at every
+            depth. A set of dot-notation paths restricts union to those
+            paths and replaces all other arrays (per-path whitelist
+            preserved for the YAML inheritance layer). An empty set
+            disables union entirely (all arrays replaced).
 
     Returns:
         New merged dict with base keys preserved and updates applied.
 
     Examples:
-        >>> base = {"a": 1, "b": {"c": 2}}
-        >>> updates = {"b": {"d": 3}, "e": 4}
+        >>> base = {"permissions": {"allow": ["Read"], "deny": ["Bash(rm *)"]}}
+        >>> updates = {"permissions": {"allow": ["Write"]}}
         >>> deep_merge_settings(base, updates)
-        {"a": 1, "b": {"c": 2, "d": 3}, "e": 4}
+        {'permissions': {'allow': ['Read', 'Write'], 'deny': ['Bash(rm *)']}}
 
-        >>> base = {"permissions": {"allow": ["Read", "Glob"]}}
-        >>> updates = {"permissions": {"allow": ["Write", "Read"]}}
+        >>> base = {"companyAnnouncements": ["Welcome"]}
+        >>> updates = {"companyAnnouncements": ["Welcome", "Maintenance Sunday"]}
         >>> deep_merge_settings(base, updates)
-        {"permissions": {"allow": ["Read", "Glob", "Write"]}}
+        {'companyAnnouncements': ['Welcome', 'Maintenance Sunday']}
 
         >>> base = {"a": 1, "b": 2}
         >>> updates = {"b": None}
         >>> deep_merge_settings(base, updates)
-        {"a": 1}
+        {'a': 1}
     """
-    # Use default union keys if not specified
-    if array_union_keys is None:
-        array_union_keys = DEFAULT_ARRAY_UNION_KEYS
-
     # Create a fresh result dict (do not mutate base)
     result: dict[str, JsonValue] = {}
 
@@ -1426,7 +1460,9 @@ def deep_merge_settings(
     for key, value in base.items():
         result[key] = _deep_copy_value(cast(JsonValue, value))
 
-    # Merge in updates
+    # Merge in updates. None means "union every array at every depth";
+    # explicit set[str] restricts union to those paths (whitelist);
+    # set() disables union entirely.
     _merge_recursive(result, cast(dict[str, JsonValue], updates), array_union_keys, '')
 
     return cast(dict[str, Any], result)
@@ -1473,19 +1509,30 @@ def _write_merged_json(
     *,
     ensure_parent: bool = True,
 ) -> tuple[bool, dict[str, Any]]:
-    """Read-merge-write JSON file with deep merge.
+    """Read-merge-write JSON file with universal deep merge.
 
     Implements the three-step merge process:
     1. READ existing JSON file (or empty dict if not exists/invalid)
-    2. DEEP MERGE new settings into existing
+    2. DEEP MERGE new settings into existing via deep_merge_settings()
     3. WRITE merged result back to file
+
+    Merge semantics (default, array_union_keys=None):
+    - Nested dicts: recursive deep merge.
+    - Lists: union with structural dedupe at every depth (matches Claude
+      Code CLI's cross-scope merge: "arrays are concatenated and
+      deduplicated, not replaced").
+    - Scalars: update wins.
+    - None values: RFC 7396 null-as-delete (top-level and nested).
+    - Keys absent from new_settings: preserved unchanged in target.
 
     Args:
         target_file: Path to the JSON file to update.
         new_settings: New settings to deep-merge into existing content.
-        array_union_keys: Key paths where arrays should be unioned.
-            Defaults to DEFAULT_ARRAY_UNION_KEYS if None.
-            Pass set() to disable array union behavior.
+        array_union_keys: None (default) unions every array at every
+            depth. Pass an explicit set[str] only when the caller needs
+            the per-path whitelist behavior (currently only the YAML
+            inheritance layer at lines 4331 and 4337). Pass set() to
+            disable union entirely (every array replaced).
         ensure_parent: If True, create parent directories if needed.
 
     Returns:
@@ -1552,8 +1599,15 @@ def write_user_settings(
     # Step 0: Platform-conditional tilde handling in command keys
     expanded_settings = _expand_tilde_keys_in_settings(settings)
 
-    # Delegate to shared READ-MERGE-WRITE helper
-    # Uses default array_union_keys (permissions.allow/deny/ask)
+    # Delegate to shared READ-MERGE-WRITE helper.
+    # Uses default array_union_keys=None: every list is unioned with
+    # structural dedupe at every depth. This preserves contributions
+    # from the Claude Code CLI, prior toolbox runs with other YAML
+    # configs, manual user edits, and other writers. permissions.allow,
+    # permissions.deny, permissions.ask, permissions.additionalDirectories,
+    # companyAnnouncements, hooks.<EventName>, sandbox.filesystem.*,
+    # disabledMcpjsonServers, and every other list-valued key compose
+    # additively across runs.
     ok, merged = _write_merged_json(settings_file, expanded_settings)
 
     if ok:
@@ -1633,29 +1687,36 @@ def write_global_config(
     global_config: dict[str, Any],
     artifact_base_dir: Path | None = None,
 ) -> bool:
-    """Write global configuration to ~/.claude.json with deep merge.
+    """Write global configuration to ~/.claude.json with universal deep merge.
 
     Implements asymmetric dual-write: always writes to ~/.claude.json
     (machine baseline for bare claude sessions), and additionally writes
     to artifact_base_dir/.claude.json when command-names creates an
-    isolated environment (since Claude Code CLI resolves getGlobalClaudeFile()
-    via CLAUDE_CONFIG_DIR with no fallback to the home directory).
+    isolated environment (since Claude Code CLI resolves
+    getGlobalClaudeFile() via CLAUDE_CONFIG_DIR with no fallback to the
+    home directory).
+
+    ~/.claude.json is a collaborative surface managed by the Claude Code
+    CLI at runtime (OAuth tokens, per-project trust decisions,
+    user-scoped MCP server approvals via /mcp approve, enabledPlugins,
+    enabledMcpjsonServers, disabledMcpjsonServers, etc.). The writer
+    MUST NOT destroy these contributions, so it delegates to
+    _write_merged_json() with the default universal union-all-arrays
+    merge policy -- exactly the same semantics as write_user_settings()
+    and write_profile_settings_to_settings().
 
     Args:
         global_config: Global config dict from YAML global-config section.
         artifact_base_dir: Isolated config directory path, or None.
 
     Returns:
-        True if config was written successfully to all targets, False on any failure.
+        True if config was written successfully to all targets, False on
+        any failure.
     """
     home_dir = get_real_user_home()
     config_file = home_dir / '.claude.json'
 
-    ok, _ = _write_merged_json(
-        config_file,
-        global_config,
-        array_union_keys=set(),
-    )
+    ok, _ = _write_merged_json(config_file, global_config)
 
     if ok:
         success(f'Wrote global config to {config_file}')
@@ -1665,11 +1726,7 @@ def write_global_config(
     # Dual-write to isolated environment when command-names is present
     if artifact_base_dir is not None and artifact_base_dir != home_dir:
         isolated_config_file = artifact_base_dir / '.claude.json'
-        iso_ok, _ = _write_merged_json(
-            isolated_config_file,
-            global_config,
-            array_union_keys=set(),
-        )
+        iso_ok, _ = _write_merged_json(isolated_config_file, global_config)
         if iso_ok:
             success(f'Wrote global config to {isolated_config_file}')
         else:
@@ -1984,9 +2041,7 @@ def _cleanup_claude_json_auto_updates(claude_json_path: Path) -> None:
         if content.get(AUTO_UPDATE_KEY) is False:
             # Use _write_merged_json with null-as-delete
             cleanup_dict: dict[str, Any] = {AUTO_UPDATE_KEY: None}
-            ok, _ = _write_merged_json(
-                claude_json_path, cleanup_dict, array_union_keys=set(),
-            )
+            ok, _ = _write_merged_json(claude_json_path, cleanup_dict)
             if ok:
                 info(f'Cleaned stale {AUTO_UPDATE_KEY}: false from {claude_json_path}')
     except (OSError, json.JSONDecodeError, ValueError):
@@ -2231,9 +2286,7 @@ def _cleanup_claude_json_ide_auto_install(claude_json_path: Path) -> None:
         if content.get(IDE_AUTO_INSTALL_KEY) is False:
             # Use _write_merged_json with null-as-delete
             cleanup_dict: dict[str, Any] = {IDE_AUTO_INSTALL_KEY: None}
-            ok, _ = _write_merged_json(
-                claude_json_path, cleanup_dict, array_union_keys=set(),
-            )
+            ok, _ = _write_merged_json(claude_json_path, cleanup_dict)
             if ok:
                 info(f'Cleaned stale {IDE_AUTO_INSTALL_KEY}: false from {claude_json_path}')
     except (OSError, json.JSONDecodeError, ValueError):
@@ -8202,8 +8255,11 @@ def _build_hooks_json(
     Generates absolute POSIX paths for hook file references. Supports all four
     hook types: command, http, prompt, agent.
 
-    Used by both create_profile_config() (per-environment config.json) and
-    write_hooks_to_settings() (global settings.json).
+    Used by create_profile_config() (per-environment config.json, atomic
+    overwrite in isolated mode) and indirectly by
+    write_profile_settings_to_settings() via _build_profile_settings()
+    (shared ~/.claude/settings.json in non-isolated mode, deep-merged via
+    _write_merged_json()).
 
     Args:
         hooks: Hooks configuration dictionary with optional 'events' key.
@@ -8386,104 +8442,52 @@ def _build_hooks_json(
     return result
 
 
-def write_hooks_to_settings(
-    hooks: dict[str, Any],
-    hooks_dir: Path,
-    settings_dir: Path,
-) -> bool:
-    """Write hooks to settings.json with key-replace semantics.
-
-    Reads existing settings.json, replaces the 'hooks' key entirely (not
-    deep-merged), and preserves all other keys. This ensures stale hook
-    events from prior runs are removed.
-
-    Used when command-names is absent from the YAML configuration, routing
-    hooks to the global settings.json instead of a per-environment config.json.
-
-    Args:
-        hooks: Hooks configuration dictionary from YAML.
-        hooks_dir: Directory containing downloaded hook files.
-        settings_dir: Directory containing settings.json (typically ~/.claude/).
-
-    Returns:
-        True if hooks were written successfully, False on failure.
-    """
-    settings_file = settings_dir / 'settings.json'
-    info('Writing hooks to settings.json...')
-
-    # Build hooks JSON using shared helper
-    hooks_json = _build_hooks_json(hooks, hooks_dir)
-
-    # Read existing settings.json (or empty dict)
-    existing: dict[str, Any] = {}
-    if settings_file.exists():
-        try:
-            file_content = settings_file.read_text(encoding='utf-8')
-            if file_content.strip():
-                parsed = json.loads(file_content)
-                if isinstance(parsed, dict):
-                    existing = parsed
-                else:
-                    warning(f'Existing {settings_file} is not a dict, starting fresh')
-        except json.JSONDecodeError as e:
-            warning(f'Invalid JSON in {settings_file}: {e}, starting fresh')
-
-    # Replace the 'hooks' key entirely (not deep merge)
-    if hooks_json:
-        existing['hooks'] = hooks_json
-    else:
-        existing.pop('hooks', None)  # Remove hooks if config produces none
-
-    # Write back
-    try:
-        settings_dir.mkdir(parents=True, exist_ok=True)
-        settings_file.write_text(
-            json.dumps(existing, indent=2, ensure_ascii=False) + '\n',
-            encoding='utf-8',
-        )
-        success(f'Wrote hooks to {settings_file}')
-        return True
-    except OSError as e:
-        warning(f'Failed to write hooks to {settings_file}: {e}')
-        return False
-
-
 def write_profile_settings_to_settings(
     settings_delta: dict[str, Any],
     settings_dir: Path,
 ) -> bool:
     """Deep-merge profile-owned settings delta into ~/.claude/settings.json.
 
-    The shared ~/.claude/settings.json is a user-facing file written to by
-    the toolbox, the Claude Code CLI, prior toolbox runs with other YAMLs,
-    and (optionally) direct user edits. The writer MUST preserve any key
-    outside the current delta. It MUST NOT destroy nested sub-keys that
-    other contributors supplied. And it MUST honor RFC 7396 null-as-delete
-    so that users can explicitly remove keys via YAML-level null.
+    The shared ~/.claude/settings.json is a user-facing file written to
+    by the toolbox, the Claude Code CLI, prior toolbox runs with other
+    YAMLs, and (optionally) direct user edits. The writer MUST preserve
+    any key outside the current delta. It MUST NOT destroy nested
+    sub-keys or list elements that other contributors supplied. And it
+    MUST honor RFC 7396 null-as-delete so that users can explicitly
+    remove keys via YAML-level null.
 
-    Delegates to ``_write_merged_json()`` to inherit all three semantics
-    from the same helper that powers ``write_user_settings()`` and
+    Delegates to ``_write_merged_json()`` to inherit all semantics from
+    the same helper that powers ``write_user_settings()`` and
     ``write_global_config()``:
 
-    - Deep-merge for nested dicts (dispatched per-key to ``_merge_recursive()``).
-    - Array-union for ``permissions.allow/deny/ask`` (default ``DEFAULT_ARRAY_UNION_KEYS``).
-    - RFC 7396 null-as-delete for any key whose value is ``None`` (top-level or nested).
+    - Deep-merge for nested dicts (dispatched per-key to
+      ``_merge_recursive()``).
+    - **Array-union with structural dedupe for EVERY list at every depth**
+      (matches Claude Code CLI's cross-scope merge: "arrays are
+      concatenated and deduplicated, not replaced"). Two hook matcher
+      groups with the same ``matcher`` string from different
+      contributions coexist as separate entries -- matches Claude Code's
+      native concatenation; the runtime then dedupes by command string
+      (for command hooks) and URL (for HTTP hooks) per the Claude Code
+      hooks documentation.
+    - RFC 7396 null-as-delete for any key whose value is ``None``
+      (top-level or nested).
     - Preservation for keys omitted from ``settings_delta``.
 
-    The delta is expected to be the output of ``_build_profile_settings()``,
-    which contains one entry per YAML-declared profile-owned key (value
-    for present-with-value keys, ``None`` for present-with-null keys, no
-    entry for absent keys).
+    The delta is expected to be the output of
+    ``_build_profile_settings()``, which contains one entry per
+    YAML-declared profile-owned key (value for present-with-value keys,
+    ``None`` for present-with-null keys, no entry for absent keys).
 
-    IMPORTANT: This function is called ONLY in non-command-names mode. In
-    command-names mode, profile settings are routed to the isolated
+    IMPORTANT: This function is called ONLY in non-command-names mode.
+    In command-names mode, profile settings are routed to the isolated
     ~/.claude/{cmd}/config.json via ``create_profile_config()`` with
     atomic overwrite semantics (isolated config is fully toolbox-owned).
 
     Args:
         settings_delta: Dict of profile-owned keys to write (output of
-            ``_build_profile_settings()``). May be empty, in which case no
-            file I/O occurs and the function returns ``True``.
+            ``_build_profile_settings()``). May be empty, in which case
+            no file I/O occurs and the function returns ``True``.
         settings_dir: Directory containing settings.json (typically
             ~/.claude/).
 
@@ -8498,9 +8502,10 @@ def write_profile_settings_to_settings(
     settings_file = settings_dir / 'settings.json'
     info('Writing profile settings to settings.json...')
 
-    # Delegate to the shared READ-MERGE-WRITE helper. Uses default
-    # array_union_keys (permissions.allow/deny/ask) and the default
-    # ensure_parent=True (creates settings_dir if missing).
+    # Delegate to the shared READ-MERGE-WRITE helper. Uses the default
+    # array_union_keys=None (every array at every depth is unioned with
+    # structural dedupe) and ensure_parent=True (creates settings_dir
+    # if missing).
     ok, _ = _write_merged_json(settings_file, settings_delta)
 
     if ok:
@@ -10010,8 +10015,11 @@ def main() -> None:
                 warning(
                     '  Under deep merge semantics, root-level values overwrite '
                     'user-settings values for scalar keys. For dict keys, '
-                    'user-settings and root-level values are deep-merged; for '
-                    'permissions.allow/deny/ask, array union applies.',
+                    'user-settings and root-level values are deep-merged. '
+                    'For ALL array-valued keys at any depth, array union with '
+                    "structural dedupe applies (matching Claude Code CLI's "
+                    'cross-scope merge: "arrays are concatenated and '
+                    'deduplicated, not replaced").',
                 )
 
         # Validate: profile-scoped MCP servers require command-names (launcher)

--- a/tests/e2e/test_hooks_settings_routing.py
+++ b/tests/e2e/test_hooks_settings_routing.py
@@ -19,58 +19,14 @@ if TYPE_CHECKING:
 import pytest
 
 from scripts.setup_environment import _build_hooks_json
+from scripts.setup_environment import _build_profile_settings
 from scripts.setup_environment import create_profile_config
-from scripts.setup_environment import write_hooks_to_settings
+from scripts.setup_environment import write_profile_settings_to_settings
 from tests.e2e.validators import _validate_hooks_structure
-from tests.e2e.validators import validate_hooks_in_settings_json
 
 # ---------------------------------------------------------------------------
 # Inline YAML-like configs (dicts) for tests WITHOUT command-names
 # ---------------------------------------------------------------------------
-
-
-def _hooks_only_config() -> dict[str, Any]:
-    """Minimal config with hooks but NO command-names."""
-    return {
-        'name': 'Hooks Only',
-        'hooks': {
-            'files': ['hooks/e2e_test_hook.py'],
-            'events': [
-                {
-                    'event': 'PostToolUse',
-                    'matcher': 'Write',
-                    'type': 'command',
-                    'command': 'e2e_test_hook.py',
-                },
-                {
-                    'event': 'PostToolUse',
-                    'matcher': 'Read',
-                    'type': 'http',
-                    'url': 'http://localhost:8080/hooks',
-                    'headers': {'Authorization': 'Bearer $TOKEN'},
-                    'allowed-env-vars': ['TOKEN'],
-                    'timeout': 15,
-                    'status-message': 'Sending webhook...',
-                },
-                {
-                    'event': 'PreToolUse',
-                    'matcher': 'Bash',
-                    'type': 'prompt',
-                    'prompt': 'Check safety before bash execution',
-                    'timeout': 30,
-                },
-                {
-                    'event': 'PreToolUse',
-                    'matcher': 'Bash(rm *)',
-                    'type': 'agent',
-                    'prompt': 'Verify security of: $ARGUMENTS',
-                    'model': 'sonnet',
-                    'once': True,
-                },
-            ],
-        },
-        # NO command-names
-    }
 
 
 def _hooks_with_user_settings_config() -> dict[str, Any]:
@@ -110,154 +66,6 @@ def _no_hooks_no_commands_config() -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # E2E Test Class: Hooks routing to settings.json (no command-names)
 # ---------------------------------------------------------------------------
-
-
-class TestHooksToSettingsJson:
-    """Tests for hooks routing to settings.json when command-names is absent."""
-
-    def test_hooks_written_to_settings_json(
-        self,
-        e2e_isolated_home: dict[str, Path],
-    ) -> None:
-        """Verify hooks are written to settings.json when command-names is absent.
-
-        Uses write_hooks_to_settings directly with a hooks-only config.
-        Validates hook structure, all four hook types, and path expansion.
-        """
-        paths = e2e_isolated_home
-        claude_dir = paths['claude_dir']
-        hooks_dir = claude_dir / 'hooks'
-
-        config = _hooks_only_config()
-        hooks = config['hooks']
-
-        result = write_hooks_to_settings(hooks, hooks_dir, claude_dir)
-        assert result is True
-
-        settings_path = claude_dir / 'settings.json'
-        assert settings_path.exists(), 'settings.json not created'
-
-        errors = validate_hooks_in_settings_json(settings_path, hooks)
-        assert not errors, 'Hooks in settings.json validation failed:\n' + '\n'.join(errors)
-
-    def test_all_four_hook_types_in_settings_json(
-        self,
-        e2e_isolated_home: dict[str, Path],
-    ) -> None:
-        """Verify all four hook types (command, http, prompt, agent) in settings.json."""
-        paths = e2e_isolated_home
-        claude_dir = paths['claude_dir']
-        hooks_dir = claude_dir / 'hooks'
-
-        config = _hooks_only_config()
-        hooks = config['hooks']
-
-        write_hooks_to_settings(hooks, hooks_dir, claude_dir)
-
-        data = json.loads((claude_dir / 'settings.json').read_text())
-        hooks_data = data['hooks']
-
-        # Verify PostToolUse has command and http hooks
-        post_tool_groups = hooks_data['PostToolUse']
-        hook_types_found: set[str] = set()
-        for group in post_tool_groups:
-            hook_types_found.update(hook['type'] for hook in group.get('hooks', []))
-        assert 'command' in hook_types_found, 'command hook type missing'
-        assert 'http' in hook_types_found, 'http hook type missing'
-
-        # Verify PreToolUse has prompt and agent hooks
-        pre_tool_groups = hooks_data['PreToolUse']
-        pre_types: set[str] = set()
-        for group in pre_tool_groups:
-            pre_types.update(hook['type'] for hook in group.get('hooks', []))
-        assert 'prompt' in pre_types, 'prompt hook type missing'
-        assert 'agent' in pre_types, 'agent hook type missing'
-
-    def test_hook_paths_expanded_in_settings_json(
-        self,
-        e2e_isolated_home: dict[str, Path],
-    ) -> None:
-        """Verify hook command paths are absolute POSIX with no unexpanded tildes."""
-        paths = e2e_isolated_home
-        claude_dir = paths['claude_dir']
-        hooks_dir = claude_dir / 'hooks'
-
-        hooks = {
-            'events': [
-                {'event': 'PostToolUse', 'matcher': 'Write', 'type': 'command',
-                 'command': 'e2e_test_hook.py'},
-                {'event': 'PostToolUse', 'matcher': 'Read', 'type': 'command',
-                 'command': 'e2e_test_hook.js'},
-            ],
-        }
-
-        write_hooks_to_settings(hooks, hooks_dir, claude_dir)
-
-        data = json.loads((claude_dir / 'settings.json').read_text())
-        hooks_data = data['hooks']
-
-        for event_groups in hooks_data.values():
-            for group in event_groups:
-                for hook in group.get('hooks', []):
-                    if hook.get('type') == 'command':
-                        cmd = hook.get('command', '')
-                        assert '~' not in cmd, f'Unexpanded tilde in command: {cmd}'
-                        # Python hooks should have uv run prefix
-                        if 'e2e_test_hook.py' in cmd:
-                            assert 'uv run' in cmd, f'Missing uv run prefix: {cmd}'
-                        # JS hooks should have node prefix
-                        if 'e2e_test_hook.js' in cmd:
-                            assert cmd.startswith('node '), f'Missing node prefix: {cmd}'
-
-    def test_stale_hooks_removed_on_rerun(
-        self,
-        e2e_isolated_home: dict[str, Path],
-    ) -> None:
-        """Verify stale hook events from prior runs are removed on re-run."""
-        paths = e2e_isolated_home
-        claude_dir = paths['claude_dir']
-        hooks_dir = claude_dir / 'hooks'
-
-        # First run: create hooks with event A
-        hooks_v1 = {
-            'events': [
-                {'event': 'OldEvent', 'matcher': 'Write', 'type': 'command',
-                 'command': 'old.py'},
-            ],
-        }
-        write_hooks_to_settings(hooks_v1, hooks_dir, claude_dir)
-
-        data_v1 = json.loads((claude_dir / 'settings.json').read_text())
-        assert 'OldEvent' in data_v1['hooks'], 'First run: OldEvent should be present'
-
-        # Second run: create hooks with different event
-        hooks_v2 = {
-            'events': [
-                {'event': 'PostToolUse', 'matcher': 'Write', 'type': 'command',
-                 'command': 'new.py'},
-            ],
-        }
-        write_hooks_to_settings(hooks_v2, hooks_dir, claude_dir)
-
-        data_v2 = json.loads((claude_dir / 'settings.json').read_text())
-        assert 'OldEvent' not in data_v2['hooks'], 'Second run: OldEvent should be removed'
-        assert 'PostToolUse' in data_v2['hooks'], 'Second run: PostToolUse should be present'
-
-    def test_config_json_not_created_without_command_names(
-        self,
-        e2e_isolated_home: dict[str, Path],
-    ) -> None:
-        """Verify config.json is NOT created when command-names is absent."""
-        paths = e2e_isolated_home
-        claude_dir = paths['claude_dir']
-        hooks_dir = claude_dir / 'hooks'
-
-        config = _hooks_only_config()
-        write_hooks_to_settings(config['hooks'], hooks_dir, claude_dir)
-
-        # config.json should NOT exist (no command-names means no isolated environment)
-        config_json = claude_dir / 'config.json'
-        assert not config_json.exists(), 'config.json should not be created without command-names'
 
 
 class TestHooksToConfigJsonRegression:
@@ -337,6 +145,7 @@ class TestHooksAndUserSettingsCoexistence:
         paths = e2e_isolated_home
         claude_dir = paths['claude_dir']
         hooks_dir = claude_dir / 'hooks'
+        hooks_dir.mkdir(parents=True, exist_ok=True)
 
         config = _hooks_with_user_settings_config()
 
@@ -344,8 +153,9 @@ class TestHooksAndUserSettingsCoexistence:
         from scripts.setup_environment import write_user_settings
         write_user_settings(config['user-settings'], claude_dir)
 
-        # Simulate Step 18: write hooks to settings.json
-        write_hooks_to_settings(config['hooks'], hooks_dir, claude_dir)
+        # Simulate Step 18: write profile settings (including hooks) to settings.json
+        delta = _build_profile_settings({'hooks': config['hooks']}, hooks_dir)
+        write_profile_settings_to_settings(delta, claude_dir)
 
         settings_path = claude_dir / 'settings.json'
         assert settings_path.exists()
@@ -368,6 +178,7 @@ class TestHooksAndUserSettingsCoexistence:
         paths = e2e_isolated_home
         claude_dir = paths['claude_dir']
         hooks_dir = claude_dir / 'hooks'
+        hooks_dir.mkdir(parents=True, exist_ok=True)
 
         # Pre-populate with rich user settings
         settings_file = claude_dir / 'settings.json'
@@ -385,18 +196,60 @@ class TestHooksAndUserSettingsCoexistence:
                  'command': 'hook.py'},
             ],
         }
-        write_hooks_to_settings(hooks, hooks_dir, claude_dir)
+        delta = _build_profile_settings({'hooks': hooks}, hooks_dir)
+        write_profile_settings_to_settings(delta, claude_dir)
 
         data = json.loads(settings_file.read_text())
 
         # All original keys preserved exactly
         assert data['language'] == 'english'
+        # Under universal union, permissions.allow with no new entries
+        # is a no-op (the hooks-only delta contributes no permissions)
         assert data['permissions'] == {'allow': ['Read', 'Write']}
         assert data['theme'] == 'dark'
         assert data['nested'] == {'key1': 'val1', 'key2': [1, 2, 3]}
 
         # Hooks added
         assert 'hooks' in data
+
+    def test_two_matcher_groups_with_same_matcher_coexist(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """Two runs with the same matcher string + different commands produce TWO matcher groups.
+
+        Naive structural dedupe keeps both groups because the inner
+        'hooks' arrays differ. This matches Claude Code's native
+        cross-scope merge behavior and its runtime dedupe by command
+        string (documented at https://code.claude.com/docs/en/hooks).
+        """
+        paths = e2e_isolated_home
+        claude_dir = paths['claude_dir']
+        hooks_dir = claude_dir / 'hooks'
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+
+        hooks_a = {
+            'events': [
+                {'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'command', 'command': 'a.sh'},
+            ],
+        }
+        delta_a = _build_profile_settings({'hooks': hooks_a}, hooks_dir)
+        write_profile_settings_to_settings(delta_a, claude_dir)
+
+        hooks_b = {
+            'events': [
+                {'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'command', 'command': 'b.sh'},
+            ],
+        }
+        delta_b = _build_profile_settings({'hooks': hooks_b}, hooks_dir)
+        write_profile_settings_to_settings(delta_b, claude_dir)
+
+        settings = json.loads((claude_dir / 'settings.json').read_text())
+        pre_tool = settings['hooks']['PreToolUse']
+        assert len(pre_tool) == 2
+        commands = sorted(g['hooks'][0]['command'] for g in pre_tool)
+        # Both scripts are absolute POSIX paths, so sort alphabetically
+        assert len(commands) == 2
 
 
 class TestNoHooksNoCommandNames:
@@ -422,14 +275,22 @@ class TestNoHooksNoCommandNames:
             data = json.loads(settings_path.read_text())
             assert 'hooks' not in data, 'hooks key should not be present when none configured'
 
-    def test_empty_hooks_cleans_up(
+    def test_explicit_null_hooks_removes_stale_events(
         self,
         e2e_isolated_home: dict[str, Path],
     ) -> None:
-        """Verify write_hooks_to_settings with empty hooks removes stale hooks key."""
+        """Verify explicit RFC 7396 null removes stale hooks from settings.json.
+
+        Under the universal deep-merge + union-all-arrays contract, the
+        only way to delete stale hooks from ~/.claude/settings.json is
+        to declare ``hooks: null`` in YAML (or ``{'hooks': None}`` in
+        the profile delta). Under union semantics, omitting the hooks
+        key leaves existing hooks in place.
+        """
         paths = e2e_isolated_home
         claude_dir = paths['claude_dir']
         hooks_dir = claude_dir / 'hooks'
+        hooks_dir.mkdir(parents=True, exist_ok=True)
 
         # Pre-populate with stale hooks
         settings_file = claude_dir / 'settings.json'
@@ -438,11 +299,12 @@ class TestNoHooksNoCommandNames:
             'language': 'russian',
         }))
 
-        # Write empty hooks (simulates config with no hook events)
-        write_hooks_to_settings({}, hooks_dir, claude_dir)
+        # Explicit null removes hooks block (simulates YAML: hooks: null)
+        delta = _build_profile_settings({'hooks': None}, hooks_dir)
+        write_profile_settings_to_settings(delta, claude_dir)
 
         data = json.loads(settings_file.read_text())
-        assert 'hooks' not in data, 'Stale hooks key should be removed'
+        assert 'hooks' not in data, 'Stale hooks key should be removed by explicit null'
         assert data['language'] == 'russian', 'Other settings should be preserved'
 
 

--- a/tests/e2e/test_profile_settings_routing.py
+++ b/tests/e2e/test_profile_settings_routing.py
@@ -4,17 +4,22 @@ Verifies that when `command-names` is absent, all profile-owned keys
 (model, permissions, env, attribution, alwaysThinkingEnabled, effortLevel,
 companyAnnouncements, statusLine, hooks) are correctly routed to
 ~/.claude/settings.json via write_profile_settings_to_settings(), which
-deep-merges the delta into the existing file: nested dicts are recursively
-merged, permissions.allow/deny/ask arrays are unioned,
-RFC 7396 null (both top-level and nested) deletes keys, and keys not in
-the delta are preserved unchanged.
+deep-merges the delta into the existing file: nested dicts are
+recursively merged, EVERY list at every depth is unioned with structural
+dedupe (matching Claude Code CLI's cross-scope merge: "arrays are
+concatenated and deduplicated, not replaced"), RFC 7396 null (both
+top-level and nested) deletes keys, and keys not in the delta are
+preserved unchanged.
 
 Test coverage matrix:
 - Happy path: all 9 profile-owned keys deep-merged correctly
 - Partial config: only subset of keys declared, rest preserved
 - Deep-merge preservation: pre-existing settings.json sub-keys survive
 - Step 14/18 interaction: user-settings contributions preserved
-- permissions array union: user-settings + root-level deny rules accumulate
+- Array union at every depth: permissions.allow/deny/ask,
+  permissions.additionalDirectories, companyAnnouncements,
+  hooks.<EventName>, and every other list-valued key accumulate
+  across runs
 - Conflict detection: warnings fire in non-command-names mode
 - Top-level null-as-delete: model/permissions/env/hooks/... all removable via null
 - Nested null-as-delete: permissions.deny=None removes just the deny sub-key
@@ -55,10 +60,16 @@ class TestDeepMergeWriterFilesystem:
     """Filesystem-level tests of write_profile_settings_to_settings().
 
     Verifies that the shared settings.json writer applies deep-merge via
-    delegation to _write_merged_json(): nested dicts are recursively
-    merged, permissions.allow/deny/ask arrays are unioned,
+    delegation to _write_merged_json() with the universal union-all-arrays
+    default (array_union_keys=None): nested dicts are recursively merged,
+    EVERY array at every depth is unioned with structural dedupe,
     RFC 7396 null-as-delete works for both top-level keys and nested
     sub-keys, and keys not present in the delta are preserved unchanged.
+
+    Matches Claude Code CLI's documented cross-scope merge semantics:
+    "Array settings merge across scopes. When the same array-valued
+    setting appears in multiple scopes, the arrays are concatenated and
+    deduplicated, not replaced."
     """
 
     def test_happy_path_all_nine_keys(self, tmp_path: Path) -> None:
@@ -303,6 +314,108 @@ class TestDeepMergeWriterFilesystem:
         # 'allow' preserved, 'deny' deleted
         assert content['permissions'] == {'allow': ['Read']}
 
+    def test_company_announcements_preserved_across_runs(self, tmp_path: Path) -> None:
+        """companyAnnouncements unions across two Step 18 filesystem writes."""
+        hooks_dir = tmp_path / 'hooks'
+        hooks_dir.mkdir()
+        delta_a = _build_profile_settings({'companyAnnouncements': ['Welcome']}, hooks_dir)
+        write_profile_settings_to_settings(delta_a, tmp_path)
+        delta_b = _build_profile_settings({'companyAnnouncements': ['Maintenance']}, hooks_dir)
+        write_profile_settings_to_settings(delta_b, tmp_path)
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+        assert content['companyAnnouncements'] == ['Welcome', 'Maintenance']
+
+    def test_permissions_additional_directories_preserved(self, tmp_path: Path) -> None:
+        """permissions.additionalDirectories unions across two Step 18 writes."""
+        hooks_dir = tmp_path / 'hooks'
+        hooks_dir.mkdir()
+        delta_a = _build_profile_settings(
+            {'permissions': {'additionalDirectories': ['/existing']}},
+            hooks_dir,
+        )
+        write_profile_settings_to_settings(delta_a, tmp_path)
+        delta_b = _build_profile_settings(
+            {'permissions': {'additionalDirectories': ['/new']}},
+            hooks_dir,
+        )
+        write_profile_settings_to_settings(delta_b, tmp_path)
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+        assert content['permissions']['additionalDirectories'] == ['/existing', '/new']
+
+    def test_hooks_event_list_preserved_across_runs(self, tmp_path: Path) -> None:
+        """Two Step 18 writes with different hook events both survive on disk."""
+        hooks_dir = tmp_path / 'hooks'
+        hooks_dir.mkdir()
+        delta_a = _build_profile_settings(
+            {
+                'hooks': {
+                    'events': [
+                        {
+                            'event': 'PreToolUse', 'matcher': 'Bash',
+                            'type': 'command', 'command': 'a.sh',
+                        },
+                    ],
+                },
+            },
+            hooks_dir,
+        )
+        write_profile_settings_to_settings(delta_a, tmp_path)
+        delta_b = _build_profile_settings(
+            {
+                'hooks': {
+                    'events': [
+                        {
+                            'event': 'PostToolUse', 'matcher': 'Write',
+                            'type': 'command', 'command': 'b.sh',
+                        },
+                    ],
+                },
+            },
+            hooks_dir,
+        )
+        write_profile_settings_to_settings(delta_b, tmp_path)
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+        assert 'PreToolUse' in content['hooks']
+        assert 'PostToolUse' in content['hooks']
+
+    def test_user_managed_array_outside_delta_preserved(self, tmp_path: Path) -> None:
+        """A user-managed array outside the toolbox delta survives Step 18."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(
+            json.dumps({'customUserArray': ['a', 'b']}),
+            encoding='utf-8',
+        )
+        hooks_dir = tmp_path / 'hooks'
+        hooks_dir.mkdir()
+        delta = _build_profile_settings({'model': 'sonnet'}, hooks_dir)
+        write_profile_settings_to_settings(delta, tmp_path)
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert content['customUserArray'] == ['a', 'b']
+        assert content['model'] == 'sonnet'
+
+    def test_explicit_null_hooks_removes_stale_block(self, tmp_path: Path) -> None:
+        """Explicit RFC 7396 null at YAML root removes the entire hooks block."""
+        hooks_dir = tmp_path / 'hooks'
+        hooks_dir.mkdir()
+        delta_a = _build_profile_settings(
+            {
+                'hooks': {
+                    'events': [
+                        {
+                            'event': 'PreToolUse', 'matcher': 'Bash',
+                            'type': 'command', 'command': 'a.sh',
+                        },
+                    ],
+                },
+            },
+            hooks_dir,
+        )
+        write_profile_settings_to_settings(delta_a, tmp_path)
+        # Simulate YAML with hooks: null -> delta has {'hooks': None}
+        write_profile_settings_to_settings({'hooks': None}, tmp_path)
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+        assert 'hooks' not in content
+
 
 # ---------------------------------------------------------------------------
 # Test Class 2: Step 14 / Step 18 Interaction (user-settings + profile delta)
@@ -358,13 +471,14 @@ class TestStep14Step18Interaction:
     ) -> None:
         """Step 14 user-settings.permissions and Step 18 root permissions accumulate via union.
 
-        With deep-merge + DEFAULT_ARRAY_UNION_KEYS, both Step 14
-        (write_user_settings writing user-settings) and Step 18
-        (write_profile_settings_to_settings writing root-level permissions)
-        contribute additively to permissions.allow, permissions.deny,
-        permissions.ask. This is a deliberate security property: a team's
-        shared user-settings 'deny' rules compose with a per-run YAML's
-        additional 'deny' rules rather than one destroying the other.
+        Under the universal union-all-arrays default, EVERY list at
+        every depth is unioned across Step 14 (write_user_settings) and
+        Step 18 (write_profile_settings_to_settings). This specific test
+        is one instance of a general behavior that covers
+        permissions.allow, permissions.deny, permissions.ask, and every
+        other array-valued key. A team's shared user-settings 'deny'
+        rules compose with a per-run YAML's additional 'deny' rules
+        rather than one destroying the other.
         """
         # Step 14 wrote user-settings.permissions
         settings_file = tmp_path / 'settings.json'
@@ -477,7 +591,7 @@ class TestConflictDetectionInNonCommandNamesMode:
         assert "Key 'model' specified in both root level and user-settings" in captured.out
         # Composite deep-merge precedence message
         assert 'Under deep merge semantics' in captured.out
-        assert 'permissions.allow/deny/ask, array union applies' in captured.out
+        assert 'array union with structural dedupe applies' in captured.out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -4562,142 +4562,6 @@ class TestBuildHooksJson:
             assert direct_hooks == config_hooks
 
 
-class TestWriteHooksToSettings:
-    """Tests for write_hooks_to_settings() function."""
-
-    def test_creates_new_file(self, tmp_path):
-        """Creates settings.json when it does not exist."""
-        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write',
-                             'type': 'command', 'command': 'hook.py'}]}
-        hooks_dir = tmp_path / 'hooks'
-        result = setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
-        assert result is True
-        settings_file = tmp_path / 'settings.json'
-        assert settings_file.exists()
-        data = json.loads(settings_file.read_text())
-        assert 'hooks' in data
-        assert 'PostToolUse' in data['hooks']
-
-    def test_preserves_existing_keys(self, tmp_path):
-        """Existing keys in settings.json are preserved."""
-        settings_file = tmp_path / 'settings.json'
-        settings_file.write_text(json.dumps({'language': 'english', 'theme': 'dark'}))
-        hooks = {'events': [{'event': 'SessionStart', 'matcher': '*',
-                             'type': 'command', 'command': 'hook.py'}]}
-        hooks_dir = tmp_path / 'hooks'
-        result = setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
-        assert result is True
-        data = json.loads(settings_file.read_text())
-        assert data['language'] == 'english'
-        assert data['theme'] == 'dark'
-        assert 'hooks' in data
-
-    def test_replaces_stale_hooks(self, tmp_path):
-        """Stale hook events from prior runs are removed."""
-        settings_file = tmp_path / 'settings.json'
-        settings_file.write_text(json.dumps({
-            'hooks': {'OldEvent': [{'matcher': '', 'hooks': [{'type': 'command', 'command': 'old.py'}]}]},
-        }))
-        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write',
-                             'type': 'command', 'command': 'new.py'}]}
-        hooks_dir = tmp_path / 'hooks'
-        result = setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
-        assert result is True
-        data = json.loads(settings_file.read_text())
-        assert 'OldEvent' not in data['hooks']
-        assert 'PostToolUse' in data['hooks']
-
-    def test_empty_hooks_removes_key(self, tmp_path):
-        """Empty hooks configuration removes 'hooks' key from settings."""
-        settings_file = tmp_path / 'settings.json'
-        settings_file.write_text(json.dumps({
-            'hooks': {'SomeEvent': []},
-            'language': 'english',
-        }))
-        hooks_dir = tmp_path / 'hooks'
-        result = setup_environment.write_hooks_to_settings({}, hooks_dir, tmp_path)
-        assert result is True
-        data = json.loads(settings_file.read_text())
-        assert 'hooks' not in data
-        assert data['language'] == 'english'
-
-    def test_invalid_json_starts_fresh(self, tmp_path):
-        """Invalid JSON in existing file starts with fresh dict."""
-        settings_file = tmp_path / 'settings.json'
-        settings_file.write_text('not valid json!!!')
-        hooks = {'events': [{'event': 'PostToolUse', 'matcher': '',
-                             'type': 'command', 'command': 'hook.py'}]}
-        hooks_dir = tmp_path / 'hooks'
-        result = setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
-        assert result is True
-        data = json.loads(settings_file.read_text())
-        assert 'hooks' in data
-
-    def test_non_dict_json_starts_fresh(self, tmp_path):
-        """Non-dict JSON content starts with fresh dict."""
-        settings_file = tmp_path / 'settings.json'
-        settings_file.write_text('"just a string"')
-        hooks = {'events': [{'event': 'PostToolUse', 'matcher': '',
-                             'type': 'command', 'command': 'hook.py'}]}
-        hooks_dir = tmp_path / 'hooks'
-        result = setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
-        assert result is True
-        data = json.loads(settings_file.read_text())
-        assert 'hooks' in data
-
-    def test_preserves_user_settings_from_prior_step(self, tmp_path):
-        """Hooks write preserves user settings written by write_user_settings."""
-        settings_file = tmp_path / 'settings.json'
-        settings_file.write_text(json.dumps({
-            'language': 'english',
-            'theme': 'dark',
-            'permissions': {'allow': ['Read']},
-        }))
-        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write',
-                             'type': 'command', 'command': 'hook.py'}]}
-        hooks_dir = tmp_path / 'hooks'
-        result = setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
-        assert result is True
-        data = json.loads(settings_file.read_text())
-        assert data['language'] == 'english'
-        assert data['theme'] == 'dark'
-        assert data['permissions'] == {'allow': ['Read']}
-        assert 'PostToolUse' in data['hooks']
-
-    def test_idempotent(self, tmp_path):
-        """Running write_hooks_to_settings twice produces same result."""
-        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write',
-                             'type': 'command', 'command': 'hook.py'}]}
-        hooks_dir = tmp_path / 'hooks'
-        setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
-        first_content = (tmp_path / 'settings.json').read_text()
-        setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
-        second_content = (tmp_path / 'settings.json').read_text()
-        assert first_content == second_content
-
-    def test_creates_directory_if_missing(self, tmp_path):
-        """Creates settings_dir if it does not exist."""
-        new_dir = tmp_path / 'new_dir'
-        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write',
-                             'type': 'command', 'command': 'hook.py'}]}
-        hooks_dir = new_dir / 'hooks'
-        result = setup_environment.write_hooks_to_settings(hooks, hooks_dir, new_dir)
-        assert result is True
-        assert (new_dir / 'settings.json').exists()
-
-    def test_empty_file_starts_fresh(self, tmp_path):
-        """Empty settings.json starts with fresh dict."""
-        settings_file = tmp_path / 'settings.json'
-        settings_file.write_text('')
-        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write',
-                             'type': 'command', 'command': 'hook.py'}]}
-        hooks_dir = tmp_path / 'hooks'
-        result = setup_environment.write_hooks_to_settings(hooks, hooks_dir, tmp_path)
-        assert result is True
-        data = json.loads(settings_file.read_text())
-        assert 'hooks' in data
-
-
 class TestCreateLauncherScript:
     """Test launcher script creation."""
 
@@ -6033,19 +5897,19 @@ class TestDeepMergeSettings:
         result = setup_environment.deep_merge_settings(base, updates)
         assert result == {'permissions': {'allow': ['Read']}}
 
-    # === Array Non-Union Tests ===
+    # === Universal Array Union Tests ===
 
-    def test_non_union_key_replaces(self):
-        """Arrays at non-union keys are replaced entirely."""
-        base = {'items': [1, 2]}
+    def test_default_unions_arbitrary_array_path(self):
+        """Arrays at any path are unioned under the default (array_union_keys=None)."""
+        base: dict[str, object] = {'items': [1, 2]}
         updates = {'items': [3, 4]}
         result = setup_environment.deep_merge_settings(base, updates)
-        assert result == {'items': [3, 4]}
+        assert result == {'items': [1, 2, 3, 4]}
 
-    # === Custom Array Union Keys Tests ===
+    # === Per-Path Whitelist Tests ===
 
-    def test_custom_array_union_keys(self):
-        """Custom array union keys override defaults."""
+    def test_explicit_set_whitelist_still_works(self):
+        """Explicit per-path whitelist (array_union_keys=set[str]) is preserved for the inheritance layer."""
         base = {
             'custom': {'list': [1, 2]},
             'permissions': {'allow': ['a']},
@@ -6057,16 +5921,20 @@ class TestDeepMergeSettings:
         result = setup_environment.deep_merge_settings(
             base, updates, array_union_keys={'custom.list'},
         )
-        # custom.list is unioned, permissions.allow is replaced (not in custom keys)
+        # Explicit whitelist: custom.list unioned, permissions.allow replaced
         assert result['custom']['list'] == [1, 2, 3]
         assert result['permissions']['allow'] == ['b']
 
-    def test_empty_custom_keys_disables_union(self):
-        """Empty custom keys set disables all array union."""
+    def test_empty_set_replaces_all_arrays(self):
+        """Explicit empty set[str] disables union entirely.
+
+        The YAML inheritance layer at the global-config call site uses this
+        form for child-replaces-parent semantics.
+        """
         base = {'permissions': {'allow': ['Read']}}
         updates = {'permissions': {'allow': ['Write']}}
         result = setup_environment.deep_merge_settings(base, updates, array_union_keys=set())
-        # With no union keys, array is replaced
+        # With empty set, array is replaced
         assert result == {'permissions': {'allow': ['Write']}}
 
     # === Immutability Tests ===
@@ -6129,7 +5997,12 @@ class TestDeepMergeSettings:
         assert result == {'name': 'updated'}
 
     def test_default_array_union_keys_constant(self):
-        """DEFAULT_ARRAY_UNION_KEYS contains expected permission keys."""
+        """DEFAULT_ARRAY_UNION_KEYS contains permission keys for inheritance layer.
+
+        The constant is preserved only for the YAML inheritance layer
+        (_resolve_single_key for user-settings). On-disk writers use
+        universal union-all-arrays via array_union_keys=None default.
+        """
         expected = {'permissions.allow', 'permissions.deny', 'permissions.ask'}
         assert expected == setup_environment.DEFAULT_ARRAY_UNION_KEYS
 
@@ -6197,11 +6070,17 @@ class TestDeepMergeSettings:
         assert 'allow' not in result['permissions']
 
     def test_null_inside_array_not_deleted(self):
-        """Null values inside arrays are NOT treated as deletion signals."""
+        """Null values inside arrays are NOT treated as deletion signals.
+
+        Under universal union semantics, the union combines existing
+        elements with new ones and preserves None values verbatim --
+        None inside an array is an ordinary element, not a deletion
+        signal (which only applies to object keys).
+        """
         base = {'items': [1, 2, 3]}
         updates = {'items': [None, 4, 5]}
         result = setup_environment.deep_merge_settings(base, updates)
-        assert result == {'items': [None, 4, 5]}
+        assert result == {'items': [1, 2, 3, None, 4, 5]}
 
     def test_none_in_base_preserved_without_update(self):
         """None values in base are preserved when no update for that key."""
@@ -6224,6 +6103,181 @@ class TestDeepMergeSettings:
         updates = {'b': None, 'd': None}
         result = setup_environment.deep_merge_settings(base, updates)
         assert result == {'a': 1, 'c': 3}
+
+
+class TestUnionAllArraysDefault:
+    """Tests for the universal union-all-arrays default in deep_merge_settings.
+
+    Under the default (array_union_keys=None), every list at every depth
+    is unioned with structural dedupe. These tests serve as regression
+    guards for the shared-settings writer contract: no on-disk list is
+    ever silently replaced.
+    """
+
+    def test_default_unions_permissions_allow(self):
+        """permissions.allow still unions under universal default."""
+        base = {'permissions': {'allow': ['Read']}}
+        updates = {'permissions': {'allow': ['Write']}}
+        result = setup_environment.deep_merge_settings(base, updates)
+        assert result == {'permissions': {'allow': ['Read', 'Write']}}
+
+    def test_default_unions_permissions_additional_directories(self):
+        """permissions.additionalDirectories is unioned under the default."""
+        base = {'permissions': {'additionalDirectories': ['/existing']}}
+        updates = {'permissions': {'additionalDirectories': ['/new']}}
+        result = setup_environment.deep_merge_settings(base, updates)
+        assert result == {
+            'permissions': {'additionalDirectories': ['/existing', '/new']},
+        }
+
+    def test_default_unions_company_announcements(self):
+        """companyAnnouncements is unioned under the default."""
+        base = {'companyAnnouncements': ['Welcome']}
+        updates = {'companyAnnouncements': ['Maintenance Sunday']}
+        result = setup_environment.deep_merge_settings(base, updates)
+        assert result == {'companyAnnouncements': ['Welcome', 'Maintenance Sunday']}
+
+    def test_default_unions_hooks_event_list_disjoint_matchers(self):
+        """Two hook matcher groups with disjoint matcher strings compose additively."""
+        base = {
+            'hooks': {
+                'PreToolUse': [
+                    {'matcher': 'Bash', 'hooks': [{'type': 'command', 'command': 'a.sh'}]},
+                ],
+            },
+        }
+        updates = {
+            'hooks': {
+                'PreToolUse': [
+                    {'matcher': 'Write', 'hooks': [{'type': 'command', 'command': 'b.sh'}]},
+                ],
+            },
+        }
+        result = setup_environment.deep_merge_settings(base, updates)
+        matchers = [g['matcher'] for g in result['hooks']['PreToolUse']]
+        assert matchers == ['Bash', 'Write']
+
+    def test_default_hooks_same_matcher_different_command_both_kept(self):
+        """Matcher groups with the SAME matcher string but different inner hooks coexist.
+
+        Naive structural dedupe: the two groups are not structurally
+        equal (inner 'hooks' arrays differ), so both are kept as
+        separate entries. This matches Claude Code's cross-scope merge
+        (concat+dedupe) and its runtime dedupe by command string.
+        """
+        base = {
+            'hooks': {
+                'PreToolUse': [
+                    {'matcher': 'Bash', 'hooks': [{'type': 'command', 'command': 'a.sh'}]},
+                ],
+            },
+        }
+        updates = {
+            'hooks': {
+                'PreToolUse': [
+                    {'matcher': 'Bash', 'hooks': [{'type': 'command', 'command': 'b.sh'}]},
+                ],
+            },
+        }
+        result = setup_environment.deep_merge_settings(base, updates)
+        groups = result['hooks']['PreToolUse']
+        assert len(groups) == 2
+        commands = [g['hooks'][0]['command'] for g in groups]
+        assert commands == ['a.sh', 'b.sh']
+
+    def test_default_dedupes_identical_matcher_groups(self):
+        """Structurally identical matcher groups are deduplicated (idempotent re-run)."""
+        shared = {'matcher': 'Bash', 'hooks': [{'type': 'command', 'command': 'a.sh'}]}
+        base = {'hooks': {'PreToolUse': [shared]}}
+        updates = {'hooks': {'PreToolUse': [shared]}}
+        result = setup_environment.deep_merge_settings(base, updates)
+        assert result['hooks']['PreToolUse'] == [shared]
+
+    def test_default_unions_sandbox_filesystem_allow_write(self):
+        """sandbox.filesystem.allowWrite nested list is unioned."""
+        base = {'sandbox': {'filesystem': {'allowWrite': ['/existing']}}}
+        updates = {'sandbox': {'filesystem': {'allowWrite': ['/new']}}}
+        result = setup_environment.deep_merge_settings(base, updates)
+        assert result == {'sandbox': {'filesystem': {'allowWrite': ['/existing', '/new']}}}
+
+    def test_default_unions_disabled_mcpjson_servers(self):
+        """disabledMcpjsonServers is unioned under the default."""
+        base = {'disabledMcpjsonServers': ['srv1']}
+        updates = {'disabledMcpjsonServers': ['srv2']}
+        result = setup_environment.deep_merge_settings(base, updates)
+        assert result == {'disabledMcpjsonServers': ['srv1', 'srv2']}
+
+    def test_default_unions_enabled_mcpjson_servers(self):
+        """enabledMcpjsonServers is unioned under the default."""
+        base = {'enabledMcpjsonServers': ['srv1']}
+        updates = {'enabledMcpjsonServers': ['srv2']}
+        result = setup_environment.deep_merge_settings(base, updates)
+        assert result == {'enabledMcpjsonServers': ['srv1', 'srv2']}
+
+    def test_default_unions_at_arbitrary_nested_depth(self):
+        """Union applies at any nesting depth, not just top-level."""
+        base = {'a': {'b': {'c': {'items': [1, 2]}}}}
+        updates = {'a': {'b': {'c': {'items': [2, 3]}}}}
+        result = setup_environment.deep_merge_settings(base, updates)
+        assert result == {'a': {'b': {'c': {'items': [1, 2, 3]}}}}
+
+    def test_default_preserves_rfc7396_null_delete_top_level(self):
+        """RFC 7396 null-as-delete still works at top level under the default."""
+        base = {'a': 1, 'b': 2}
+        updates = {'b': None}
+        result = setup_environment.deep_merge_settings(base, updates)
+        assert result == {'a': 1}
+        assert 'b' not in result
+
+    def test_default_preserves_rfc7396_null_delete_nested(self):
+        """RFC 7396 null-as-delete still works at nested levels under the default."""
+        base = {'permissions': {'allow': ['Read'], 'deny': ['Bash']}}
+        updates = {'permissions': {'deny': None}}
+        result = setup_environment.deep_merge_settings(base, updates)
+        assert 'deny' not in result['permissions']
+        assert result['permissions']['allow'] == ['Read']
+
+    def test_default_preserves_scalar_overwrite(self):
+        """Scalar values still overwrite under the default."""
+        base = {'model': 'sonnet'}
+        updates = {'model': 'opus'}
+        result = setup_environment.deep_merge_settings(base, updates)
+        assert result == {'model': 'opus'}
+
+    def test_default_preserves_dict_deep_merge(self):
+        """Dict deep merge still works under the default."""
+        base = {'attribution': {'commit': 'c1'}}
+        updates = {'attribution': {'pr': 'p1'}}
+        result = setup_environment.deep_merge_settings(base, updates)
+        assert result == {'attribution': {'commit': 'c1', 'pr': 'p1'}}
+
+    def test_default_dedupe_preserves_order_existing_first(self):
+        """Dedupe preserves order: existing elements first, then new elements."""
+        base = {'items': [1, 2, 3]}
+        updates = {'items': [3, 2, 4, 1]}
+        result = setup_environment.deep_merge_settings(base, updates)
+        assert result == {'items': [1, 2, 3, 4]}
+
+    def test_default_empty_delta_preserves_base_arrays(self):
+        """Empty delta preserves base arrays unchanged."""
+        base = {'permissions': {'allow': ['Read'], 'deny': ['Bash']}}
+        updates: dict[str, object] = {}
+        result = setup_environment.deep_merge_settings(base, updates)
+        assert result == {'permissions': {'allow': ['Read'], 'deny': ['Bash']}}
+
+    def test_default_empty_list_in_updates_is_noop(self):
+        """Empty list in updates adds nothing and does not wipe existing."""
+        base = {'items': [1, 2, 3]}
+        updates: dict[str, object] = {'items': []}
+        result = setup_environment.deep_merge_settings(base, updates)
+        assert result == {'items': [1, 2, 3]}
+
+    def test_default_type_mismatch_list_vs_scalar_replaces(self):
+        """Type mismatch falls through to the scalar-replace branch."""
+        base = {'x': [1, 2]}
+        updates = {'x': 'not a list'}
+        result = setup_environment.deep_merge_settings(base, updates)
+        assert result == {'x': 'not a list'}
 
 
 class TestWriteUserSettings:
@@ -7479,6 +7533,136 @@ class TestWriteProfileSettingsToSettings:
         assert result is True
         assert (target_dir / 'settings.json').exists()
 
+    def test_permissions_additional_directories_unioned_across_runs(self, tmp_path: Path) -> None:
+        """permissions.additionalDirectories unions across two writer calls."""
+        first_delta = {'permissions': {'additionalDirectories': ['/existing']}}
+        setup_environment.write_profile_settings_to_settings(first_delta, tmp_path)
+        second_delta = {'permissions': {'additionalDirectories': ['/new']}}
+        setup_environment.write_profile_settings_to_settings(second_delta, tmp_path)
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+        assert content['permissions']['additionalDirectories'] == ['/existing', '/new']
+
+    def test_company_announcements_unioned_across_runs(self, tmp_path: Path) -> None:
+        """companyAnnouncements unions across two writer calls."""
+        setup_environment.write_profile_settings_to_settings(
+            {'companyAnnouncements': ['Welcome']}, tmp_path,
+        )
+        setup_environment.write_profile_settings_to_settings(
+            {'companyAnnouncements': ['Maintenance']}, tmp_path,
+        )
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+        assert content['companyAnnouncements'] == ['Welcome', 'Maintenance']
+
+    def test_hooks_event_list_concatenated_across_runs(self, tmp_path: Path) -> None:
+        """hooks.<EventName> matcher groups concatenate across two writer calls."""
+        delta_a = {
+            'hooks': {
+                'PreToolUse': [
+                    {'matcher': 'Bash', 'hooks': [{'type': 'command', 'command': 'a.sh'}]},
+                ],
+            },
+        }
+        delta_b = {
+            'hooks': {
+                'PreToolUse': [
+                    {'matcher': 'Write', 'hooks': [{'type': 'command', 'command': 'b.sh'}]},
+                ],
+            },
+        }
+        setup_environment.write_profile_settings_to_settings(delta_a, tmp_path)
+        setup_environment.write_profile_settings_to_settings(delta_b, tmp_path)
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+        matchers = [g['matcher'] for g in content['hooks']['PreToolUse']]
+        assert matchers == ['Bash', 'Write']
+
+    def test_hooks_event_list_dedupes_identical_matcher_groups(self, tmp_path: Path) -> None:
+        """Idempotent re-run with identical hooks produces identical result."""
+        delta = {
+            'hooks': {
+                'PreToolUse': [
+                    {'matcher': 'Bash', 'hooks': [{'type': 'command', 'command': 'a.sh'}]},
+                ],
+            },
+        }
+        setup_environment.write_profile_settings_to_settings(delta, tmp_path)
+        setup_environment.write_profile_settings_to_settings(delta, tmp_path)
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+        assert len(content['hooks']['PreToolUse']) == 1
+
+    def test_hooks_disjoint_events_coexist_across_runs(self, tmp_path: Path) -> None:
+        """Disjoint hook event names (PreToolUse, PostToolUse) coexist across runs."""
+        setup_environment.write_profile_settings_to_settings(
+            {
+                'hooks': {
+                    'PreToolUse': [
+                        {'matcher': 'Bash', 'hooks': [{'type': 'command', 'command': 'a.sh'}]},
+                    ],
+                },
+            },
+            tmp_path,
+        )
+        setup_environment.write_profile_settings_to_settings(
+            {
+                'hooks': {
+                    'PostToolUse': [
+                        {'matcher': 'Write', 'hooks': [{'type': 'command', 'command': 'b.sh'}]},
+                    ],
+                },
+            },
+            tmp_path,
+        )
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+        assert 'PreToolUse' in content['hooks']
+        assert 'PostToolUse' in content['hooks']
+
+    def test_user_managed_unrelated_arrays_preserved_across_runs(self, tmp_path: Path) -> None:
+        """A user-managed array outside the toolbox delta survives writer calls."""
+        settings_file = tmp_path / 'settings.json'
+        settings_file.write_text(
+            json.dumps({'customUserArray': ['a', 'b', 'c']}),
+            encoding='utf-8',
+        )
+        setup_environment.write_profile_settings_to_settings({'model': 'sonnet'}, tmp_path)
+        content = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert content['customUserArray'] == ['a', 'b', 'c']
+        assert content['model'] == 'sonnet'
+
+    def test_stale_hooks_preserved_on_rerun(self, tmp_path: Path) -> None:
+        """Hooks from a prior run are preserved under union semantics (NOT removed)."""
+        first = {
+            'hooks': {
+                'PreToolUse': [
+                    {'matcher': 'Bash', 'hooks': [{'type': 'command', 'command': 'old.sh'}]},
+                ],
+            },
+        }
+        setup_environment.write_profile_settings_to_settings(first, tmp_path)
+        second = {
+            'hooks': {
+                'PostToolUse': [
+                    {'matcher': 'Write', 'hooks': [{'type': 'command', 'command': 'new.sh'}]},
+                ],
+            },
+        }
+        setup_environment.write_profile_settings_to_settings(second, tmp_path)
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+        assert 'PreToolUse' in content['hooks']
+        assert 'PostToolUse' in content['hooks']
+
+    def test_explicit_null_hooks_removes_stale_events(self, tmp_path: Path) -> None:
+        """Explicit RFC 7396 null removes stale hook events (the canonical deletion pattern)."""
+        first = {
+            'hooks': {
+                'PreToolUse': [
+                    {'matcher': 'Bash', 'hooks': [{'type': 'command', 'command': 'old.sh'}]},
+                ],
+            },
+        }
+        setup_environment.write_profile_settings_to_settings(first, tmp_path)
+        setup_environment.write_profile_settings_to_settings({'hooks': None}, tmp_path)
+        content = json.loads((tmp_path / 'settings.json').read_text(encoding='utf-8'))
+        assert 'hooks' not in content
+
 
 class TestCreateProfileConfigDelegation:
     """Regression tests verifying create_profile_config() delegates to builder."""
@@ -7574,8 +7758,8 @@ class TestWriteMergedJson:
         assert ok is True
         assert merged == {'key': 'value'}
 
-    def test_custom_array_union_keys(self, tmp_path: Path) -> None:
-        """Custom array_union_keys are used."""
+    def test_set_whitelist_via_writer(self, tmp_path: Path) -> None:
+        """Explicit set[str] whitelist routes through the writer correctly."""
         target = tmp_path / 'output.json'
         target.write_text(json.dumps({'list': [1, 2]}), encoding='utf-8')
 
@@ -7586,8 +7770,8 @@ class TestWriteMergedJson:
         assert ok is True
         assert set(merged['list']) == {1, 2, 3}
 
-    def test_empty_array_union_keys(self, tmp_path: Path) -> None:
-        """Empty set() disables array union."""
+    def test_empty_set_replaces_all_arrays_via_writer(self, tmp_path: Path) -> None:
+        """Explicit empty set() disables array union via the writer."""
         target = tmp_path / 'output.json'
         target.write_text(json.dumps({'list': [1, 2]}), encoding='utf-8')
 
@@ -7769,9 +7953,10 @@ class TestWriteGlobalConfig:
         written = json.loads(config_file.read_text(encoding='utf-8'))
         assert written['editorMode'] == 'vim'
 
-    def test_no_array_union(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Arrays are NOT unioned (replaced instead)."""
+    def test_global_config_arrays_unioned(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Arrays in ~/.claude.json are unioned under the universal deep-merge contract."""
         monkeypatch.setattr(Path, 'home', lambda: tmp_path)
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
         config_file = tmp_path / '.claude.json'
         config_file.write_text(json.dumps({'items': [1, 2]}), encoding='utf-8')
 
@@ -7779,7 +7964,7 @@ class TestWriteGlobalConfig:
 
         assert result is True
         written = json.loads(config_file.read_text(encoding='utf-8'))
-        assert written['items'] == [3, 4]
+        assert written['items'] == [1, 2, 3, 4]
 
     def test_returns_false_on_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Returns False on write failure."""
@@ -7824,6 +8009,56 @@ class TestWriteGlobalConfig:
         data = json.loads(config_file.read_text())
         assert 'oauthAccount' not in data
         assert data['other'] == 1
+
+    def test_global_config_disabled_mcpjson_servers_unioned(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """disabledMcpjsonServers unions across two write_global_config calls."""
+        monkeypatch.setattr(Path, 'home', lambda: tmp_path)
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        setup_environment.write_global_config({'disabledMcpjsonServers': ['srv1']})
+        setup_environment.write_global_config({'disabledMcpjsonServers': ['srv2']})
+        data = json.loads((tmp_path / '.claude.json').read_text(encoding='utf-8'))
+        assert data['disabledMcpjsonServers'] == ['srv1', 'srv2']
+
+    def test_global_config_enabled_mcpjson_servers_unioned(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """enabledMcpjsonServers unions across two write_global_config calls."""
+        monkeypatch.setattr(Path, 'home', lambda: tmp_path)
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        setup_environment.write_global_config({'enabledMcpjsonServers': ['srv1']})
+        setup_environment.write_global_config({'enabledMcpjsonServers': ['srv2']})
+        data = json.loads((tmp_path / '.claude.json').read_text(encoding='utf-8'))
+        assert data['enabledMcpjsonServers'] == ['srv1', 'srv2']
+
+    def test_global_config_scalar_still_overwrites(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Scalar overwrite still works in ~/.claude.json (regression guard)."""
+        monkeypatch.setattr(Path, 'home', lambda: tmp_path)
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        (tmp_path / '.claude.json').write_text(
+            json.dumps({'editorMode': 'emacs'}), encoding='utf-8',
+        )
+        setup_environment.write_global_config({'editorMode': 'vim'})
+        data = json.loads((tmp_path / '.claude.json').read_text(encoding='utf-8'))
+        assert data['editorMode'] == 'vim'
+
+    def test_global_config_nested_dict_still_deep_merges(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Nested dict deep-merge still works in ~/.claude.json (regression guard)."""
+        monkeypatch.setattr(Path, 'home', lambda: tmp_path)
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', lambda: tmp_path)
+        (tmp_path / '.claude.json').write_text(
+            json.dumps({'mcpServers': {'srv1': {'url': 'http://old'}}}),
+            encoding='utf-8',
+        )
+        setup_environment.write_global_config({'mcpServers': {'srv2': {'url': 'http://new'}}})
+        data = json.loads((tmp_path / '.claude.json').read_text(encoding='utf-8'))
+        assert 'srv1' in data['mcpServers']
+        assert 'srv2' in data['mcpServers']
 
 
 class TestDetectSettingsConflicts:


### PR DESCRIPTION
Shared-settings writers in non-isolated mode now deep-merge and union-all-arrays at every depth, matching Claude Code CLI's documented cross-scope merge semantics ("arrays are concatenated and deduplicated, not replaced").

The contract applies uniformly to write_user_settings(), write_profile_settings_to_settings(), and write_global_config() -- every list-valued key accumulates additively across runs, preserving contributions from the Claude Code CLI at runtime, prior toolbox runs with other YAMLs, manual user edits, and other writers.

Paths affected include permissions.additionalDirectories, companyAnnouncements, hooks.<EventName> matcher groups, sandbox.filesystem.* path lists, disabledMcpjsonServers/enabledMcpjsonServers, and every other list-valued key at any depth.

The flip is implemented by changing _merge_recursive(), deep_merge_settings(), and _write_merged_json() so that array_union_keys=None (the default) unions every list via Python structural equality; explicit set[str] values still yield the per-path whitelist for the YAML inheritance layer at _resolve_single_key.

write_global_config() drops its array_union_keys=set() arguments at both call sites because ~/.claude.json is a collaborative surface managed by the CLI (OAuth tokens, per-project trust, /mcp approve decisions, enabledPlugins, enabledMcpjsonServers/disabledMcpjsonServers) and the toolbox MUST NOT destroy CLI-managed state.

create_profile_config() isolated atomic-overwrite semantics are unchanged -- each YAML run produces a fresh per-environment isolated config.

Hooks composition uses naive structural dedupe: two matcher groups with the same matcher string but different inner handlers coexist as separate entries, matching Claude Code's native cross-scope merge and its runtime dedupe by command string and URL (https://code.claude.com/docs/en/hooks).

Dead code write_hooks_to_settings() (zero production callers) and its dependent tests are deleted. Tests that previously verified stale-hook removal are rewritten to use RFC 7396 null-as-delete via write_profile_settings_to_settings({'hooks': None}).