### PR TITLE
Add CLI flag and environment variable parity for setup script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,9 @@ All Linux/macOS scripts refuse to run as root/sudo by default (`id -u == 0` in s
 
 ### Installation Confirmation
 
-The setup script requires explicit user confirmation before installing. CLI flags: `--yes`/`-y` (auto-confirm), `--dry-run` (preview and exit). Env vars: `CLAUDE_CODE_TOOLBOX_CONFIRM_INSTALL=1` (auto-confirm), `CLAUDE_CODE_TOOLBOX_DRY_RUN=1` (preview). Both accept only exact value `'1'`.
+The setup script requires explicit user confirmation before installing. CLI flags: `--yes`/`-y` (auto-confirm), `--dry-run` (preview and exit), `--skip-install` (skip Claude Code installation), `--no-admin` (skip Windows admin elevation). Env vars: `CLAUDE_CODE_TOOLBOX_CONFIRM_INSTALL=1` (auto-confirm), `CLAUDE_CODE_TOOLBOX_DRY_RUN=1` (preview), `CLAUDE_CODE_TOOLBOX_SKIP_INSTALL=1` (skip installation), `CLAUDE_CODE_TOOLBOX_NO_ADMIN=1` (skip elevation). All accept only exact value `'1'`. Auth: `CLAUDE_CODE_TOOLBOX_ENV_AUTH` (string, `header:value` format).
+
+**Environment Variable Resolution:** All CLI flags and their env var equivalents are merged in `resolve_args()`, called immediately after `parse_args()`. CLI flags take precedence over env vars. The going-forward naming convention is: `--flag-name` becomes `CLAUDE_CODE_TOOLBOX_FLAG_NAME` (direct mechanical mapping). `CONFIRM_INSTALL` is a preserved historical exception.
 
 **Default:** Interactive → `[y/N]` prompt (deny default). Piped with `/dev/tty` → prompts via tty. Non-interactive → refuses (exit 1). Exit `0` for success/dry-run/cancellation, `1` for errors. Bootstrap scripts forward `--yes`, `--dry-run`, `--skip-install`, `--no-admin` to Python.
 
@@ -212,15 +214,18 @@ MCP servers are automatically pre-allowed via `permissions.allow: ["mcp__servern
 
 **Target 2 null-as-delete:** `_remove_auto_update_controls()` Target 2 (`user_settings.env`) uses `env_section[key] = None` (not `del`) because `_write_merged_json()` -> `_merge_recursive()` requires `None` to trigger key deletion from the target file. Target 3 (`env_variables`) correctly uses `del` because `create_profile_config()` uses atomic overwrite, not merge.
 
-### Environment Variables for Debugging
+### Environment Variables
 
+- `CLAUDE_CODE_TOOLBOX_CONFIRM_INSTALL`: `1` only -- auto-confirm installation (env var for `--yes`)
+- `CLAUDE_CODE_TOOLBOX_DRY_RUN`: `1` only -- preview installation plan without changes (env var for `--dry-run`)
+- `CLAUDE_CODE_TOOLBOX_SKIP_INSTALL`: `1` only -- skip Claude Code installation (env var for `--skip-install`)
+- `CLAUDE_CODE_TOOLBOX_NO_ADMIN`: `1` only -- skip Windows admin elevation (env var for `--no-admin`)
+- `CLAUDE_CODE_TOOLBOX_ENV_AUTH`: string -- authentication for private repos, `header:value` format (env var for `--auth`)
+- `CLAUDE_CODE_TOOLBOX_ALLOW_ROOT`: `1` only -- allow root on Linux/macOS (see Root Detection Guard)
 - `CLAUDE_CODE_TOOLBOX_DEBUG`: `1`/`true`/`yes` -- verbose debug logging
 - `CLAUDE_CODE_TOOLBOX_GIT_BASH_PATH`: Override Git Bash executable path
 - `CLAUDE_CODE_TOOLBOX_PARALLEL_WORKERS`: Override concurrent download workers (default: 2)
 - `CLAUDE_CODE_TOOLBOX_SEQUENTIAL_MODE`: `1`/`true`/`yes` -- disable parallel downloads
-- `CLAUDE_CODE_TOOLBOX_ALLOW_ROOT`: `1` only -- allow root on Linux/macOS (see Root Detection Guard)
-- `CLAUDE_CODE_TOOLBOX_CONFIRM_INSTALL`: `1` only -- auto-confirm installation
-- `CLAUDE_CODE_TOOLBOX_DRY_RUN`: `1` only -- preview installation plan without changes
 
 ### npm Sudo Handling (Three-Tier Fallback)
 

--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -99,7 +99,7 @@ export CLAUDE_CODE_TOOLBOX_ENV_CONFIG='https://raw.githubusercontent.com/org/rep
 | `--yes` / `-y` | Auto-confirm installation (skip interactive prompt) |
 | `--dry-run`    | Show installation plan and exit without installing  |
 
-> **Important:** CLI flags like `--yes` and `--dry-run` cannot be passed through piped invocations (`iex (irm ...)` on Windows, `curl ... | bash` on Linux/macOS). The piped execution pattern creates no parameter binding context, so flags are silently ignored. Use environment variables instead (see [Non-interactive mode](#non-interactive-mode) and [Dry-run mode](#dry-run-mode) below).
+> **Important:** CLI flags like `--yes`, `--dry-run`, `--skip-install`, and `--no-admin` cannot be passed through piped invocations (`iex (irm ...)` on Windows, `curl ... | bash` on Linux/macOS). The piped execution pattern creates no parameter binding context, so flags are silently ignored. Use environment variables instead (see [Non-interactive mode](#non-interactive-mode), [Dry-run mode](#dry-run-mode), [Skip Claude Code installation](#skip-claude-code-installation), and [Skip admin elevation (Windows)](#skip-admin-elevation-windows) below).
 
 ## Ready-Made Configurations
 
@@ -2108,17 +2108,19 @@ hooks:
 |----------------------------------|-------------------------------------------|--------------------------------------|
 | `CLAUDE_CODE_TOOLBOX_ENV_CONFIG` | Configuration source (URL, path, or name) | `python`, `./my.yaml`, `https://...` |
 
-### Debugging and Behavior
+### Workflow Control and Behavior
 
-| Variable                               | Purpose                                     | Accepted Values       |
-|----------------------------------------|---------------------------------------------|-----------------------|
-| `CLAUDE_CODE_TOOLBOX_DEBUG`            | Enable verbose debug logging                | `1`, `true`, or `yes` |
-| `CLAUDE_CODE_TOOLBOX_PARALLEL_WORKERS` | Override concurrent download workers        | Integer (default: 2)  |
-| `CLAUDE_CODE_TOOLBOX_SEQUENTIAL_MODE`  | Disable parallel downloads                  | `1`, `true`, or `yes` |
-| `CLAUDE_CODE_TOOLBOX_ALLOW_ROOT`       | Allow running as root on Linux/macOS        | Exact value `1` only  |
-| `CLAUDE_CODE_TOOLBOX_CONFIRM_INSTALL`  | Auto-confirm installation                   | Exact value `1` only  |
-| `CLAUDE_CODE_TOOLBOX_DRY_RUN`          | Preview installation plan without changes   | Exact value `1` only  |
-| `CLAUDE_CODE_TOOLBOX_GIT_BASH_PATH`    | Override Git Bash executable path (Windows) | Path to `bash.exe`    |
+| Variable                               | Purpose                                          | Accepted Values       |
+|----------------------------------------|--------------------------------------------------|-----------------------|
+| `CLAUDE_CODE_TOOLBOX_CONFIRM_INSTALL`  | Auto-confirm installation (`--yes`)              | Exact value `1` only  |
+| `CLAUDE_CODE_TOOLBOX_DRY_RUN`          | Preview installation plan (`--dry-run`)          | Exact value `1` only  |
+| `CLAUDE_CODE_TOOLBOX_SKIP_INSTALL`     | Skip Claude Code installation (`--skip-install`) | Exact value `1` only  |
+| `CLAUDE_CODE_TOOLBOX_NO_ADMIN`         | Skip Windows admin elevation (`--no-admin`)      | Exact value `1` only  |
+| `CLAUDE_CODE_TOOLBOX_ALLOW_ROOT`       | Allow running as root on Linux/macOS             | Exact value `1` only  |
+| `CLAUDE_CODE_TOOLBOX_DEBUG`            | Enable verbose debug logging                     | `1`, `true`, or `yes` |
+| `CLAUDE_CODE_TOOLBOX_PARALLEL_WORKERS` | Override concurrent download workers             | Integer (default: 2)  |
+| `CLAUDE_CODE_TOOLBOX_SEQUENTIAL_MODE`  | Disable parallel downloads                       | `1`, `true`, or `yes` |
+| `CLAUDE_CODE_TOOLBOX_GIT_BASH_PATH`    | Override Git Bash executable path (Windows)      | Path to `bash.exe`    |
 
 ### Authentication
 
@@ -2129,15 +2131,17 @@ hooks:
 | `REPO_TOKEN`                   | Shell-level (passed as `--auth`)      | Generic token, auto-detects repo type    |
 | `CLAUDE_CODE_TOOLBOX_ENV_AUTH` | Shell-level (passed as `--auth`)      | Custom header: `Header-Name:token-value` |
 
-### CLI Flags
+### CLI Flags and Environment Variable Equivalents
 
-| Flag             | Purpose                                                 |
-|------------------|---------------------------------------------------------|
-| `--yes` / `-y`   | Auto-confirm installation (skip interactive prompt)     |
-| `--dry-run`      | Show installation plan and exit without installing      |
-| `--auth`         | Authentication parameter: `"token"` or `"header:value"` |
-| `--skip-install` | Skip Claude Code installation                           |
-| `--no-admin`     | Do not request admin elevation on Windows               |
+| Flag             | Environment Variable                   | Purpose                                                 |
+|------------------|----------------------------------------|---------------------------------------------------------|
+| `--yes` / `-y`   | `CLAUDE_CODE_TOOLBOX_CONFIRM_INSTALL`  | Auto-confirm installation (skip interactive prompt)     |
+| `--dry-run`      | `CLAUDE_CODE_TOOLBOX_DRY_RUN`          | Show installation plan and exit without installing      |
+| `--skip-install` | `CLAUDE_CODE_TOOLBOX_SKIP_INSTALL`     | Skip Claude Code installation                           |
+| `--no-admin`     | `CLAUDE_CODE_TOOLBOX_NO_ADMIN`         | Do not request admin elevation on Windows               |
+| `--auth`         | `CLAUDE_CODE_TOOLBOX_ENV_AUTH`         | Authentication parameter: `"token"` or `"header:value"` |
+
+CLI flags take precedence over environment variables. For piped invocations (`curl | bash`, `iex(irm ...)`), use environment variables since CLI flags cannot be passed.
 
 ## Troubleshooting
 
@@ -2265,6 +2269,38 @@ export CLAUDE_CODE_TOOLBOX_DRY_RUN=1
 
 ```powershell
 $env:CLAUDE_CODE_TOOLBOX_DRY_RUN='1'; $env:CLAUDE_CODE_TOOLBOX_ENV_CONFIG='python'; iex (irm 'https://raw.githubusercontent.com/alex-feel/claude-code-toolbox/main/scripts/windows/setup-environment.ps1')
+```
+
+### Skip Claude Code installation
+
+To skip the Claude Code installation step (useful when Claude Code is already installed):
+
+**Environment variable (all platforms, works in piped mode):**
+
+```bash
+export CLAUDE_CODE_TOOLBOX_SKIP_INSTALL=1
+```
+
+**CLI flag (direct invocation only, not piped):**
+
+```bash
+./setup-environment.sh python --skip-install
+```
+
+### Skip admin elevation (Windows)
+
+To prevent the setup from requesting Windows admin elevation:
+
+**Environment variable (all platforms, works in piped mode):**
+
+```bash
+export CLAUDE_CODE_TOOLBOX_NO_ADMIN=1
+```
+
+**CLI flag (direct invocation only, not piped):**
+
+```bash
+./setup-environment.sh python --no-admin
 ```
 
 ## Security Considerations

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -489,6 +489,11 @@ def request_admin_elevation(script_args: list[str] | None = None) -> None:
             'GITLAB_TOKEN',
             'REPO_TOKEN',
             'CLAUDE_CODE_TOOLBOX_VERSION',
+            'CLAUDE_CODE_TOOLBOX_CONFIRM_INSTALL',
+            'CLAUDE_CODE_TOOLBOX_DRY_RUN',
+            'CLAUDE_CODE_TOOLBOX_SKIP_INSTALL',
+            'CLAUDE_CODE_TOOLBOX_NO_ADMIN',
+            'CLAUDE_CODE_TOOLBOX_ENV_AUTH',
         ]
 
         for var_name in critical_env_vars:
