### PR TITLE
Add cross-field validators and improve EnvironmentConfig model validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,12 @@ Global commands (e.g., `claude-python`) work across all Windows shells: shared P
 
 Pydantic schema `EnvironmentConfig` in `scripts/models/environment_config.py` defines the complete structure for environment YAML configurations. This repository is the canonical source; changes are synced to downstream repos.
 
+**Cross-field model validators** (`@model_validator(mode='after')`): `validate_command_names_and_defaults` (command-names + command-defaults co-dependency), `validate_effort_level_max` (effort-level `max` requires Opus model), `validate_version_requires_command_names` (version requires non-empty command-names), `validate_merge_keys_requires_inherit` (non-empty merge-keys requires inherit), `validate_profile_mcp_requires_command_names` (profile-scoped MCP servers require command-names), `validate_hooks_files_consistency` (hooks files/events cross-references).
+
+**Field validators**: `validate_model` accepts any non-empty string (supports Anthropic models, third-party models, and provider-prefixed identifiers). `validate_env_variables` and `validate_os_env_variables` both enforce key format `^[A-Za-z_][A-Za-z0-9_]*$` and reject null bytes in values.
+
+**MCPServerStdio fields**: `name`, `scope`, `command`, `args` (`list[str] | None`), `env`. The `args` field provides an optional argument list; when present, the runtime combines `command + args` (via `shlex.quote` in `configure_mcp_server()`) or passes them separately to the MCP config JSON (in `create_mcp_config_file()`).
+
 **KNOWN_CONFIG_KEYS parity rule:** When adding new config keys to `setup_environment.py` (extending `KNOWN_CONFIG_KEYS`), the `EnvironmentConfig` model MUST be updated simultaneously (and vice versa). `tests/scripts/models/test_known_config_keys_parity.py` enforces STRICT BIDIRECTIONAL match with ZERO exceptions. Deprecated keys must be DELETED from both, not kept with backward compatibility shims.
 
 **Tests:** `tests/scripts/models/` -- `test_environment_config.py`, `test_mcp_server_scope.py`, `test_known_config_keys_parity.py`, `test_mergeable_config_keys_parity.py`.

--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -234,7 +234,7 @@ Configuration version for update checking. Extracted from the root config before
 
 - **Type:** `str | None`
 - **Default:** `None`
-- **Validation:** Must be valid semver (`X.Y.Z` format, with optional pre-release and build metadata)
+- **Validation:** Must be valid semver (`X.Y.Z` format, with optional pre-release and build metadata). Requires `command-names` to be specified -- setting `version` without `command-names` produces a validation error because the version field controls update checking via `manifest.json` and launcher scripts, which are only created when `command-names` is present.
 - **Inheritance:** Not inherited. Extracted from the root config before inheritance resolution.
 - **Example:** `version: "1.0.0"` or `version: "2.1.0-beta.1"`
 
@@ -314,7 +314,7 @@ List of top-level keys that should be merged (extended from parent) rather than 
 - **Type:** `list[str] | None`
 - **Default:** `None`
 - **Valid values:** `dependencies`, `agents`, `slash-commands`, `rules`, `skills`, `files-to-download`, `hooks`, `mcp-servers`, `global-config`, `user-settings`, `env-variables`, `os-env-variables`
-- **Validation:** Non-eligible keys produce an error. Presence without `inherit` produces a warning.
+- **Validation:** Non-eligible keys produce an error. Non-empty `merge-keys` without `inherit` produces a validation error because `merge-keys` controls merge semantics during inheritance resolution and has no effect without a parent configuration to merge from. An empty `merge-keys` list without `inherit` is permitted (treated as a no-op).
 - **Stripped from output:** Yes (like `inherit`)
 - **Inheritance:** Not applicable. Evaluated at each inheritance level independently; not inherited or accumulated across levels.
 - **Example:**
@@ -515,12 +515,20 @@ mcp-servers:
 - **Optional fields:** `scope`, `env`, `args`
 - **Note:** On Windows, commands starting with `npx` get automatic `cmd /c` wrapping
 
