### PR TITLE
Add xhigh effort level for Opus models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Global commands (e.g., `claude-python`) work across all Windows shells: shared P
 
 Pydantic schema `EnvironmentConfig` in `scripts/models/environment_config.py` defines the complete structure for environment YAML configurations. This repository is the canonical source; changes are synced to downstream repos.
 
-**Cross-field model validators** (`@model_validator(mode='after')`): `validate_command_names_and_defaults` (command-names + command-defaults co-dependency), `validate_effort_level_max` (effort-level `max` requires Opus model), `validate_version_requires_command_names` (version requires non-empty command-names), `validate_merge_keys_requires_inherit` (non-empty merge-keys requires inherit), `validate_profile_mcp_requires_command_names` (profile-scoped MCP servers require command-names), `validate_hooks_files_consistency` (hooks files/events cross-references).
+**Cross-field model validators** (`@model_validator(mode='after')`): `validate_command_names_and_defaults` (command-names + command-defaults co-dependency), `validate_effort_level_opus_only` (effort-level `xhigh`/`max` require an Opus model), `validate_version_requires_command_names` (version requires non-empty command-names), `validate_merge_keys_requires_inherit` (non-empty merge-keys requires inherit), `validate_profile_mcp_requires_command_names` (profile-scoped MCP servers require command-names), `validate_hooks_files_consistency` (hooks files/events cross-references).
 
 **Field validators**: `validate_model` accepts any non-empty string (supports Anthropic models, third-party models, and provider-prefixed identifiers). `validate_env_variables` and `validate_os_env_variables` both enforce key format `^[A-Za-z_][A-Za-z0-9_]*$` and reject null bytes in values.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Define your complete Claude Code environment in a single YAML file -- custom age
 - **System prompts** -- replace or append to the default Claude Code prompt
 - **Hooks** -- four hook types: command (shell scripts), HTTP (webhooks), prompt (LLM evaluation), and agent (subagent with tools)
 - **Permissions** -- fine-grained allow, deny, and ask rules for Claude Code tools and actions
-- **Model and reasoning control** -- model selection, effort levels (low, medium, high, max), thinking mode
+- **Model and reasoning control** -- model selection, effort levels (low, medium, high, xhigh, max), thinking mode
 - **User and global settings** -- direct control over `settings.json` and `~/.claude.json`
 - **Status line** -- custom status bar scripts for real-time session information
 - **Configuration inheritance** -- extend and override parent configurations with selective per-key merge

--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -604,15 +604,22 @@ Enable always-on extended thinking mode.
 
 Controls adaptive reasoning effort.
 
-- **Type:** `str | None` (one of `low`, `medium`, `high`, `max`)
+- **Type:** `str | None` (one of `low`, `medium`, `high`, `xhigh`, `max`)
 - **Default:** `None`
 - **Inheritance:** Standard override (child replaces parent)
 - **Values:**
   - `low` -- Minimal reasoning, fastest responses
   - `medium` -- Balanced reasoning and speed
   - `high` -- Thorough reasoning for complex tasks
-  - `max` -- Maximum reasoning effort. **Requires the model to be set to an Opus variant** (the model name must contain `opus`, case-insensitive)
+  - `xhigh` -- Extended reasoning for long-horizon coding and agentic work. **Requires the model to be set to an Opus variant** (the model name must contain `opus`, case-insensitive). Supported on Opus 4.7/4.8; on Opus models that do not support it, Claude Code runs it as `high`
+  - `max` -- Maximum reasoning effort. **Requires the model to be set to an Opus variant** (the model name must contain `opus`, case-insensitive). Supported on Opus 4.6 and later
 - **Example:**
+
+```yaml
+# xhigh requires Opus
+model: "opus"
+effort-level: "xhigh"
+```
 
 ```yaml
 # max requires Opus
@@ -621,9 +628,11 @@ effort-level: "max"
 ```
 
 ```yaml
-# high works with any model
+# low, medium, and high work with any model
 effort-level: "high"
 ```
