### PR TITLE
Improve Windows installer fallback chain and recovery cascade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ This is the Claude Code Toolbox - a community project providing automated instal
 
 ### Native Claude Code Installation Support
 
-The installer uses a native-first approach with automatic npm fallback. Entry point: `ensure_claude()` → `install_claude_native_cross_platform()` → platform-specific `install_claude_native_{windows,macos,linux}()`. Platform-specific fallback chains: Windows uses Native installer → winget → npm; macOS/Linux use Native installer → GCS direct download → npm. In `native` mode, npm is excluded from the chain.
+The installer uses a native-first approach with automatic npm fallback. Entry point: `ensure_claude()` → `install_claude_native_cross_platform()` → platform-specific `install_claude_native_{windows,macos,linux}()`. Platform-specific fallback chains: Windows uses Native installer (with HTTP retry) → GCS direct download → npm; macOS/Linux use Native installer → GCS direct download → npm. In `native` mode, npm is excluded from the chain.
 
 ### Standalone Script Policy
 
@@ -33,17 +33,18 @@ The installer uses a native-first approach with automatic npm fallback. Entry po
 
 **Native Path Priority:** `find_command()` and `verify_claude_installation()` check the native path (`~/.local/bin/claude[.exe]`) first, before `shutil.which()` PATH search. This ensures native binary is preferred even when PATH would resolve to npm first. Validates file exists with `st_size > 1000` to skip empty/corrupt files.
 
-**Environment Variables:** `CLAUDE_CODE_TOOLBOX_INSTALL_METHOD` (`auto`/`native`/`npm`, default `auto` -- unknown sources → native-first with npm fallback), `CLAUDE_CODE_TOOLBOX_VERSION` (installs a specific Claude Code version; all methods support version pinning -- native via GCS download, winget via `--version`, and npm), `CLAUDE_CODE_TOOLBOX_ALLOW_ROOT` (`1` only -- see Root Detection Guard).
+**Environment Variables:** `CLAUDE_CODE_TOOLBOX_INSTALL_METHOD` (`auto`/`native`/`npm`, default `auto` -- unknown sources → native-first with npm fallback), `CLAUDE_CODE_TOOLBOX_VERSION` (installs a specific Claude Code version; all methods support version pinning -- native via GCS download and npm; winget is used only for specific version requests and the upgrade_source=='winget' branch), `CLAUDE_CODE_TOOLBOX_ALLOW_ROOT` (`1` only -- see Root Detection Guard).
 
 **Native Path Detection:** `verify_claude_installation()` classifies the binary location for upgrade strategy:
 
-| Path Pattern                           | Source    | Upgrade Method                    |
-|----------------------------------------|-----------|-----------------------------------|
-| Contains `npm` or `.npm-global`        | `npm`     | npm directly                      |
-| Contains `.local/bin` or `.claude/bin` | `native`  | Native installer                  |
-| Windows: `Programs\claude` (winget)    | `winget`  | winget upgrade, then npm fallback |
-| Other / `/usr/local/bin`               | `unknown` | Native-first, npm fallback        |
-| Not found                              | `none`    | Fresh install                     |
+| Path Pattern                                      | Source               | Upgrade Method                        |
+|---------------------------------------------------|----------------------|---------------------------------------|
+| Contains `npm` or `.npm-global`                   | `npm`                | npm directly                          |
+| Contains `.local/bin` or `.claude/bin`            | `native`             | Native installer                      |
+| Windows: `Programs\claude` (legacy winget/native) | `winget` or `native` | Via `_classify_localappdata_claude()` |
+| Windows: `WinGet\Links` or `WinGet\Packages`      | `winget`             | winget upgrade, then npm fallback     |
+| Other / `/usr/local/bin`                          | `unknown`            | Native-first, npm fallback            |
+| Not found                                         | `none`               | Fresh install                         |
 
 In `auto` mode, `native` and `unknown` sources attempt native first with npm fallback. Confirmed `npm` sources go directly to npm. Confirmed `winget` sources try `winget upgrade` first, falling back to npm on failure.
 