+The `args` field provides an optional argument list for the command. When `args` is specified, the `command` field is treated as just the executable and `args` provides the arguments separately. This maps directly to the `args` array in the generated MCP configuration JSON, matching the Claude Code MCP server configuration format. When `args` is absent, the `command` string is parsed into command and arguments automatically.
+
 ```yaml
 mcp-servers:
+  # Without args (command string is parsed automatically)
   - name: "memory-server"
     command: "npx @modelcontextprotocol/server-memory"
     env:
       - "DEBUG=1"
+
+  # With explicit args (command + args kept separate)
+  - name: "python-server"
+    command: "python"
+    args: ["-m", "my_mcp_server"]
 ```
 
 #### Scope Options
@@ -579,10 +587,9 @@ Model alias or custom model name for Claude Code.
 
 - **Type:** `str | None`
 - **Default:** `None`
-- **Valid aliases:** `default`, `sonnet`, `opus`, `haiku`, `opus[1m]`, `sonnet[1m]`, `opusplan`
-- **Custom names:** Any model name starting with `claude-` (for example, `claude-3-5-sonnet-20241022`)
+- **Validation:** Any non-empty string. Supports Anthropic model names (for example, `claude-sonnet-4-20250514`), built-in aliases (`default`, `sonnet`, `opus`, `haiku`, `opus[1m]`, `sonnet[1m]`, `opusplan`), and third-party or provider-prefixed model identifiers (for example, `gpt-4o`, `openrouter/anthropic/claude-3.5-sonnet`). Empty or whitespace-only strings produce a validation error.
 - **Inheritance:** Standard override (child replaces parent)
-- **Example:** `model: "opus"` or `model: "claude-3-5-sonnet-20241022"`
+- **Example:** `model: "opus"` or `model: "claude-sonnet-4-20250514"` or `model: "openrouter/anthropic/claude-3.5-sonnet"`
 
 #### `always-thinking-enabled`
 
@@ -658,6 +665,7 @@ Claude-level environment variables set in the settings file. These are available
 
 - **Type:** `dict[str, str] | None`
 - **Default:** `None`
+- **Validation:** Variable names must match `^[A-Za-z_][A-Za-z0-9_]*$` (must start with a letter or underscore, followed by letters, digits, or underscores). Values cannot contain null bytes.
 - **Inheritance:** Standard override (child replaces parent) by default. When listed in `merge-keys`: shallow dictionary merge. Child keys override matching parent keys. Set a value to `null` to delete a parent key (RFC 7396 semantics).
 - **Example:**
 
@@ -1900,7 +1908,7 @@ Any rule or entry preserved on disk is the combined contribution of all writers;
 
 Profile-scoped MCP servers (`scope: profile` or `scope: [user, profile]`) CANNOT work without `command-names` because the launcher script that consumes `--mcp-config` is only created in isolated mode. In non-isolated mode, profile-scoped servers would have no launcher target and would be silently dropped at runtime -- a correctness risk.
 