+
+> **Note:** `ultracode` is **not** an `effort-level` value. It is a session-only Claude Code mode (set with `/effort ultracode` or the `ultracode` session flag) and is intentionally not accepted here, because this key writes the `effortLevel` setting, which accepts only `low`, `medium`, `high`, `xhigh`, and `max`.
 
 ### Permissions
 
@@ -2140,13 +2149,13 @@ The `merge-keys` directive controls merge semantics during inheritance resolutio
 
 Both `command-names` and `command-defaults` must be specified together. Provide both or neither.
 
-### effort-level 'max' requires model to be specified
+### effort-level 'xhigh'/'max' requires an Opus model
 
-The `max` effort level requires the `model` key to be set to an Opus variant:
+The `xhigh` and `max` effort levels require the `model` key to be set to an Opus variant (the model name must contain `opus`, case-insensitive):
 
 ```yaml
 model: "opus"
-effort-level: "max"
+effort-level: "max"   # or "xhigh"
 ```
 
 ### Invalid platform keys in dependencies

--- a/scripts/models/environment_config.py
+++ b/scripts/models/environment_config.py
@@ -773,11 +773,11 @@ class EnvironmentConfig(BaseModel):
         alias='always-thinking-enabled',
         description='Whether to enable always-on thinking mode for extended reasoning (default: False)',
     )