--- a/docs/installing-claude-code.md
+++ b/docs/installing-claude-code.md
@@ -28,7 +28,7 @@ The installer automatically handles all dependencies (uv, Python, Node.js if nee
 
 ### Native Installation (Default)
 
-The native method uses official Anthropic installers (`https://claude.ai/install.ps1` on Windows, `https://claude.ai/install.sh` on macOS and Linux) with platform-specific fallback chains. On Windows, if the native installer fails, the installer tries winget (`Anthropic.ClaudeCode`) before falling back to npm. On macOS and Linux, the fallback is GCS direct binary download. This is the default and recommended approach because it does not require Node.js, provides more reliable auto-updates via the official update mechanism, and supports specific version installation via direct binary download from Google Cloud Storage and winget's `--version` flag (Windows).
+The native method uses official Anthropic installers (`https://claude.ai/install.ps1` on Windows, `https://claude.ai/install.sh` on macOS and Linux) with platform-specific fallback chains. On Windows, if the native installer fails (including HTTP retry for transient 403/429/5xx errors), the installer tries GCS direct binary download before falling back to npm. On macOS and Linux, the fallback is GCS direct binary download. This is the default and recommended approach because it does not require Node.js, provides more reliable auto-updates via the official update mechanism, and supports specific version installation via direct binary download from Google Cloud Storage. On Windows, winget is used for specific version requests (CASE 2) and the winget upgrade branch.
 
 ### npm Installation (Fallback)
 
@@ -36,7 +36,7 @@ The npm method installs via the `@anthropic-ai/claude-code` npm package. It requ
 
 ### Auto Mode (Default Behavior)
 
-In `auto` mode (the default), the installer tries the full native fallback chain first: native installer, then platform-specific alternatives (winget on Windows, GCS direct download on macOS/Linux). If all native methods fail, it automatically falls back to npm. This is the recommended approach for most users and requires no additional configuration.
+In `auto` mode (the default), the installer tries the full native fallback chain first: native installer (with HTTP retry for transient errors), then GCS direct binary download on all platforms. If all native methods fail, it automatically falls back to npm. This is the recommended approach for most users and requires no additional configuration.
 
 ## Environment Variables
 
@@ -46,8 +46,8 @@ Controls which installation method the installer uses.
 
 | Value            | Behavior                                                                                            |
 |------------------|-----------------------------------------------------------------------------------------------------|
-| `auto` (default) | Try native installation first (including GCS and winget on Windows), fall back to npm if needed     |
-| `native`         | Use only native methods (native installer, GCS direct download, winget on Windows), no npm fallback |
+| `auto` (default) | Try native installation first (including GCS direct download), fall back to npm if needed           |
+| `native`         | Use only native methods (native installer, GCS direct download), no npm fallback                    |
 | `npm`            | Use only npm installer, requires Node.js 18+                                                        |
 
 Invalid values default to `auto` with a warning.
@@ -66,7 +66,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command "$env:CLAUDE_CODE_TOOLBOX
 
 ### `CLAUDE_CODE_TOOLBOX_VERSION`
 
-Specify a particular version to install (e.g., `2.0.76`). All installation methods support version pinning: native via direct binary download from Google Cloud Storage, winget via `--version` flag (Windows), and npm. Auto-update management is handled by `setup_environment.py` when used; see the [Environment Configuration Guide](environment-configuration-guide.md) for details. If the requested version is not available via one method, the installer cascades through the fallback chain (e.g., GCS → winget → native installer "latest" → npm on Windows).
+Specify a particular version to install (e.g., `2.0.76`). All installation methods support version pinning: native via direct binary download from Google Cloud Storage and npm. On Windows, winget is used for specific version requests (CASE 2) and the winget upgrade branch. Auto-update management is handled by `setup_environment.py` when used; see the [Environment Configuration Guide](environment-configuration-guide.md) for details. If the requested version is not available via one method, the installer cascades through the fallback chain (e.g., GCS → winget with --version → native installer "latest" → npm on Windows for specific version requests).
 
 **Linux/macOS example:**
 
@@ -132,14 +132,15 @@ In `auto` mode, when an npm installation is detected, the installer automaticall
 
 The installer classifies the existing installation by examining the binary path.
 
-| Path Pattern                           | Detected Source | Upgrade Method                    |
-|----------------------------------------|-----------------|-----------------------------------|
-| Contains `npm` or `.npm-global`        | npm             | npm directly                      |
-| Contains `.local/bin` or `.claude/bin` | native          | Native installer                  |
-| Contains `/usr/local/bin`              | unknown         | Native-first, npm fallback        |
-| Windows: contains `Programs\claude`    | winget          | winget upgrade, then npm fallback |
-| Any other path                         | unknown         | Native-first, npm fallback        |
-| Not found                              | none            | Fresh install                     |
+| Path Pattern                                      | Detected Source      | Upgrade Method                        |
+|---------------------------------------------------|----------------------|---------------------------------------|
+| Contains `npm` or `.npm-global`                   | npm                  | npm directly                          |
+| Contains `.local/bin` or `.claude/bin`            | native               | Native installer                      |
+| Contains `/usr/local/bin`                         | unknown              | Native-first, npm fallback            |
+| Windows: `Programs\claude` (legacy winget/native) | winget or native     | Via `_classify_localappdata_claude()` |
+| Windows: `WinGet\Links` or `WinGet\Packages`      | winget               | winget upgrade, then npm fallback     |
+| Any other path                                    | unknown              | Native-first, npm fallback            |
+| Not found                                         | none                 | Fresh install                         |
 
 ### Switching from npm to Native
 
@@ -163,7 +164,7 @@ The Claude Code auto-updater may ignore disable settings in some versions:
 
 ### Native Installation Fails
 
-The installer automatically tries platform-specific alternatives before falling back to npm in `auto` mode (winget on Windows, GCS direct download on macOS/Linux), so most users do not need to take any action. To isolate the issue, use `CLAUDE_CODE_TOOLBOX_INSTALL_METHOD=native` to see only native method output without the npm fallback. You can also try the native installer directly:
+The installer automatically tries GCS direct download before falling back to npm in `auto` mode, so most users do not need to take any action. To isolate the issue, use `CLAUDE_CODE_TOOLBOX_INSTALL_METHOD=native` to see only native method output without the npm fallback. You can also try the native installer directly:
 
 - **Windows:** `irm https://claude.ai/install.ps1 | iex`
 - **macOS/Linux:** `curl -fsSL https://claude.ai/install.sh | bash`

--- a/scripts/install_claude.py
+++ b/scripts/install_claude.py
@@ -362,12 +362,12 @@ def find_command(cmd: str, fallback_paths: list[str] | None = None) -> str | Non
 
 
 def _classify_localappdata_claude() -> str:
-    """Classify a Claude installation at %LOCALAPPDATA%\\Programs\\claude\\.
+    """Classify a Claude installation that may be from the native installer or winget.
 
     Distinguishes between native installer and winget by checking for
-    winget package metadata. The native installer and winget both use
-    the %LOCALAPPDATA%\\Programs\\claude\\ path, so binary inspection
-    alone cannot distinguish them.
+    winget package metadata in the WinGet Packages directory. Both the
+    legacy path (%LOCALAPPDATA%\\Programs\\claude) and current portable
+    installers can result in a binary that needs classification.
 
     Returns:
         'winget' if winget package metadata is found, 'native' otherwise.
@@ -425,20 +425,27 @@ def verify_claude_installation() -> tuple[bool, str | None, str]:
                         source = _classify_localappdata_claude()
                         result = (True, str(programs_path), source)
                     else:
-                        # Fallback to PATH search (with source detection)
-                        claude_path = find_command('claude')
-                        if claude_path:
-                            source = 'unknown'
-                            claude_lower = claude_path.lower()
-                            if 'npm' in claude_lower or 'roaming' in claude_lower:
-                                source = 'npm'
-                            elif '.local\\bin' in claude_lower:
-                                source = 'native'
-                            elif 'programs\\claude' in claude_lower:
-                                source = _classify_localappdata_claude()
-                            result = (True, claude_path, source)
+                        # Check winget portable installation (InstallerType: portable)
+                        winget_links = Path(os.path.expandvars(r'%LOCALAPPDATA%\Microsoft\WinGet\Links\claude.exe'))
+                        if winget_links.exists():
+                            result = (True, str(winget_links), 'winget')
                         else:
-                            result = (False, None, 'none')
+                            # Fallback to PATH search (with source detection)
+                            claude_path = find_command('claude')
+                            if claude_path:
+                                source = 'unknown'
+                                claude_lower = claude_path.lower()
+                                if 'npm' in claude_lower or 'roaming' in claude_lower:
+                                    source = 'npm'
+                                elif '.local\\bin' in claude_lower:
+                                    source = 'native'
+                                elif 'programs\\claude' in claude_lower:
+                                    source = _classify_localappdata_claude()
+                                elif 'winget\\links' in claude_lower or 'winget\\packages' in claude_lower:
+                                    source = 'winget'
+                                result = (True, claude_path, source)
+                            else:
+                                result = (False, None, 'none')
     else:
         # Non-Windows platforms: check native path explicitly first (mirrors Windows branch)
         native_path = get_real_user_home() / '.local' / 'bin' / 'claude'
@@ -650,7 +657,8 @@ def _install_claude_winget(version: str | None = None) -> bool:
         # Verify installation
         is_installed, claude_path, source = verify_claude_installation()
         if is_installed:
-            update_install_method_config('winget')
+            if source == 'winget':
+                update_install_method_config('winget')
             return True
         warning('winget installation reported success but Claude executable not found')
         return False
@@ -2647,8 +2655,11 @@ def install_claude_native_windows(version: str | None = None) -> bool:
     """Install Claude Code using native installer on Windows.
 
     Uses a hybrid approach with multiple fallback methods:
-    - If version is None or "latest": Native installer -> winget
+    - If version is None or "latest": Native installer (with HTTP retry) -> GCS direct download
     - If specific version: GCS direct download -> winget --version -> native installer "latest"
+
+    Note: ensure_claude() upgrade paths pass the resolved latest_version, routing
+    through the specific-version path for version-precise GCS download.
 
     See: https://github.com/anthropics/claude-code/issues/14942
 
@@ -2676,9 +2687,29 @@ def install_claude_native_windows(version: str | None = None) -> bool:
     if not version or version.lower() == 'latest':
         if _install_claude_native_windows_installer(version='latest'):
             return True
-        # Native installer failed -- try winget
-        info('Native installer failed, trying winget...')
-        return _install_claude_winget()
+        # Native installer failed -- try GCS direct download
+        info('Native installer failed, trying GCS direct download...')
+        latest_version = get_latest_claude_version()
+        if not latest_version:
+            warning('Could not determine latest version for GCS download')
+            return False
+        if _download_claude_direct_from_gcs(latest_version, native_target):
+            info('Updating PATH for native installation...')
+            ensure_local_bin_in_path_windows()
+            time.sleep(1)
+            is_installed, claude_path, source = verify_claude_installation()
+            if is_installed and source == 'native':
+                success(f'GCS download installation verified at: {claude_path}')
+                _finalize_native_install()
+                return True
+            if is_installed:
+                warning(f'Claude found but from {source} source at: {claude_path}')
+                if _check_npm_claude_installed():
+                    warning('npm Claude Code package detected alongside non-native installation')
+                    _warn_npm_removal_failed()
+                return True
+            warning('GCS download succeeded but verification failed')
+        return False
 
     # CASE 2: Specific version requested
     info(f'Specific version {version} requested.')
@@ -2745,17 +2776,33 @@ def _install_claude_native_windows_installer(version: str = 'latest') -> bool:
     try:
         info('Trying official native installer...')
 
-        # Download installer script (with SSL fallback)
+        # Download installer script (with retry for transient HTTP errors and SSL fallback)
         installer_script: str | None = None
         ssl_retry_needed = False
+        max_attempts = 3
+        backoff_delays = [1, 2, 4]
 
-        try:
-            with urlopen(CLAUDE_INSTALLER_URL) as response:
-                installer_script = response.read().decode('utf-8')
-        except urllib.error.URLError as e:
-            if 'SSL' in str(e) or 'certificate' in str(e).lower():
-                ssl_retry_needed = True
-            else:
+        for attempt in range(max_attempts):
+            try:
+                with urlopen(CLAUDE_INSTALLER_URL) as response:
+                    installer_script = response.read().decode('utf-8')
+                break  # Success
+            except urllib.error.HTTPError as e:
+                # Transient HTTP errors: 403 (Cloudflare challenge), 429, 5xx
+                if e.code in {403, 429, 500, 502, 503, 504} and attempt < max_attempts - 1:
+                    delay = backoff_delays[attempt]
+                    warning(
+                        f'HTTP {e.code} downloading installer '
+                        f'(attempt {attempt + 1}/{max_attempts}), retrying in {delay}s...',
+                    )
+                    time.sleep(delay)
+                    continue
+                error(f'HTTP error downloading installer: {e.code} {e.reason}')
+                return False
+            except urllib.error.URLError as e:
+                if 'SSL' in str(e) or 'certificate' in str(e).lower():
+                    ssl_retry_needed = True
+                    break
                 error(f'Network error downloading installer: {e}')
                 return False
 
@@ -3403,6 +3450,44 @@ def _recover_from_versions_directory(target_version: str) -> str | None:
     return None
 
 
+def _recovery_cascade(target_version: str) -> bool:
+    """Attempt multi-tier recovery when upgrade verification fails.
+
+    Tries recovery methods in priority order:
+    1. Promote from Anthropic versions cache directory
+    2. Direct GCS binary download to ~/.local/bin/
+
+    Both tiers produce a native binary at ~/.local/bin/, so on success
+    the installation method is recorded as 'native'.
+
+    Args:
+        target_version: The version to recover (e.g., "2.1.92").
+
+    Returns:
+        True if any recovery tier succeeded, False if all failed.
+    """
+    info('Attempting version recovery...')
+
+    # Tier 1: Promote from versions cache
+    recovered = _recover_from_versions_directory(target_version)
+    if recovered:
+        success(f'Claude Code upgraded to version {recovered} via versions cache recovery')
+        update_install_method_config('native')
+        return True
+
+    # Tier 2: Direct GCS binary download
+    binary_name = 'claude.exe' if sys.platform == 'win32' else 'claude'
+    native_target = get_real_user_home() / '.local' / 'bin' / binary_name
+    if _download_claude_direct_from_gcs(target_version, native_target):
+        gcs_version = get_claude_version()
+        if gcs_version:
+            success(f'Claude Code upgraded to version {gcs_version} via GCS recovery')
+        update_install_method_config('native')
+        return True
+
+    return False
+
+
 def ensure_claude() -> bool:
     """Ensure Claude Code is installed (native-first, npm fallback).
 
@@ -3582,25 +3667,13 @@ def ensure_claude() -> bool:
             if install_method == 'native':
                 # Native-only mode - use native installer
                 info('Upgrading via native installer (method: native)...')
-                if install_claude_native_cross_platform(version=None):
+                if install_claude_native_cross_platform(version=latest_version):
                     version_ok, actual_version = _verify_upgrade_version(latest_version, 'native installer')
                     if version_ok:
                         success(f'Claude Code upgraded to version {actual_version} via native installer')
                         return True
-                    # Recovery cascade (no npm in native-only mode)
-                    info('Attempting version recovery...')
-                    recovered = _recover_from_versions_directory(latest_version)
-                    if recovered:
-                        success(f'Claude Code upgraded to version {recovered} via versions cache recovery')
+                    if _recovery_cascade(latest_version):
                         return True
-                    binary_name = 'claude.exe' if sys.platform == 'win32' else 'claude'
-                    native_target = get_real_user_home() / '.local' / 'bin' / binary_name
-                    if _download_claude_direct_from_gcs(latest_version, native_target):
-                        gcs_version = get_claude_version()
-                        if gcs_version:
-                            success(f'Claude Code upgraded to version {gcs_version} via GCS recovery')
-                        return True
-                    # No npm fallback in native-only mode (Tier 3 skipped)
                     warning(
                         f'Upgrade verification failed: expected >= {latest_version}, '
                         f'got {actual_version}. Continuing with current version.',
@@ -3613,7 +3686,7 @@ def ensure_claude() -> bool:
             if upgrade_source == 'native':
                 info(f'Detected native installation at: {upgrade_claude_path}')
                 info(f'Upgrading to {latest_version} via native installer...')
-                if install_claude_native_cross_platform(version=None):
+                if install_claude_native_cross_platform(version=latest_version):
                     version_ok, actual_version = _verify_upgrade_version(
                         latest_version, 'native installer',
                     )
@@ -3622,23 +3695,7 @@ def ensure_claude() -> bool:
                             f'Claude Code upgraded to version {actual_version} via native installer',
                         )
                         return True
-                    # Recovery cascade (full 4-tier in auto mode)
-                    info('Attempting version recovery...')
-                    recovered = _recover_from_versions_directory(latest_version)
-                    if recovered:
-                        success(
-                            f'Claude Code upgraded to version {recovered} '
-                            f'via versions cache recovery',
-                        )
-                        return True
-                    binary_name = 'claude.exe' if sys.platform == 'win32' else 'claude'
-                    native_target = get_real_user_home() / '.local' / 'bin' / binary_name
-                    if _download_claude_direct_from_gcs(latest_version, native_target):
-                        gcs_version = get_claude_version()
-                        if gcs_version:
-                            success(
-                                f'Claude Code upgraded to version {gcs_version} via GCS recovery',
-                            )
+                    if _recovery_cascade(latest_version):
                         return True
                     if install_claude_npm(upgrade=True, version=latest_version):
                         npm_version = get_claude_version()
@@ -3669,7 +3726,7 @@ def ensure_claude() -> bool:
                 # unrecognized path. Try native upgrade first, fall back to npm.
                 info(f'Detected unknown installation source at: {upgrade_claude_path}')
                 info(f'Trying native upgrade to {latest_version} first...')
-                if install_claude_native_cross_platform(version=None):
+                if install_claude_native_cross_platform(version=latest_version):
                     version_ok, actual_version = _verify_upgrade_version(
                         latest_version, 'native installer',
                     )
@@ -3679,23 +3736,7 @@ def ensure_claude() -> bool:
                             f'via native installer',
                         )
                         return True