@@ -5253,6 +5258,11 @@ def confirm_installation(
         info('  2. Set environment variable: CLAUDE_CODE_TOOLBOX_CONFIRM_INSTALL=1')
         info('  3. Preview only: setup_environment.py <config> --dry-run')
         info('  4. Set environment variable: CLAUDE_CODE_TOOLBOX_DRY_RUN=1')
+        info('')
+        info('Additional environment variables for piped invocations:')
+        info('  CLAUDE_CODE_TOOLBOX_SKIP_INSTALL=1  Skip Claude Code installation')
+        info('  CLAUDE_CODE_TOOLBOX_NO_ADMIN=1      Do not request admin elevation')
+        info('  CLAUDE_CODE_TOOLBOX_ENV_AUTH=<val>   Authentication (header:value)')
         return False
 
     # Interactive confirmation
@@ -9668,6 +9678,32 @@ def restore_env_vars_from_args() -> tuple[list[str], bool]:
     return remaining_args, was_elevated_via_uac
 
 
+def resolve_args(args: argparse.Namespace) -> argparse.Namespace:
+    """Merge CLI flags with environment variable equivalents.
+
+    CLI flags take precedence over environment variables. For boolean
+    flags (store_true), argparse defaults to False when the flag is
+    absent, so the env var acts as a fallback for piped invocations
+    where CLI flags cannot be passed.
+
+    Called immediately after parse_args() and before any flag-dependent
+    logic (admin checks, confirmation gates, installation flow).
+
+    Args:
+        args: Parsed command-line arguments from argparse.
+
+    Returns:
+        Modified args namespace with environment variables merged.
+    """
+    args.yes = args.yes or os.environ.get('CLAUDE_CODE_TOOLBOX_CONFIRM_INSTALL') == '1'
+    args.dry_run = args.dry_run or os.environ.get('CLAUDE_CODE_TOOLBOX_DRY_RUN') == '1'
+    args.skip_install = args.skip_install or os.environ.get('CLAUDE_CODE_TOOLBOX_SKIP_INSTALL') == '1'
+    args.no_admin = args.no_admin or os.environ.get('CLAUDE_CODE_TOOLBOX_NO_ADMIN') == '1'
+    if not args.auth:
+        args.auth = os.environ.get('CLAUDE_CODE_TOOLBOX_ENV_AUTH')
+    return args
+
+
 def main() -> None:
     """Main setup flow."""
     # Track if we were elevated via UAC (new window opened) for better UX
@@ -9728,6 +9764,7 @@ def main() -> None:
         help='Show installation plan and exit without installing',
     )
     args = parser.parse_args()