-The setup script enforces this with a hard validation error (exit 1) at the validation phase, BEFORE any side effects (downloads, writes) occur:
+This constraint is enforced at two levels: the `EnvironmentConfig` Pydantic model raises a `ValueError` during YAML validation (catching the issue at parse time), and the setup script enforces a hard validation error (exit 1) at the runtime validation phase as defense-in-depth, BEFORE any side effects (downloads, writes) occur:
 
 ```text
 [ERROR] MCP server 'my-server' declares scope: profile but command-names is not specified.
@@ -2152,6 +2160,14 @@ If you see an error about no configuration, ensure you set the `CLAUDE_CODE_TOOL
 ### Configuration not found in repository
 
 If the named configuration is not found, verify the name matches a YAML file in the [claude-code-artifacts-public](https://github.com/alex-feel/claude-code-artifacts-public) repository. Browse the repository to see available configurations.
+
+### version requires command-names
+
+The `version` field controls update checking via `manifest.json` and launcher scripts, which are only created when `command-names` is present. Either add `command-names` or remove `version`.
+
+### merge-keys requires inherit
+
+The `merge-keys` directive controls merge semantics during inheritance resolution. Without `inherit`, there is no parent configuration to merge from. Either add `inherit` or remove `merge-keys`. Note: an empty `merge-keys: []` without `inherit` is permitted.
 
 ### command-defaults requires command-names
 

--- a/scripts/models/environment_config.py
+++ b/scripts/models/environment_config.py
@@ -232,6 +232,7 @@ class MCPServerStdio(BaseModel):
     name: str = Field(..., description='Server name')
     scope: str | list[str] = Field('user', description='Scope of the server (user, local, project, profile, or combined)')
     command: str = Field(..., description='Command to execute')
+    args: list[str] | None = Field(None, description='Optional argument list for the command')
     env: str | list[str] | None = Field(None, description='Optional environment variables (string or list)')
 
     @field_validator('scope')
@@ -929,12 +930,20 @@ class EnvironmentConfig(BaseModel):
     @field_validator('model')
     @classmethod
     def validate_model(cls, v: str | None) -> str | None:
-        """Validate model configuration."""
-        valid_aliases = ['default', 'sonnet', 'opus', 'haiku', 'opus[1m]', 'sonnet[1m]', 'opusplan']
-        if v and not (v in valid_aliases or v.startswith('claude-')):
-            raise ValueError(
-                f"model must be one of {valid_aliases} or a custom model name starting with 'claude-'",
-            )
+        """Validate model configuration.
+
+        Accepts any non-empty model identifier string to support
+        Anthropic models, third-party models, and provider-prefixed
+        model names (e.g., OpenRouter, AWS Bedrock).
+
+        Returns:
+            The validated model string.
+
+        Raises:
+            ValueError: If model is empty or whitespace-only.
+        """
+        if v is not None and not v.strip():
+            raise ValueError('model cannot be empty or whitespace-only')
         return v
 
     @field_validator('claude_code_version')
@@ -1067,6 +1076,41 @@ class EnvironmentConfig(BaseModel):
             )
         return v
 
+    @field_validator('env_variables')
+    @classmethod
+    def validate_env_variables(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        """Validate environment variables configuration.
+
+        Checks that variable names follow the standard pattern
+        (letters, digits, underscores; must start with letter or underscore)
+        and that values do not contain null bytes.
+
+        Args:
+            v: Dictionary of environment variable names to string values.
+
+        Returns:
+            The validated dictionary.
+
+        Raises:
+            ValueError: If variable names are invalid or values contain null bytes.
+        """
+        if v is None:
+            return v
+
+        env_var_pattern = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+        for name, value in v.items():
+            if not env_var_pattern.match(name):
+                raise ValueError(
+                    f'Invalid environment variable name: {name}. '
+                    'Must start with letter or underscore, followed by letters, digits, or underscores.',
+                )
+
+            if '\x00' in str(value):
+                raise ValueError(f'Environment variable {name} value cannot contain null bytes')
+
+        return v
+
     @field_validator('os_env_variables')
     @classmethod
     def validate_os_env_variables(cls, v: dict[str, str | None] | None) -> dict[str, str | None] | None:
@@ -1136,6 +1180,94 @@ class EnvironmentConfig(BaseModel):
                 "Use 'low', 'medium', or 'high' for non-Opus models.",
             )
 