-                    # Recovery cascade (full 4-tier in auto mode)
-                    info('Attempting version recovery...')
-                    recovered = _recover_from_versions_directory(latest_version)
-                    if recovered:
-                        success(
-                            f'Claude Code upgraded to version {recovered} '
-                            f'via versions cache recovery',
-                        )
-                        return True
-                    binary_name = 'claude.exe' if sys.platform == 'win32' else 'claude'
-                    native_target = get_real_user_home() / '.local' / 'bin' / binary_name
-                    if _download_claude_direct_from_gcs(latest_version, native_target):
-                        gcs_version = get_claude_version()
-                        if gcs_version:
-                            success(
-                                f'Claude Code upgraded to version {gcs_version} via GCS recovery',
-                            )
+                    if _recovery_cascade(latest_version):
                         return True
                     if install_claude_npm(upgrade=True, version=latest_version):
                         npm_version = get_claude_version()
@@ -3747,23 +3788,7 @@ def ensure_claude() -> bool:
                             f'Claude Code upgraded to version {actual_version} via winget',
                         )
                         return True
-                    # Recovery cascade (full 4-tier in auto mode)
-                    info('Attempting version recovery...')
-                    recovered = _recover_from_versions_directory(latest_version)
-                    if recovered:
-                        success(
-                            f'Claude Code upgraded to version {recovered} '
-                            f'via versions cache recovery',
-                        )
-                        return True
-                    binary_name = 'claude.exe' if sys.platform == 'win32' else 'claude'
-                    native_target = get_real_user_home() / '.local' / 'bin' / binary_name
-                    if _download_claude_direct_from_gcs(latest_version, native_target):
-                        gcs_version = get_claude_version()
-                        if gcs_version:
-                            success(
-                                f'Claude Code upgraded to version {gcs_version} via GCS recovery',
-                            )
+                    if _recovery_cascade(latest_version):
                         return True
                     if install_claude_npm(upgrade=True, version=latest_version):
                         npm_version = get_claude_version()