+    resolve_args(args)
 
     # Get configuration from args or environment
     config_name = args.config or os.environ.get('CLAUDE_CODE_TOOLBOX_ENV_CONFIG')
@@ -10101,9 +10138,8 @@ def main() -> None:
         )
         plan.auto_injected_items = auto_injected_items
 
-        # Determine auto-confirm from --yes flag or environment variable
-        auto_confirm = args.yes or os.environ.get('CLAUDE_CODE_TOOLBOX_CONFIRM_INSTALL') == '1'
-        dry_run = args.dry_run or os.environ.get('CLAUDE_CODE_TOOLBOX_DRY_RUN') == '1'
+        auto_confirm = args.yes
+        dry_run = args.dry_run
 
         # Confirmation gate
         confirmed = confirm_installation(

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -2,6 +2,7 @@
 Comprehensive tests for setup_environment.py - the main environment setup script.
 """
 
+import argparse
 import contextlib
 import json
 import os
@@ -13586,3 +13587,164 @@ class TestSetOsEnvVariableWindowsBroadcast:
         assert called_with[1] == ['setx', 'CLAUDE_CODE_TOOLBOX_TEMP', 'temp']
         assert called_with[2][0] == 'reg'
         assert 'CLAUDE_CODE_TOOLBOX_TEMP' in called_with[2]
+
+
+class TestResolveArgs:
+    """Test resolve_args() env var merging with CLI flags."""
+
+    @staticmethod
+    def _make_args(
+        yes: bool = False,
+        dry_run: bool = False,
+        skip_install: bool = False,
+        no_admin: bool = False,
+        auth: str | None = None,
+    ) -> argparse.Namespace:
+        return argparse.Namespace(
+            yes=yes,
+            dry_run=dry_run,
+            skip_install=skip_install,
+            no_admin=no_admin,
+            auth=auth,
+        )
+
+    def test_cli_flags_unchanged_when_no_env_vars(self) -> None:
+        """CLI flags pass through without env vars."""
+        args = self._make_args(yes=True, skip_install=True)
+        result = setup_environment.resolve_args(args)
+        assert result.yes is True
+        assert result.skip_install is True
+        assert result.dry_run is False
+        assert result.no_admin is False
+        assert result.auth is None
+
+    def test_skip_install_from_env_var(self) -> None:
+        """CLAUDE_CODE_TOOLBOX_SKIP_INSTALL=1 sets args.skip_install."""
+        with patch.dict(os.environ, {'CLAUDE_CODE_TOOLBOX_SKIP_INSTALL': '1'}):
+            args = self._make_args()
+            setup_environment.resolve_args(args)
+            assert args.skip_install is True
+
+    def test_skip_install_env_var_requires_exact_one(self) -> None:
+        """Only exact '1' activates SKIP_INSTALL."""
+        for value in ['true', 'yes', 'TRUE', '0', '', 'on']:
+            with patch.dict(os.environ, {'CLAUDE_CODE_TOOLBOX_SKIP_INSTALL': value}):
+                args = self._make_args()
+                setup_environment.resolve_args(args)
+                assert args.skip_install is False, f'Value {value!r} should not activate skip_install'
+
+    def test_no_admin_from_env_var(self) -> None:
+        """CLAUDE_CODE_TOOLBOX_NO_ADMIN=1 sets args.no_admin."""
+        with patch.dict(os.environ, {'CLAUDE_CODE_TOOLBOX_NO_ADMIN': '1'}):
+            args = self._make_args()
+            setup_environment.resolve_args(args)
+            assert args.no_admin is True
+
+    def test_no_admin_env_var_requires_exact_one(self) -> None:
+        """Only exact '1' activates NO_ADMIN."""
+        for value in ['true', 'yes', 'TRUE', '0', '', 'on']:
+            with patch.dict(os.environ, {'CLAUDE_CODE_TOOLBOX_NO_ADMIN': value}):
+                args = self._make_args()
+                setup_environment.resolve_args(args)
+                assert args.no_admin is False, f'Value {value!r} should not activate no_admin'
+
+    def test_confirm_install_from_env_var(self) -> None:
+        """CLAUDE_CODE_TOOLBOX_CONFIRM_INSTALL=1 sets args.yes."""
+        with patch.dict(os.environ, {'CLAUDE_CODE_TOOLBOX_CONFIRM_INSTALL': '1'}):
+            args = self._make_args()
+            setup_environment.resolve_args(args)
+            assert args.yes is True
+
+    def test_dry_run_from_env_var(self) -> None:
+        """CLAUDE_CODE_TOOLBOX_DRY_RUN=1 sets args.dry_run."""
+        with patch.dict(os.environ, {'CLAUDE_CODE_TOOLBOX_DRY_RUN': '1'}):
+            args = self._make_args()
+            setup_environment.resolve_args(args)
+            assert args.dry_run is True
+
+    def test_auth_from_env_var_when_cli_absent(self) -> None:
+        """CLAUDE_CODE_TOOLBOX_ENV_AUTH provides fallback for args.auth."""
+        with patch.dict(os.environ, {'CLAUDE_CODE_TOOLBOX_ENV_AUTH': 'Authorization:Bearer token123'}):
+            args = self._make_args()
+            setup_environment.resolve_args(args)
+            assert args.auth == 'Authorization:Bearer token123'
+
+    def test_auth_cli_takes_precedence_over_env(self) -> None:
+        """CLI --auth wins over CLAUDE_CODE_TOOLBOX_ENV_AUTH."""
+        with patch.dict(os.environ, {'CLAUDE_CODE_TOOLBOX_ENV_AUTH': 'env-value'}):
+            args = self._make_args(auth='cli-value')
+            setup_environment.resolve_args(args)
+            assert args.auth == 'cli-value'
+
+    def test_cli_flag_takes_precedence_over_env_var(self) -> None:
+        """CLI --skip-install wins over env var (both True is fine)."""
+        with patch.dict(os.environ, {'CLAUDE_CODE_TOOLBOX_SKIP_INSTALL': '1'}):
+            args = self._make_args(skip_install=True)
+            setup_environment.resolve_args(args)
+            assert args.skip_install is True
+
+    def test_all_env_vars_simultaneously(self) -> None:
+        """All env vars activate when set to '1' at the same time."""
+        env = {
+            'CLAUDE_CODE_TOOLBOX_CONFIRM_INSTALL': '1',
+            'CLAUDE_CODE_TOOLBOX_DRY_RUN': '1',
+            'CLAUDE_CODE_TOOLBOX_SKIP_INSTALL': '1',
+            'CLAUDE_CODE_TOOLBOX_NO_ADMIN': '1',
+            'CLAUDE_CODE_TOOLBOX_ENV_AUTH': 'X-Custom:secret',
+        }
+        with patch.dict(os.environ, env):
+            args = self._make_args()
+            setup_environment.resolve_args(args)
+            assert args.yes is True
+            assert args.dry_run is True
+            assert args.skip_install is True
+            assert args.no_admin is True
+            assert args.auth == 'X-Custom:secret'
+
+    def test_returns_same_namespace(self) -> None:
+        """resolve_args returns the same namespace object it received."""
+        args = self._make_args()
+        result = setup_environment.resolve_args(args)
+        assert result is args
+
+
+class TestRequestAdminElevationEnvVars:
+    """Test that critical_env_vars in request_admin_elevation covers all workflow env vars."""
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only UAC logic')
+    def test_critical_env_vars_include_workflow_control_vars(self) -> None:
+        """Verify critical_env_vars includes all workflow-control environment variables."""
+        import ast
+        import inspect
+
+        source = inspect.getsource(setup_environment.request_admin_elevation)
+        tree = ast.parse(source)
+
+        critical_vars: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if (
+                        isinstance(target, ast.Name)
+                        and target.id == 'critical_env_vars'
+                        and isinstance(node.value, ast.List)
+                    ):
+                        critical_vars.extend(
+                            elt.value
+                            for elt in node.value.elts
+                            if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                        )
+
+        expected_vars = {
+            'CLAUDE_CODE_TOOLBOX_ENV_CONFIG',
+            'GITHUB_TOKEN',
+            'GITLAB_TOKEN',
+            'REPO_TOKEN',
+            'CLAUDE_CODE_TOOLBOX_VERSION',
+            'CLAUDE_CODE_TOOLBOX_CONFIRM_INSTALL',
+            'CLAUDE_CODE_TOOLBOX_DRY_RUN',
+            'CLAUDE_CODE_TOOLBOX_SKIP_INSTALL',
+            'CLAUDE_CODE_TOOLBOX_NO_ADMIN',
+            'CLAUDE_CODE_TOOLBOX_ENV_AUTH',
+        }
+        assert set(critical_vars) == expected_vars


### PR DESCRIPTION
All CLI flags now have environment variable equivalents merged via resolve_args(), called immediately after parse_args(). New env vars: CLAUDE_CODE_TOOLBOX_SKIP_INSTALL (--skip-install), CLAUDE_CODE_TOOLBOX_NO_ADMIN (--no-admin). CLAUDE_CODE_TOOLBOX_ENV_AUTH now also resolves at Python level as fallback for --auth. CLI flags always take precedence over environment variables. Extended critical_env_vars in request_admin_elevation() to forward all workflow-control env vars across Windows UAC elevation. Simplified redundant inline env var checks in main() confirmation gate.