-    effort_level: Literal['low', 'medium', 'high', 'max'] | None = Field(
+    effort_level: Literal['low', 'medium', 'high', 'xhigh', 'max'] | None = Field(
         None,
         alias='effort-level',
         description='Effort level for adaptive reasoning. Controls how much thinking is allocated based on task complexity. '
-        'The "max" level is only available for Opus models.',
+        'The "xhigh" and "max" levels are only available for Opus models.',
     )
     install_nodejs: bool | None = Field(
         None,
@@ -1162,20 +1162,33 @@ class EnvironmentConfig(BaseModel):
         return self
 
     @model_validator(mode='after')
-    def validate_effort_level_max(self) -> 'EnvironmentConfig':
-        """Validate that effort_level 'max' is only used with Opus models."""
-        if self.effort_level != 'max':
+    def validate_effort_level_opus_only(self) -> 'EnvironmentConfig':
+        """Validate that effort_level 'xhigh' and 'max' are only used with Opus models.
+
+        Both 'xhigh' and 'max' are Opus-only effort levels ('xhigh' on Opus 4.7/4.8,
+        'max' on Opus 4.6+). The free-form model field cannot resolve which Opus
+        version an alias points to, so the gate checks for the 'opus' substring;
+        Claude Code gracefully downgrades an unsupported level to the highest
+        supported level at runtime (for example, 'xhigh' runs as 'high' on Opus 4.6).
+
+        Returns:
+            The validated EnvironmentConfig instance.
+
+        Raises:
+            ValueError: If 'xhigh'/'max' is set without a model or with a non-Opus model.
+        """
+        if self.effort_level not in ('xhigh', 'max'):
             return self
 
         if self.model is None:
             raise ValueError(
-                "effort-level 'max' requires model to be specified. "
-                "The 'max' effort level is only available for Opus models.",
+                f"effort-level '{self.effort_level}' requires model to be specified. "
+                f"The '{self.effort_level}' effort level is only available for Opus models.",
             )
 
         if 'opus' not in self.model.lower():
             raise ValueError(
-                f"effort-level 'max' is only available for Opus models, "
+                f"effort-level '{self.effort_level}' is only available for Opus models, "
                 f"but model is set to '{self.model}'. "
                 "Use 'low', 'medium', or 'high' for non-Opus models.",
             )

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -10293,7 +10293,7 @@ def main() -> None:
         # from both the isolated config.json and the shared settings.json.
         effort_level = config.get('effort-level')
         if effort_level is not None:
-            valid_effort_levels = ('low', 'medium', 'high', 'max')
+            valid_effort_levels = ('low', 'medium', 'high', 'xhigh', 'max')
             if effort_level not in valid_effort_levels:
                 warning(
                     f'Invalid effort-level value: {effort_level!r}. '

--- a/tests/scripts/models/test_environment_config.py
+++ b/tests/scripts/models/test_environment_config.py
@@ -1340,6 +1340,109 @@ class TestEffortLevel:
         })
         assert config.effort_level == 'high'
 
+    def test_effort_level_xhigh_with_opus_alias(self) -> None:
+        """effort-level 'xhigh' accepted when model is 'opus'."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'model': 'opus',
+            'effort-level': 'xhigh',
+        })
+        assert config.effort_level == 'xhigh'
+
+    def test_effort_level_xhigh_with_opus_1m_alias(self) -> None:
+        """effort-level 'xhigh' accepted when model is 'opus[1m]'."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'model': 'opus[1m]',
+            'effort-level': 'xhigh',
+        })
+        assert config.effort_level == 'xhigh'
+
+    def test_effort_level_xhigh_with_opusplan_alias(self) -> None:
+        """effort-level 'xhigh' accepted when model is 'opusplan'."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'model': 'opusplan',
+            'effort-level': 'xhigh',
+        })
+        assert config.effort_level == 'xhigh'
+
+    def test_effort_level_xhigh_with_claude_opus_4_7_model(self) -> None:
+        """effort-level 'xhigh' accepted when model is 'claude-opus-4-7'."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'model': 'claude-opus-4-7',
+            'effort-level': 'xhigh',
+        })
+        assert config.effort_level == 'xhigh'
+
+    def test_effort_level_xhigh_with_claude_opus_4_8_model(self) -> None:
+        """effort-level 'xhigh' accepted when model is 'claude-opus-4-8'."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'model': 'claude-opus-4-8',
+            'effort-level': 'xhigh',
+        })
+        assert config.effort_level == 'xhigh'
+
+    def test_effort_level_xhigh_rejected_with_sonnet_model(self) -> None:
+        """effort-level 'xhigh' rejected when model is 'sonnet'."""
+        with pytest.raises(ValidationError, match='only available for Opus models'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'model': 'sonnet',
+                'effort-level': 'xhigh',
+            })
+
+    def test_effort_level_xhigh_rejected_with_haiku_model(self) -> None:
+        """effort-level 'xhigh' rejected when model is 'haiku'."""
+        with pytest.raises(ValidationError, match='only available for Opus models'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'model': 'haiku',
+                'effort-level': 'xhigh',
+            })
+
+    def test_effort_level_xhigh_rejected_with_claude_sonnet_model(self) -> None:
+        """effort-level 'xhigh' rejected when model is 'claude-sonnet-4-6'."""
+        with pytest.raises(ValidationError, match='only available for Opus models'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'model': 'claude-sonnet-4-6',
+                'effort-level': 'xhigh',
+            })
+
+    def test_effort_level_xhigh_rejected_without_model(self) -> None:
+        """effort-level 'xhigh' rejected when model is not specified."""
+        with pytest.raises(ValidationError, match='requires model to be specified'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'effort-level': 'xhigh',
+            })
+
+    def test_effort_level_xhigh_rejected_with_default_model(self) -> None:
+        """effort-level 'xhigh' rejected when model is 'default'."""
+        with pytest.raises(ValidationError, match='only available for Opus models'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'model': 'default',
+                'effort-level': 'xhigh',
+            })
+
+    def test_effort_level_ultracode_rejected(self) -> None:
+        """effort-level 'ultracode' rejected: it is not an effortLevel value.
+
+        'ultracode' is a session-only Claude Code mode (set via /effort ultracode
+        or the 'ultracode' session flag), not a value accepted in the effortLevel
+        setting that this toolbox writes. It must never be an accepted effort-level.
+        """
+        with pytest.raises(ValidationError):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'model': 'opus',
+                'effort-level': 'ultracode',
+            })
+
 
 class TestVersionValidation:
     """Test version field validation (semantic versioning)."""

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -3571,6 +3571,23 @@ class TestCreateSettings:
             assert 'effortLevel' in settings
             assert settings['effortLevel'] == 'max'
 
+    def test_create_profile_config_effort_level_xhigh(self):
+        """Test effortLevel set to xhigh."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            claude_dir = Path(tmpdir)
+
+            result = setup_environment.create_profile_config(
+                {'effortLevel': 'xhigh'},
+                claude_dir,
+            )
+
+            assert result is True
+            settings_file = claude_dir / 'config.json'
+            settings = json.loads(settings_file.read_text())
+
+            assert 'effortLevel' in settings
+            assert settings['effortLevel'] == 'xhigh'
+
     def test_create_profile_config_effort_level_none_not_included(self):
         """Test effortLevel not included when absent from profile_config."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -5001,6 +5018,74 @@ class TestMainFunction:
         # profile_config is the first positional argument
         profile_config = call_args[0][0]
         assert 'effortLevel' not in profile_config
+
+    @patch('setup_environment.load_config_from_source')
+    @patch('setup_environment.validate_all_config_files')
+    @patch('setup_environment.install_claude')
+    @patch('setup_environment.install_dependencies')
+    @patch('setup_environment.process_resources')
+    @patch('setup_environment.process_skills')
+    @patch('setup_environment.configure_all_mcp_servers')
+    @patch('setup_environment.create_profile_config')
+    @patch('setup_environment.create_launcher_script')
+    @patch('setup_environment.register_global_command')
+    @patch('setup_environment.is_admin', return_value=True)
+    @patch('setup_environment.write_manifest')
+    @patch('setup_environment.cleanup_stale_marker')
+    @patch('pathlib.Path.mkdir')
+    def test_main_xhigh_effort_level_not_stripped(
+        self,
+        mock_mkdir: MagicMock,
+        mock_cleanup_stale_marker: MagicMock,
+        mock_write_manifest: MagicMock,
+        mock_is_admin: MagicMock,
+        mock_register: MagicMock,
+        mock_launcher: MagicMock,
+        mock_settings: MagicMock,
+        mock_mcp: MagicMock,
+        mock_skills: MagicMock,
+        mock_resources: MagicMock,
+        mock_deps: MagicMock,
+        mock_install: MagicMock,
+        mock_validate: MagicMock,
+        mock_load: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """main() keeps 'xhigh' effort-level (valid value is not stripped)."""
+        # Mocks required by @patch decorators but not directly asserted
+        del mock_mkdir, mock_is_admin, mock_skills, mock_resources, mock_deps
+        del mock_cleanup_stale_marker, mock_write_manifest
+        mock_load.return_value = (
+            {
+                'name': 'Effort Level Test',
+                'command-names': ['test-cmd'],
+                'model': 'opus',
+                'effort-level': 'xhigh',  # Valid value (Opus-only)
+            },
+            'test.yaml',
+        )
+        mock_validate.return_value = (True, [])
+        mock_install.return_value = True
+        mock_mcp.return_value = (True, [], {'global_count': 0, 'profile_count': 0, 'combined_count': 0})
+        mock_settings.return_value = True
+        mock_launcher.return_value = (Path('/tmp/launcher.sh'), Path('/tmp/launcher.sh'))
+        mock_register.return_value = True
+
+        with patch('sys.argv', ['setup_environment.py', 'test', '--yes']), patch('sys.exit') as mock_exit:
+            setup_environment.main()
+            mock_exit.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert 'Invalid effort-level value' not in captured.out
+
+        # Verify create_profile_config receives a profile_config that retains
+        # the effortLevel entry set to 'xhigh' (valid values pass through the
+        # runtime allowlist without being stripped).
+        mock_settings.assert_called_once()
+        call_args = mock_settings.call_args
+        # profile_config is the first positional argument
+        profile_config = call_args[0][0]
+        assert profile_config.get('effortLevel') == 'xhigh'
 
 
 class TestDownloadFailureTracking:


### PR DESCRIPTION
Support the xhigh adaptive-reasoning effort level in environment configurations so users can request extended reasoning for long-horizon coding and agentic work on Opus 4.7/4.8.

Expand the effort-level enumeration to (low, medium, high, xhigh, max) in the Pydantic model and the runtime allowlist so xhigh is accepted and not stripped at install time.

Broaden the cross-field validator (renamed to validate_effort_level_opus_only) to gate both xhigh and max to Opus models, since both are Opus-only and Claude Code downgrades unsupported levels at runtime.

ultracode is deliberately not accepted because it is a session-only mode, not an effortLevel value.