--- a/tests/test_install_claude.py
+++ b/tests/test_install_claude.py
@@ -1727,6 +1727,147 @@ class TestGitInstallerRetryLogic:
         mock_fallback.assert_called_once()
 
 
+class TestNativeInstallerHttpRetry:
+    """Tests for HTTP retry logic in _install_claude_native_windows_installer()."""
+
+    @staticmethod
+    def _make_http_error(code, reason='Error'):
+        from email.message import Message
+        return urllib.error.HTTPError(
+            'https://claude.ai/install.ps1', code, reason, Message(), None,
+        )
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch('install_claude.time.sleep')
+    @patch('install_claude.urlopen')
+    def test_retries_on_http_403(self, mock_urlopen, mock_sleep):
+        """Retries on HTTP 403 (Cloudflare challenge) and succeeds on third attempt."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'echo "installer"'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.side_effect = [
+            self._make_http_error(403, 'Forbidden'),
+            self._make_http_error(403, 'Forbidden'),
+            mock_response,
+        ]
+        with patch('install_claude.run_command') as mock_run, \
+             patch('install_claude.ensure_local_bin_in_path_windows'), \
+             patch('install_claude.verify_claude_installation', return_value=(False, None, 'none')), \
+             patch('install_claude.get_latest_claude_version', return_value=None):
+            mock_run.return_value = MagicMock(returncode=1, stdout='', stderr='')
+            install_claude._install_claude_native_windows_installer()
+        assert mock_urlopen.call_count == 3
+        assert mock_sleep.call_args_list == [((1,),), ((2,),)]
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch('install_claude.time.sleep')
+    @patch('install_claude.urlopen')
+    def test_retries_on_http_429(self, mock_urlopen, mock_sleep):
+        """Retries on HTTP 429 and succeeds on second attempt."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'echo "installer"'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.side_effect = [
+            self._make_http_error(429, 'Too Many Requests'),
+            mock_response,
+        ]
+        with patch('install_claude.run_command') as mock_run, \
+             patch('install_claude.ensure_local_bin_in_path_windows'), \
+             patch('install_claude.verify_claude_installation', return_value=(False, None, 'none')), \
+             patch('install_claude.get_latest_claude_version', return_value=None):
+            mock_run.return_value = MagicMock(returncode=1, stdout='', stderr='')
+            install_claude._install_claude_native_windows_installer()
+        assert mock_urlopen.call_count == 2
+        mock_sleep.assert_called_once_with(1)
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch('install_claude.time.sleep')
+    @patch('install_claude.urlopen')
+    def test_retries_on_http_5xx(self, mock_urlopen, mock_sleep):
+        """Retries on HTTP 503 and succeeds on second attempt."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'echo "installer"'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.side_effect = [
+            self._make_http_error(503, 'Service Unavailable'),
+            mock_response,
+        ]
+        with patch('install_claude.run_command') as mock_run, \
+             patch('install_claude.ensure_local_bin_in_path_windows'), \
+             patch('install_claude.verify_claude_installation', return_value=(False, None, 'none')), \
+             patch('install_claude.get_latest_claude_version', return_value=None):
+            mock_run.return_value = MagicMock(returncode=1, stdout='', stderr='')
+            install_claude._install_claude_native_windows_installer()
+        assert mock_urlopen.call_count == 2
+        mock_sleep.assert_called_once_with(1)
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch('install_claude.time.sleep')
+    @patch('install_claude.urlopen')
+    def test_no_retry_on_http_404(self, mock_urlopen, mock_sleep):
+        """Non-transient HTTP 404 returns False immediately without retry."""
+        mock_urlopen.side_effect = self._make_http_error(404, 'Not Found')
+        result = install_claude._install_claude_native_windows_installer()
+        assert result is False
+        assert mock_urlopen.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch('install_claude.time.sleep')
+    @patch('install_claude.urlopen')
+    def test_returns_false_after_max_retries(self, mock_urlopen, mock_sleep):
+        """Returns False after exhausting all retry attempts."""
+        mock_urlopen.side_effect = self._make_http_error(403, 'Forbidden')
+        result = install_claude._install_claude_native_windows_installer()
+        assert result is False
+        assert mock_urlopen.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch('install_claude.time.sleep')
+    @patch('install_claude.urlopen')
+    def test_ssl_error_still_triggers_fallback(self, mock_urlopen, mock_sleep):
+        """SSL URLError triggers the SSL fallback path, not a retry or hard failure."""
+        mock_urlopen.side_effect = urllib.error.URLError('SSL: CERTIFICATE_VERIFY_FAILED')
+        with patch('install_claude.ssl') as mock_ssl:
+            mock_ctx = MagicMock()
+            mock_ssl.create_default_context.return_value = mock_ctx
+            # SSL fallback also fails to keep test simple
+            second_urlopen_error = Exception('SSL fallback failed')
+            mock_urlopen.side_effect = [
+                urllib.error.URLError('SSL: CERTIFICATE_VERIFY_FAILED'),
+                second_urlopen_error,
+            ]
+            result = install_claude._install_claude_native_windows_installer()
+        assert result is False
+        # urlopen called twice: once in retry loop (SSL error), once in SSL fallback
+        assert mock_urlopen.call_count == 2
+        # SSL errors do not trigger HTTP retry backoff
+        mock_sleep.assert_not_called()
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch('install_claude.time.sleep')
+    @patch('install_claude.urlopen')
+    def test_success_on_first_attempt_no_retry(self, mock_urlopen, mock_sleep):
+        """Successful first attempt does not trigger any retry or sleep."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'echo "installer"'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+        with patch('install_claude.run_command') as mock_run, \
+             patch('install_claude.ensure_local_bin_in_path_windows'), \
+             patch('install_claude.verify_claude_installation', return_value=(False, None, 'none')), \
+             patch('install_claude.get_latest_claude_version', return_value=None):
+            mock_run.return_value = MagicMock(returncode=1, stdout='', stderr='')
+            install_claude._install_claude_native_windows_installer()
+        assert mock_urlopen.call_count == 1
+        mock_sleep.assert_not_called()
+
+
 class TestVerifyClaudeInstallation:
     """Test verify_claude_installation() function for robust installation verification."""
 