+        return self
+
+    @model_validator(mode='after')
+    def validate_version_requires_command_names(self) -> 'EnvironmentConfig':
+        """Validate that version requires command-names to be present.
+
+        The version field controls update checking via manifest.json and
+        launcher scripts, which are only created when command-names is
+        specified. Without command-names, version has no functional effect.
+
+        Returns:
+            The validated EnvironmentConfig instance.
+
+        Raises:
+            ValueError: If version is set without command-names.
+        """
+        if self.version is not None and not self.command_names:
+            raise ValueError(
+                'version requires command-names to be specified. '
+                'The version field controls update checking via manifest.json '
+                'and launcher scripts, which are only created when command-names '
+                'is present. Either add command-names or remove version.',
+            )
+        return self
+
+    @model_validator(mode='after')
+    def validate_merge_keys_requires_inherit(self) -> 'EnvironmentConfig':
+        """Validate that merge-keys requires inherit to be present.
+
+        The merge-keys directive controls which keys use merge (extend)
+        semantics during inheritance resolution. Without inherit, there is
+        no parent configuration to merge from, making merge-keys meaningless.
+
+        An empty merge-keys list is treated as a no-op and does not require
+        inherit.
+
+        Returns:
+            The validated EnvironmentConfig instance.
+
+        Raises:
+            ValueError: If non-empty merge-keys is set without inherit.
+        """
+        if self.merge_keys and self.inherit is None:
+            raise ValueError(
+                'merge-keys requires inherit to be specified. '
+                'The merge-keys directive controls merge semantics during inheritance. '
+                'Without inherit, merge-keys has no effect. '
+                'Either add inherit or remove merge-keys.',
+            )
+        return self
+
+    @model_validator(mode='after')
+    def validate_profile_mcp_requires_command_names(self) -> 'EnvironmentConfig':
+        """Validate that profile-scoped MCP servers require command-names.
+
+        Profile-scoped MCP servers need a launcher script with --mcp-config
+        flag, which is only created when command-names is present. Without
+        command-names, profile-scoped servers would be silently dropped.
+
+        Returns:
+            The validated EnvironmentConfig instance.
+
+        Raises:
+            ValueError: If profile-scoped servers exist without command-names.
+        """
+        if self.command_names or not self.mcp_servers:
+            return self
+
+        profile_server_names: list[str] = []
+        for server in self.mcp_servers:
+            scope_raw = server.get('scope', 'user')
+            if isinstance(scope_raw, str):
+                scopes = [scope_raw]
+            elif isinstance(scope_raw, list):
+                scopes = [s for s in scope_raw if isinstance(s, str)]
+            else:
+                scopes = []
+            if 'profile' in scopes:
+                profile_server_names.append(str(server.get('name', '<unnamed>')))
+
+        if profile_server_names:
+            names_str = ', '.join(f"'{n}'" for n in profile_server_names)
+            raise ValueError(
+                f'Profile-scoped MCP server(s) {names_str} require command-names. '
+                'Profile-scoped servers need a launcher script with --mcp-config flag, '
+                'which is only created when command-names is present. '
+                'Either add command-names or change the server scope to user/local/project.',
+            )
         return self
 
     @model_validator(mode='after')

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -7880,6 +7880,11 @@ def configure_mcp_server(
         elif command:
             # Stdio transport (command)
 
+            # When args is provided separately, combine command + args into full command string
+            args_list = server.get('args')
+            if args_list and isinstance(args_list, list):
+                command = command + ' ' + ' '.join(shlex.quote(str(a)) for a in args_list)
+
             # Build the command properly
             base_cmd.append(name)  # Add name FIRST, before post-name options
             # Add all environment variables
@@ -8128,10 +8133,18 @@ def create_mcp_config_file(
         command = server.get('command')
         if command:
             server_config['type'] = 'stdio'
-            parsed = parse_mcp_command(command)
-            server_config['command'] = parsed['command']
-            if parsed['args']:
-                server_config['args'] = parsed['args']
+            args_from_yaml = server.get('args')
+            if args_from_yaml and isinstance(args_from_yaml, list):
+                # Explicit command + args format from YAML (no parsing needed)
+                expanded_cmd = expand_tildes_in_command(command).replace('\\', '/')
+                server_config['command'] = expanded_cmd
+                server_config['args'] = [str(a) for a in args_from_yaml]
+            else:
+                # Parse command string into command + args
+                parsed = parse_mcp_command(command)
+                server_config['command'] = parsed['command']
+                if parsed['args']:
+                    server_config['args'] = parsed['args']
             server_config['env'] = {}  # Format consistency with claude mcp add
 
         # Environment variables (override default empty env)

--- a/tests/scripts/models/test_environment_config.py
+++ b/tests/scripts/models/test_environment_config.py
@@ -16,6 +16,7 @@ from pydantic import ValidationError
 
 from scripts.models.environment_config import EnvironmentConfig
 from scripts.models.environment_config import InheritEntry
+from scripts.models.environment_config import MCPServerStdio
 
 
 class TestInheritEntryModel:
@@ -1348,6 +1349,8 @@ class TestVersionValidation:
         config = EnvironmentConfig.model_validate({
             'name': 'Test',
             'version': '1.0.0',
+            'command-names': ['test-cmd'],
+            'command-defaults': {'system-prompt': 'test.md'},
         })
         assert config.version == '1.0.0'
 
@@ -1356,6 +1359,8 @@ class TestVersionValidation:
         config = EnvironmentConfig.model_validate({
             'name': 'Test',
             'version': '2.1.0-beta.1',
+            'command-names': ['test-cmd'],
+            'command-defaults': {'system-prompt': 'test.md'},
         })
         assert config.version == '2.1.0-beta.1'
 
@@ -1364,6 +1369,8 @@ class TestVersionValidation:
         config = EnvironmentConfig.model_validate({
             'name': 'Test',
             'version': '1.0.0+build.123',
+            'command-names': ['test-cmd'],
+            'command-defaults': {'system-prompt': 'test.md'},
         })
         assert config.version == '1.0.0+build.123'
 
@@ -1492,6 +1499,7 @@ class TestMergeKeysField:
         """Field accepts a list of valid mergeable key names."""
         config = EnvironmentConfig.model_validate({
             'name': 'Test',
+            'inherit': 'parent.yaml',
             'merge-keys': ['agents', 'mcp-servers', 'dependencies'],
         })
         assert config.merge_keys == ['agents', 'mcp-servers', 'dependencies']
@@ -1531,6 +1539,7 @@ class TestMergeKeysField:
         ]
         config = EnvironmentConfig.model_validate({
             'name': 'Test',
+            'inherit': 'parent.yaml',
             'merge-keys': all_keys,
         })
         assert config.merge_keys == all_keys
@@ -1658,3 +1667,305 @@ class TestInheritValidation:
             'inherit': [{'config': 'x.yaml', 'merge-keys': ['agents']}],
         })
         assert len(config.inherit) == 1