@@ -2062,6 +2203,60 @@ class TestVerifyClaudeInstallation:
         assert is_installed is True
         assert source == 'unknown'
         assert path == '/usr/bin/claude'
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch('sys.platform', 'win32')
+    @patch('pathlib.Path.exists')
+    @patch('pathlib.Path.stat')
+    @patch('os.path.expandvars')
+    def test_verify_claude_installation_winget_links_detected(self, mock_expandvars, mock_stat, mock_exists):
+        """Test winget portable installation detected via WinGet Links path."""
+        mock_expandvars.side_effect = lambda x: x.replace(
+            '%LOCALAPPDATA%', r'C:\Users\Test\AppData\Local',
+        ).replace('%APPDATA%', r'C:\Users\Test\AppData\Roaming')
+        # Order of exists() calls: native_path, npm_cmd, npm_exe, programs_path, winget_links
+        mock_exists.side_effect = [
+            False,  # native_path.exists()
+            False,  # npm_cmd.exists()
+            False,  # npm_exe.exists()
+            False,  # programs_path.exists()
+            True,   # winget_links.exists()
+        ]
+        mock_stat.return_value.st_size = 100  # Small file (for native_path check)
+
+        is_installed, path, source = install_claude.verify_claude_installation()
+
+        assert is_installed is True
+        assert source == 'winget'
+        assert 'winget' in path.lower()
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch('sys.platform', 'win32')
+    @patch('pathlib.Path.exists', return_value=False)
+    @patch('install_claude.find_command')
+    def test_verify_claude_installation_path_fallback_winget_links(self, mock_find, mock_exists):
+        """Test PATH fallback detects winget Links path."""
+        assert mock_exists.return_value is False
+        mock_find.return_value = r'C:\Users\Test\AppData\Local\Microsoft\WinGet\Links\claude.exe'
+
+        is_installed, path, source = install_claude.verify_claude_installation()
+
+        assert is_installed is True
+        assert source == 'winget'
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch('sys.platform', 'win32')
+    @patch('pathlib.Path.exists', return_value=False)
+    @patch('install_claude.find_command')
+    def test_verify_claude_installation_path_fallback_winget_packages(self, mock_find, mock_exists):
+        """Test PATH fallback detects winget Packages path."""
+        assert mock_exists.return_value is False
+        mock_find.return_value = r'C:\Users\Test\AppData\Local\Microsoft\WinGet\Packages\Anthropic.ClaudeCode_1.2.3\claude.exe'
+
+        is_installed, path, source = install_claude.verify_claude_installation()
+
+        assert is_installed is True
+        assert source == 'winget'
 
 
 class TestWindowsFileLockHandling:
@@ -4750,21 +4945,93 @@ class TestInstallClaudeWinget:
         result = install_claude._install_claude_winget()
         assert result is False
 
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude.verify_claude_installation')
+    @patch('install_claude.run_command')
+    @patch('install_claude.check_winget', return_value=True)
+    def test_success_but_native_source_no_config_update(
+        self, mock_winget, mock_run, mock_verify, mock_config,
+    ):
+        """Winget succeeds but native binary shadows -- no installMethod update."""
+        assert mock_winget.return_value is True
+        mock_verify.return_value = (True, r'C:\Users\test\.local\bin\claude.exe', 'native')
+        mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+        result = install_claude._install_claude_winget()
+        assert result is True
+        mock_config.assert_not_called()
 
-class TestInstallClaudeNativeWindowsWingetFallback:
-    """Tests for winget fallback in install_claude_native_windows()."""
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude.verify_claude_installation')
+    @patch('install_claude.run_command')
+    @patch('install_claude.check_winget', return_value=True)
+    def test_success_unknown_source_no_config_update(
+        self, mock_winget, mock_run, mock_verify, mock_config,
+    ):
+        """Winget succeeds but unknown source found -- no installMethod update."""
+        assert mock_winget.return_value is True
+        mock_verify.return_value = (True, r'C:\some\other\path\claude.exe', 'unknown')
+        mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+        result = install_claude._install_claude_winget()
+        assert result is True
+        mock_config.assert_not_called()
+
+
+class TestInstallClaudeNativeWindowsGcsFallback:
+    """Tests for GCS fallback in install_claude_native_windows()."""
 
     @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
-    @patch('install_claude._install_claude_winget', return_value=True)
+    @patch('install_claude._finalize_native_install')
+    @patch(
+        'install_claude.verify_claude_installation',
+        return_value=(True, r'C:\Users\test\.local\bin\claude.exe', 'native'),
+    )
+    @patch('install_claude.ensure_local_bin_in_path_windows')
+    @patch('install_claude.time.sleep')
+    @patch('install_claude._download_claude_direct_from_gcs', return_value=True)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.98')
     @patch('install_claude._install_claude_native_windows_installer', return_value=False)
     @patch('install_claude._cleanup_old_claude_files')
-    def test_latest_winget_fallback(self, mock_cleanup, mock_native, mock_winget):
-        """Native installer fails for latest, winget succeeds."""
+    def test_latest_gcs_fallback_success(
+        self, mock_cleanup, mock_native, mock_get_latest,
+        mock_gcs, mock_sleep, mock_path, mock_verify, mock_finalize,
+    ):
+        """Native installer fails for latest, GCS direct download succeeds."""
         assert mock_cleanup is not None
+        assert mock_sleep is not None
         result = install_claude.install_claude_native_windows()
         assert result is True
         mock_native.assert_called_once_with(version='latest')
-        mock_winget.assert_called_once_with()
+        mock_get_latest.assert_called_once()
+        mock_gcs.assert_called_once()
+        mock_path.assert_called_once()
+        mock_verify.assert_called()
+        mock_finalize.assert_called_once()
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch('install_claude._download_claude_direct_from_gcs', return_value=False)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.98')
+    @patch('install_claude._install_claude_native_windows_installer', return_value=False)
+    @patch('install_claude._cleanup_old_claude_files')
+    def test_latest_gcs_fallback_fail(self, mock_cleanup, mock_native, mock_get_latest, mock_gcs):
+        """Native installer and GCS both fail, returns False."""
+        assert mock_cleanup is not None
+        result = install_claude.install_claude_native_windows()
+        assert result is False
+        mock_native.assert_called_once_with(version='latest')
+        mock_get_latest.assert_called_once()
+        mock_gcs.assert_called_once()
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch('install_claude.get_latest_claude_version', return_value=None)
+    @patch('install_claude._install_claude_native_windows_installer', return_value=False)
+    @patch('install_claude._cleanup_old_claude_files')
+    def test_latest_gcs_version_unavailable(self, mock_cleanup, mock_native, mock_get_latest):
+        """Native installer fails and latest version cannot be resolved."""
+        assert mock_cleanup is not None
+        result = install_claude.install_claude_native_windows()
+        assert result is False
+        mock_native.assert_called_once_with(version='latest')
+        mock_get_latest.assert_called_once()
 
     @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
     @patch('install_claude._install_claude_native_windows_installer', return_value=False)
@@ -5143,6 +5410,7 @@ class TestUpgradeVersionVerification:
     """Tests for post-upgrade version verification in ensure_claude() upgrade branches."""
 
     @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude.update_install_method_config')
     @patch('install_claude._recover_from_versions_directory', return_value='2.1.92')
     @patch('install_claude._verify_upgrade_version', return_value=(False, '2.1.89'))
     @patch('install_claude.install_claude_native_cross_platform', return_value=True)
@@ -5152,13 +5420,14 @@ class TestUpgradeVersionVerification:
     @patch('install_claude.verify_claude_installation')
     def test_native_source_mismatch_recovers_from_versions_dir(
         self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
-        mock_native, mock_verify_upgrade, mock_recover,
+        mock_native, mock_verify_upgrade, mock_recover, mock_config,
     ):
         """When native upgrade has version mismatch, Tier 1 recovery from versions dir."""
         mock_verify.return_value = (True, '/home/user/.local/bin/claude', 'native')
         result = install_claude.ensure_claude()
         assert result is True
         mock_recover.assert_called_once_with('2.1.92')
+        mock_config.assert_called_with('native')
         assert mock_get_version.return_value == '2.1.89'
         assert mock_get_latest.return_value == '2.1.92'
         assert mock_compare.return_value is False
@@ -5166,6 +5435,7 @@ class TestUpgradeVersionVerification:
         mock_verify_upgrade.assert_called()
 
     @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude.update_install_method_config')
     @patch('install_claude._download_claude_direct_from_gcs', return_value=True)
     @patch('install_claude._recover_from_versions_directory', return_value=None)
     @patch('install_claude._verify_upgrade_version', return_value=(False, '2.1.89'))
@@ -5176,7 +5446,7 @@ class TestUpgradeVersionVerification:
     @patch('install_claude.verify_claude_installation')
     def test_native_source_mismatch_gcs_fallback(
         self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
-        mock_native, mock_verify_upgrade, mock_recover, mock_gcs,
+        mock_native, mock_verify_upgrade, mock_recover, mock_gcs, mock_config,
     ):
         """When versions dir recovery fails, Tier 2 GCS download."""
         mock_get_version.return_value = '2.1.89'
@@ -5185,6 +5455,7 @@ class TestUpgradeVersionVerification:
         assert result is True
         mock_recover.assert_called_once()
         mock_gcs.assert_called_once()
+        mock_config.assert_called_with('native')
         assert mock_get_latest.return_value == '2.1.92'
         assert mock_compare.return_value is False
         mock_native.assert_called()
@@ -5269,6 +5540,7 @@ class TestUpgradeVersionVerification:
         mock_verify_upgrade.assert_called()
 
     @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude.update_install_method_config')
     @patch('install_claude._recover_from_versions_directory', return_value='2.1.92')
     @patch('install_claude._verify_upgrade_version', return_value=(False, '2.1.89'))
     @patch('install_claude.install_claude_native_cross_platform', return_value=True)
@@ -5278,13 +5550,14 @@ class TestUpgradeVersionVerification:
     @patch('install_claude.verify_claude_installation')
     def test_unknown_source_mismatch_recovers_from_versions_dir(
         self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
-        mock_native, mock_verify_upgrade, mock_recover,
+        mock_native, mock_verify_upgrade, mock_recover, mock_config,
     ):
         """Unknown source upgrade with mismatch triggers versions dir recovery."""
         mock_verify.return_value = (True, '/usr/local/bin/claude', 'unknown')
         result = install_claude.ensure_claude()
         assert result is True
         mock_recover.assert_called_once_with('2.1.92')
+        mock_config.assert_called_with('native')
         assert mock_get_version.return_value == '2.1.89'
         assert mock_get_latest.return_value == '2.1.92'
         assert mock_compare.return_value is False
@@ -5293,6 +5566,7 @@ class TestUpgradeVersionVerification:
 
     @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
     @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude.update_install_method_config')
     @patch('install_claude._recover_from_versions_directory', return_value='2.1.92')
     @patch('install_claude._verify_upgrade_version', return_value=(False, '2.1.89'))
     @patch('install_claude.run_command')