+
+
+class TestModelValidation:
+    """Tests for relaxed model field validation."""
+
+    def test_claude_model_valid(self) -> None:
+        """Claude model name passes."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'model': 'claude-sonnet-4-20250514',
+        })
+        assert config.model == 'claude-sonnet-4-20250514'
+
+    def test_model_alias_valid(self) -> None:
+        """Known alias passes."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'model': 'opus',
+        })
+        assert config.model == 'opus'
+
+    def test_third_party_model_valid(self) -> None:
+        """Third-party model name passes."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'model': 'gpt-4o',
+        })
+        assert config.model == 'gpt-4o'
+
+    def test_openrouter_model_valid(self) -> None:
+        """OpenRouter-prefixed model passes."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'model': 'openrouter/anthropic/claude-3.5-sonnet',
+        })
+        assert config.model == 'openrouter/anthropic/claude-3.5-sonnet'
+
+    def test_empty_model_raises(self) -> None:
+        """Empty string model raises."""
+        with pytest.raises(ValidationError, match='empty or whitespace'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'model': '',
+            })
+
+    def test_whitespace_model_raises(self) -> None:
+        """Whitespace-only model raises."""
+        with pytest.raises(ValidationError, match='empty or whitespace'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'model': '   ',
+            })
+
+    def test_none_model_valid(self) -> None:
+        """None (omitted) model is valid."""
+        config = EnvironmentConfig.model_validate({'name': 'Test'})
+        assert config.model is None
+
+
+class TestEnvVariablesValidation:
+    """Tests for env-variables field validation."""
+
+    def test_valid_env_variables(self) -> None:
+        """Valid environment variable names pass."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'env-variables': {'MY_VAR': 'value', '_PRIVATE': 'secret', 'PATH_EXT': '/usr/bin'},
+        })
+        assert config.env_variables == {'MY_VAR': 'value', '_PRIVATE': 'secret', 'PATH_EXT': '/usr/bin'}
+
+    def test_invalid_env_variable_name_starts_with_digit(self) -> None:
+        """Variable name starting with digit raises."""
+        with pytest.raises(ValidationError, match='Invalid environment variable name'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'env-variables': {'1BAD': 'value'},
+            })
+
+    def test_invalid_env_variable_name_has_dash(self) -> None:
+        """Variable name with dash raises."""
+        with pytest.raises(ValidationError, match='Invalid environment variable name'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'env-variables': {'MY-VAR': 'value'},
+            })
+
+    def test_env_variable_value_with_null_byte_raises(self) -> None:
+        """Value containing null byte raises."""
+        with pytest.raises(ValidationError, match='null bytes'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'env-variables': {'MY_VAR': 'val\x00ue'},
+            })
+
+    def test_none_env_variables_valid(self) -> None:
+        """None (omitted) env-variables is valid."""
+        config = EnvironmentConfig.model_validate({'name': 'Test'})
+        assert config.env_variables is None
+
+    def test_empty_env_variables_valid(self) -> None:
+        """Empty dict for env-variables is valid."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'env-variables': {},
+        })
+        assert config.env_variables == {}
+
+
+class TestMCPServerStdioArgs:
+    """Tests for MCPServerStdio args field."""
+
+    def test_stdio_with_args_valid(self) -> None:
+        """MCPServerStdio with args field passes validation."""
+        server = MCPServerStdio.model_validate({
+            'name': 'test-server',
+            'command': 'python',
+            'args': ['-m', 'my_server'],
+        })
+        assert server.args == ['-m', 'my_server']
+
+    def test_stdio_without_args_valid(self) -> None:
+        """MCPServerStdio without args field passes validation."""
+        server = MCPServerStdio.model_validate({
+            'name': 'test-server',
+            'command': 'python -m my_server',
+        })
+        assert server.args is None
+
+    def test_stdio_with_empty_args_valid(self) -> None:
+        """MCPServerStdio with empty args list passes validation."""
+        server = MCPServerStdio.model_validate({
+            'name': 'test-server',
+            'command': 'python',
+            'args': [],
+        })
+        assert server.args == []
+
+    def test_mcp_server_with_args_in_environment_config(self) -> None:
+        """MCP server with args field in EnvironmentConfig context."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'mcp-servers': [
+                {'name': 'srv', 'command': 'python', 'args': ['-m', 'server']},
+            ],
+        })
+        assert len(config.mcp_servers) == 1
+
+
+class TestVersionRequiresCommandNames:
+    """Tests for version + command-names cross-field validation."""
+
+    def test_version_without_command_names_raises(self) -> None:
+        """version without command-names raises ValueError."""
+        with pytest.raises(ValidationError, match='version requires command-names'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'version': '1.0.0',
+            })
+
+    def test_version_with_empty_command_names_raises(self) -> None:
+        """version with empty command-names list raises ValueError."""
+        with pytest.raises(ValidationError, match='version requires command-names'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'version': '1.0.0',
+                'command-names': [],
+            })
+
+    def test_version_with_command_names_valid(self) -> None:
+        """version with command-names passes validation."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'version': '1.0.0',
+            'command-names': ['my-cmd'],
+            'command-defaults': {'system-prompt': 'test.md'},
+        })
+        assert config.version == '1.0.0'
+
+    def test_no_version_without_command_names_valid(self) -> None:
+        """Omitting version without command-names is valid."""
+        config = EnvironmentConfig.model_validate({'name': 'Test'})
+        assert config.version is None
+
+    def test_no_version_with_command_names_valid(self) -> None:
+        """command-names without version is valid (version is optional)."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'command-names': ['my-cmd'],
+            'command-defaults': {'system-prompt': 'test.md'},
+        })
+        assert config.version is None
+
+
+class TestMergeKeysRequiresInherit:
+    """Tests for merge-keys + inherit cross-field validation."""
+
+    def test_merge_keys_without_inherit_raises(self) -> None:
+        """merge-keys without inherit raises ValueError."""
+        with pytest.raises(ValidationError, match='merge-keys requires inherit'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'merge-keys': ['agents'],
+            })
+
+    def test_merge_keys_with_inherit_valid(self) -> None:
+        """merge-keys with inherit passes validation."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'inherit': 'parent.yaml',
+            'merge-keys': ['agents'],
+        })
+        assert config.merge_keys == ['agents']
+
+    def test_no_merge_keys_without_inherit_valid(self) -> None:
+        """Omitting both merge-keys and inherit is valid."""
+        config = EnvironmentConfig.model_validate({'name': 'Test'})
+        assert config.merge_keys is None
+        assert config.inherit is None
+
+    def test_inherit_without_merge_keys_valid(self) -> None:
+        """inherit without merge-keys is valid (all keys use replace semantics)."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'inherit': 'parent.yaml',
+        })
+        assert config.inherit == 'parent.yaml'
+        assert config.merge_keys is None
+
+    def test_empty_merge_keys_without_inherit_valid(self) -> None:
+        """Empty merge-keys list without inherit is valid (no-op)."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'merge-keys': [],
+        })
+        assert config.merge_keys == []
+
+
+class TestProfileMCPRequiresCommandNames:
+    """Tests for profile-scoped MCP servers + command-names cross-field validation."""
+
+    def test_profile_mcp_without_command_names_raises(self) -> None:
+        """Profile-scoped MCP server without command-names raises."""
+        with pytest.raises(ValidationError, match='Profile-scoped MCP server'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'mcp-servers': [
+                    {'name': 'my-server', 'scope': 'profile', 'command': 'python -m server'},
+                ],
+            })
+
+    def test_profile_in_combined_scope_without_command_names_raises(self) -> None:
+        """Combined scope containing profile without command-names raises."""
+        with pytest.raises(ValidationError, match='Profile-scoped MCP server'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'mcp-servers': [
+                    {'name': 'my-server', 'scope': ['user', 'profile'], 'command': 'python -m server'},
+                ],
+            })
+
+    def test_profile_mcp_with_command_names_valid(self) -> None:
+        """Profile-scoped MCP server with command-names passes."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'command-names': ['my-cmd'],
+            'command-defaults': {'system-prompt': 'test.md'},
+            'mcp-servers': [
+                {'name': 'my-server', 'scope': 'profile', 'command': 'python -m server'},
+            ],
+        })
+        assert len(config.mcp_servers) == 1
+
+    def test_user_scope_mcp_without_command_names_valid(self) -> None:
+        """Non-profile-scoped MCP server without command-names is valid."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'mcp-servers': [
+                {'name': 'my-server', 'scope': 'user', 'command': 'python -m server'},
+            ],
+        })
+        assert len(config.mcp_servers) == 1
+
+    def test_multiple_profile_servers_all_reported(self) -> None:
+        """All profile-scoped server names appear in error message."""
+        with pytest.raises(ValidationError, match="'srv1'.*'srv2'|'srv2'.*'srv1'"):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'mcp-servers': [
+                    {'name': 'srv1', 'scope': 'profile', 'command': 'python -m s1'},
+                    {'name': 'srv2', 'scope': 'profile', 'command': 'python -m s2'},
+                ],
+            })
+
+    def test_http_profile_mcp_without_command_names_raises(self) -> None:
+        """Profile-scoped HTTP MCP server without command-names raises."""
+        with pytest.raises(ValidationError, match='Profile-scoped MCP server'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'mcp-servers': [
+                    {'name': 'my-http', 'scope': 'profile', 'transport': 'http', 'url': 'http://localhost:3000'},
+                ],
+            })


### PR DESCRIPTION
Add six validation improvements to the EnvironmentConfig Pydantic model:
- Cross-field validator requiring version when command-names is present
- Cross-field validator requiring command-names for profile-scoped MCP servers
- Cross-field validator requiring inherit when non-empty merge-keys is set
- Field validator for env-variables key format and null byte rejection
- Relax model field validator to accept any non-empty string
- Add args field to MCPServerStdio with runtime consumption in setup script