@@ -5302,7 +5576,7 @@ class TestUpgradeVersionVerification:
     @patch('install_claude.verify_claude_installation')
     def test_winget_source_mismatch_recovers_from_versions_dir(
         self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
-        mock_run, mock_verify_upgrade, mock_recover,
+        mock_run, mock_verify_upgrade, mock_recover, mock_config,
     ):
         """Winget upgrade with mismatch triggers versions dir recovery."""
         mock_verify.return_value = (
@@ -5314,6 +5588,7 @@ class TestUpgradeVersionVerification:
         result = install_claude.ensure_claude()
         assert result is True
         mock_recover.assert_called_once_with('2.1.92')
+        mock_config.assert_called_with('native')
         assert mock_get_version.return_value == '2.1.89'
         assert mock_get_latest.return_value == '2.1.92'
         assert mock_compare.return_value is False
@@ -5397,6 +5672,304 @@ class TestUpgradeVersionVerification:
         mock_verify_upgrade.assert_called()
         mock_recover.assert_called_once()
         mock_gcs.assert_called_once()
+
+
+class TestGcsRecoveryInstallMethodReset:
+    """Tests that update_install_method_config('native') is called on GCS recovery success."""
+
+    @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'native'}, clear=False)
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude._download_claude_direct_from_gcs', return_value=True)
+    @patch('install_claude._recover_from_versions_directory', return_value=None)
+    @patch('install_claude._verify_upgrade_version', return_value=(False, '2.1.89'))
+    @patch('install_claude.install_claude_native_cross_platform', return_value=True)
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.92')
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch('install_claude.verify_claude_installation')
+    def test_native_mode_gcs_recovery_sets_native(
+        self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
+        mock_native, mock_verify_upgrade, mock_recover, mock_gcs, mock_config,
+    ):
+        """install_method=='native' branch: GCS recovery sets installMethod to native."""
+        mock_verify.return_value = (True, '/home/user/.local/bin/claude', 'native')
+        result = install_claude.ensure_claude()
+        assert result is True
+        mock_gcs.assert_called_once()
+        mock_config.assert_called_with('native')
+        # Confirm mocks participated
+        assert mock_get_version.return_value == '2.1.89'
+        assert mock_get_latest.return_value == '2.1.92'
+        assert mock_compare.return_value is False
+        mock_native.assert_called()
+        mock_verify_upgrade.assert_called()
+        mock_recover.assert_called_once()
+
+    @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude._download_claude_direct_from_gcs', return_value=True)
+    @patch('install_claude._recover_from_versions_directory', return_value=None)
+    @patch('install_claude._verify_upgrade_version', return_value=(False, '2.1.89'))
+    @patch('install_claude.install_claude_native_cross_platform', return_value=True)
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.92')
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch('install_claude.verify_claude_installation')
+    def test_native_source_gcs_recovery_sets_native(
+        self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
+        mock_native, mock_verify_upgrade, mock_recover, mock_gcs, mock_config,
+    ):
+        """upgrade_source=='native' branch: GCS recovery sets installMethod to native."""
+        mock_verify.return_value = (True, '/home/user/.local/bin/claude', 'native')
+        result = install_claude.ensure_claude()
+        assert result is True
+        mock_gcs.assert_called_once()
+        mock_config.assert_called_with('native')
+        assert mock_get_version.return_value == '2.1.89'
+        assert mock_get_latest.return_value == '2.1.92'
+        assert mock_compare.return_value is False
+        mock_native.assert_called()
+        mock_verify_upgrade.assert_called()
+        mock_recover.assert_called_once()
+
+    @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude._download_claude_direct_from_gcs', return_value=True)
+    @patch('install_claude._recover_from_versions_directory', return_value=None)
+    @patch('install_claude._verify_upgrade_version', return_value=(False, '2.1.89'))
+    @patch('install_claude.install_claude_native_cross_platform', return_value=True)
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.92')
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch('install_claude.verify_claude_installation')
+    def test_unknown_source_gcs_recovery_sets_native(
+        self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
+        mock_native, mock_verify_upgrade, mock_recover, mock_gcs, mock_config,
+    ):
+        """upgrade_source=='unknown' branch: GCS recovery sets installMethod to native."""
+        mock_verify.return_value = (True, '/usr/local/bin/claude', 'unknown')
+        result = install_claude.ensure_claude()
+        assert result is True
+        mock_gcs.assert_called_once()
+        mock_config.assert_called_with('native')
+        assert mock_get_version.return_value == '2.1.89'
+        assert mock_get_latest.return_value == '2.1.92'
+        assert mock_compare.return_value is False
+        mock_native.assert_called()
+        mock_verify_upgrade.assert_called()
+        mock_recover.assert_called_once()
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch.dict('os.environ', {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'auto'}, clear=False)
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude._download_claude_direct_from_gcs', return_value=True)
+    @patch('install_claude._recover_from_versions_directory', return_value=None)
+    @patch('install_claude._verify_upgrade_version', return_value=(False, '2.1.89'))
+    @patch('install_claude.run_command')
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.92')
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch('install_claude.verify_claude_installation')
+    def test_winget_source_gcs_recovery_sets_native(
+        self, mock_verify, mock_get_version, mock_get_latest, mock_compare,
+        mock_run, mock_verify_upgrade, mock_recover, mock_gcs, mock_config,
+    ):
+        """upgrade_source=='winget' branch: GCS recovery sets installMethod to native."""
+        mock_verify.return_value = (
+            True, r'C:\Users\test\AppData\Local\Programs\claude\claude.exe', 'winget',
+        )
+        # Winget upgrade returns 0 (success) but version mismatch triggers recovery
+        mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+        result = install_claude.ensure_claude()
+        assert result is True
+        mock_gcs.assert_called_once()
+        mock_config.assert_called_with('native')
+        assert mock_get_version.return_value == '2.1.89'
+        assert mock_get_latest.return_value == '2.1.92'
+        assert mock_compare.return_value is False
+        mock_verify_upgrade.assert_called()
+        mock_recover.assert_called_once()
+
+
+class TestRecoveryCascade:
+    """Tests for _recovery_cascade() helper that consolidates versions cache + GCS recovery."""
+
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude._download_claude_direct_from_gcs')
+    @patch('install_claude._recover_from_versions_directory', return_value='2.1.92')
+    def test_versions_cache_success_returns_true(self, mock_recover, mock_gcs, mock_config):
+        """Versions cache hit returns True and skips GCS download."""
+        result = install_claude._recovery_cascade('2.1.92')
+
+        assert result is True
+        mock_recover.assert_called_once_with('2.1.92')
+        mock_gcs.assert_not_called()
+        assert mock_config.called
+
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude._download_claude_direct_from_gcs')
+    @patch('install_claude._recover_from_versions_directory', return_value='2.1.92')
+    def test_versions_cache_success_sets_native_install_method(self, mock_recover, mock_gcs, mock_config):
+        """Versions cache recovery records installMethod as 'native'."""
+        install_claude._recovery_cascade('2.1.92')
+
+        mock_config.assert_called_once_with('native')
+        assert mock_recover.return_value == '2.1.92'
+        mock_gcs.assert_not_called()
+
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude.get_claude_version', return_value='2.1.92')
+    @patch('install_claude.get_real_user_home', return_value=Path('/home/test'))
+    @patch('install_claude._download_claude_direct_from_gcs', return_value=True)
+    @patch('install_claude._recover_from_versions_directory', return_value=None)
+    def test_gcs_success_returns_true_and_sets_native(
+        self, mock_recover, mock_gcs, mock_home, mock_version, mock_config,
+    ):
+        """GCS download success returns True and records installMethod as 'native'."""
+        result = install_claude._recovery_cascade('2.1.92')
+
+        assert result is True
+        mock_recover.assert_called_once_with('2.1.92')
+        mock_gcs.assert_called_once()
+        mock_config.assert_called_once_with('native')
+        assert mock_home.return_value == Path('/home/test')
+        assert mock_version.return_value == '2.1.92'
+
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude.get_real_user_home', return_value=Path('/home/test'))
+    @patch('install_claude._download_claude_direct_from_gcs', return_value=False)
+    @patch('install_claude._recover_from_versions_directory', return_value=None)
+    def test_all_tiers_fail_returns_false(self, mock_recover, mock_gcs, mock_home, mock_config):
+        """Both tiers failing returns False without setting installMethod."""
+        result = install_claude._recovery_cascade('2.1.92')
+
+        assert result is False
+        mock_config.assert_not_called()
+        mock_recover.assert_called_once_with('2.1.92')
+        mock_gcs.assert_called_once()
+        assert mock_home.return_value == Path('/home/test')
+
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude.get_claude_version', return_value='2.1.92')
+    @patch('install_claude.get_real_user_home', return_value=Path('/home/test'))
+    @patch('install_claude._download_claude_direct_from_gcs', return_value=True)
+    @patch('install_claude._recover_from_versions_directory', return_value=None)
+    def test_gcs_success_logs_version(self, mock_recover, mock_gcs, mock_home, mock_version, mock_config):
+        """GCS recovery logs the version on success."""
+        install_claude._recovery_cascade('2.1.92')
+
+        mock_version.assert_called_once()
+        mock_recover.assert_called_once_with('2.1.92')
+        mock_gcs.assert_called_once()
+        assert mock_home.return_value == Path('/home/test')
+        assert mock_config.called
+
+    @patch('install_claude.update_install_method_config')
+    @patch('install_claude.get_claude_version', return_value=None)
+    @patch('install_claude.get_real_user_home', return_value=Path('/home/test'))
+    @patch('install_claude._download_claude_direct_from_gcs', return_value=True)
+    @patch('install_claude._recover_from_versions_directory', return_value=None)
+    def test_gcs_success_no_version_still_returns_true(
+        self, mock_recover, mock_gcs, mock_home, mock_version, mock_config,
+    ):
+        """GCS recovery returns True even when version query returns None."""
+        result = install_claude._recovery_cascade('2.1.92')
+
+        assert result is True
+        mock_config.assert_called_once_with('native')
+        mock_recover.assert_called_once_with('2.1.92')
+        mock_gcs.assert_called_once()
+        assert mock_home.return_value == Path('/home/test')
+        assert mock_version.return_value is None
+
+
+class TestEnsureClaudeVersionPassThrough:
+    """Tests verifying ensure_claude() passes latest_version to install chain at upgrade sites."""
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch.dict(os.environ, {'CLAUDE_CODE_TOOLBOX_INSTALL_METHOD': 'native'})
+    @patch('install_claude._recovery_cascade', return_value=False)
+    @patch('install_claude._verify_upgrade_version', return_value=(True, '2.1.98'))
+    @patch('install_claude.install_claude_native_cross_platform', return_value=True)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.98')
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch(
+        'install_claude.verify_claude_installation',
+        return_value=(True, r'C:\Users\test\.local\bin\claude.exe', 'native'),
+    )
+    @patch('install_claude.ensure_nodejs')
+    def test_native_mode_upgrade_passes_version(
+        self, mock_node, mock_verify, mock_get_version, mock_compare,
+        mock_get_latest, mock_cross_platform, mock_verify_upgrade, mock_cascade,
+    ):
+        """Native-only mode upgrade passes latest_version to install_claude_native_cross_platform."""
+        install_claude.ensure_claude()
+
+        mock_cross_platform.assert_called_once_with(version='2.1.98')
+        assert mock_verify.return_value == (True, r'C:\Users\test\.local\bin\claude.exe', 'native')
+        assert mock_get_version.return_value == '2.1.89'
+        assert mock_compare.return_value is False
+        assert mock_get_latest.return_value == '2.1.98'
+        mock_verify_upgrade.assert_called()
+        assert mock_cascade.return_value is False
+        assert mock_node is not None
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch('install_claude._recovery_cascade', return_value=False)
+    @patch('install_claude._verify_upgrade_version', return_value=(True, '2.1.98'))
+    @patch('install_claude.install_claude_native_cross_platform', return_value=True)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.98')
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch(
+        'install_claude.verify_claude_installation',
+        return_value=(True, r'C:\Users\test\.local\bin\claude.exe', 'native'),
+    )
+    @patch('install_claude.ensure_nodejs')
+    def test_native_source_upgrade_passes_version(
+        self, mock_node, mock_verify, mock_get_version, mock_compare,
+        mock_get_latest, mock_cross_platform, mock_verify_upgrade, mock_cascade,
+    ):
+        """Auto mode with native source passes latest_version to install_claude_native_cross_platform."""
+        install_claude.ensure_claude()
+
+        mock_cross_platform.assert_called_once_with(version='2.1.98')
+        assert mock_verify.return_value == (True, r'C:\Users\test\.local\bin\claude.exe', 'native')
+        assert mock_get_version.return_value == '2.1.89'
+        assert mock_compare.return_value is False
+        assert mock_get_latest.return_value == '2.1.98'
+        mock_verify_upgrade.assert_called()
+        assert mock_cascade.return_value is False
+        assert mock_node is not None
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows-only test')
+    @patch('install_claude._recovery_cascade', return_value=False)
+    @patch('install_claude._verify_upgrade_version', return_value=(True, '2.1.98'))
+    @patch('install_claude.install_claude_native_cross_platform', return_value=True)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.98')
+    @patch('install_claude.compare_versions', return_value=False)
+    @patch('install_claude.get_claude_version', return_value='2.1.89')
+    @patch(
+        'install_claude.verify_claude_installation',
+        return_value=(True, r'C:\some\random\path\claude.exe', 'unknown'),
+    )
+    @patch('install_claude.ensure_nodejs')
+    def test_unknown_source_upgrade_passes_version(
+        self, mock_node, mock_verify, mock_get_version, mock_compare,
+        mock_get_latest, mock_cross_platform, mock_verify_upgrade, mock_cascade,
+    ):
+        """Auto mode with unknown source passes latest_version to install_claude_native_cross_platform."""
+        install_claude.ensure_claude()
+
+        mock_cross_platform.assert_called_once_with(version='2.1.98')
+        assert mock_verify.return_value == (True, r'C:\some\random\path\claude.exe', 'unknown')
+        assert mock_get_version.return_value == '2.1.89'
+        assert mock_compare.return_value is False
+        assert mock_get_latest.return_value == '2.1.98'
+        mock_verify_upgrade.assert_called()
+        assert mock_cascade.return_value is False
+        assert mock_node is not None
 
 
 class TestDiagnosticLogging:

--- a/tests/test_install_claude_additional.py
+++ b/tests/test_install_claude_additional.py
@@ -253,14 +253,16 @@ class TestClaudeInstallationAdditional:
         mock_run.assert_called()
         mock_verify.assert_called()
 
-    @patch('install_claude._install_claude_winget', return_value=False)
+    @patch('install_claude._download_claude_direct_from_gcs', return_value=False)
+    @patch('install_claude.get_latest_claude_version', return_value='2.1.98')
     @patch('install_claude.urlopen')
-    def test_install_claude_native_download_error(self, mock_urlopen, mock_winget):
-        """Test native Claude installation with download error."""
-        assert mock_winget.return_value is False
+    def test_install_claude_native_download_error(self, mock_urlopen, mock_get_latest, mock_gcs):
+        """Test native Claude installation with download error returns False."""
         mock_urlopen.side_effect = urllib.error.URLError('Connection error')
         result = install_claude.install_claude_native_windows()
         assert result is False
+        mock_get_latest.assert_called_once()
+        mock_gcs.assert_called_once()
 
 
 class TestEnsureFunctionsAdditional:

--- a/tests/test_install_claude_additional.py
+++ b/tests/test_install_claude_additional.py
@@ -253,11 +253,13 @@ class TestClaudeInstallationAdditional:
         mock_run.assert_called()
         mock_verify.assert_called()
 
+    @patch('platform.system', return_value='Windows')
     @patch('install_claude._download_claude_direct_from_gcs', return_value=False)
     @patch('install_claude.get_latest_claude_version', return_value='2.1.98')
     @patch('install_claude.urlopen')
-    def test_install_claude_native_download_error(self, mock_urlopen, mock_get_latest, mock_gcs):
+    def test_install_claude_native_download_error(self, mock_urlopen, mock_get_latest, mock_gcs, mock_system):
         """Test native Claude installation with download error returns False."""
+        assert mock_system.return_value == 'Windows'
         mock_urlopen.side_effect = urllib.error.URLError('Connection error')
         result = install_claude.install_claude_native_windows()
         assert result is False
@@ -785,12 +787,14 @@ class TestHybridInstallApproach:
         assert call_args[0] == '2.0.76'
 
     @patch('platform.system', return_value='Windows')
+    @patch('install_claude._install_claude_winget', return_value=False)
     @patch('install_claude._download_claude_direct_from_gcs')
     @patch('install_claude._install_claude_native_windows_installer')
     def test_install_claude_native_windows_gcs_fails_fallback_to_installer(
         self,
         mock_installer,
         mock_gcs_download,
+        mock_winget,
         mock_system,
     ):
         """Test fallback to native installer when GCS download fails."""
@@ -803,6 +807,7 @@ class TestHybridInstallApproach:
 
         assert result is True
         mock_gcs_download.assert_called_once()
+        mock_winget.assert_called_once_with(version='2.0.76')
         mock_installer.assert_called_once_with(version='latest')
 
     @patch('platform.system', return_value='Linux')


### PR DESCRIPTION
Replace winget with GCS direct download in CASE 1 (latest version) fallback chain, add HTTP retry with backoff for transient errors in the native installer, and extract duplicated recovery logic into a reusable _recovery_cascade() helper.

Key changes:
- Add HTTP retry (3 attempts, backoff 1/2/4s) for 403/429/5xx errors in _install_claude_native_windows_installer
- Replace winget fallback with GCS direct download in CASE 1 of install_claude_native_windows, keeping winget for CASE 2 only
- Make installMethod update conditional on source=='winget' in _install_claude_winget to prevent incorrect classification
- Extract _recovery_cascade() helper to replace 4 inline cascades in ensure_claude(), fixing installMethod lifecycle for versions cache recovery (Tier 1 now calls update_install_method_config('native'))
- Pass resolved latest_version through upgrade paths instead of None
- Improve winget path detection with explicit WinGet\Links check and expanded PATH fallback patterns (winget\links, winget\packages)