### PR TITLE
Export setup-time CLAUDE_CONFIG_DIR and add link-projects-dir for isolated profiles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,33 @@ repos:
 
 - repo: local
   hooks:
-    - id: ty
-      name: ty (uv)
+    - id: ty-windows
+      name: ty windows (uv)
       language: system
       entry: uv
-      args: ['run', '--frozen', '--group', 'dev', '--', 'ty', 'check']
+      args: ['run', '--frozen', '--group', 'dev', '--', 'ty', 'check', '--python-platform', 'windows']
+      pass_filenames: false
+      always_run: true
+      types_or: [python, pyi]
+
+- repo: local
+  hooks:
+    - id: ty-darwin
+      name: ty darwin (uv)
+      language: system
+      entry: uv
+      args: ['run', '--frozen', '--group', 'dev', '--', 'ty', 'check', '--python-platform', 'darwin']
+      pass_filenames: false
+      always_run: true
+      types_or: [python, pyi]
+
+- repo: local
+  hooks:
+    - id: ty-linux
+      name: ty linux (uv)
+      language: system
+      entry: uv
+      args: ['run', '--frozen', '--group', 'dev', '--', 'ty', 'check', '--python-platform', 'linux']
       pass_filenames: false
       always_run: true
       types_or: [python, pyi]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,10 @@ Scope-based routing: `command-names` presence in the final resolved config deter
 
 The launcher (`launch.sh`) passes `config.json` via `--settings` flag and sets `export CLAUDE_CONFIG_DIR` to the isolated directory.
 
+**Setup-time `CLAUDE_CONFIG_DIR` export (two orthogonal channels):** `main()` exports `os.environ['CLAUDE_CONFIG_DIR'] = str(artifact_base_dir)` (guarded by `if primary_command_name:`) immediately after the `artifact_base_dir` if/else block, before deriving artifact directories. This is process-scoped and transient -- never written to `config.json` -- so setup-time child processes (dependency installers, `npx` tooling, `claude mcp ...`, IDE-extension installer) target the isolated profile. This is distinct from the runtime launcher export above (the authoritative runtime source) and from the six per-call MCP `CLAUDE_CONFIG_DIR` injections in `configure_mcp_server()` (load-bearing on the Windows curated-`extra_env` path, which does not inherit `os.environ`; all six are KEPT).
+
+**`link-projects-dir` (optional, isolated-only):** When `config.get('link-projects-dir')` is truthy, Step 22 (end of the `if primary_command_name:` branch in `main()`) calls `link_projects_directory(artifact_base_dir)`, which links `~/.claude/{cmd}/projects/` to the base `~/.claude/projects/` (Unix `symlink_to(..., target_is_directory=True)`; Windows `_winapi.CreateJunction` primary with `mklink /J` fallback). Reparse-aware detection (`os.lstat().st_file_attributes & FILE_ATTRIBUTE_REPARSE_POINT`, NOT `Path.is_symlink()` on Windows), idempotent, non-clobbering (a real non-empty `projects/` is preserved with a warning), non-fatal (returns `False` on failure). Helpers: `_is_windows_reparse_point`, `_link_targets_base`. The `link_projects_dir` model field requires `command-names` (validator above).
+
 ### Platform-Conditional Tilde Expansion in Settings
 
 `_expand_tilde_keys_in_settings()` handles tilde (`~`) paths in settings keys defined in `TILDE_EXPANSION_KEYS` (`apiKeyHelper`, `awsCredentialExport`):
@@ -127,7 +131,7 @@ Global commands (e.g., `claude-python`) work across all Windows shells: shared P
 
 Pydantic schema `EnvironmentConfig` in `scripts/models/environment_config.py` defines the complete structure for environment YAML configurations. This repository is the canonical source; changes are synced to downstream repos.
 
-**Cross-field model validators** (`@model_validator(mode='after')`): `validate_command_names_and_defaults` (command-names + command-defaults co-dependency), `validate_effort_level_opus_only` (effort-level `xhigh`/`max` require an Opus model), `validate_version_requires_command_names` (version requires non-empty command-names), `validate_merge_keys_requires_inherit` (non-empty merge-keys requires inherit), `validate_profile_mcp_requires_command_names` (profile-scoped MCP servers require command-names), `validate_hooks_files_consistency` (hooks files/events cross-references).
+**Cross-field model validators** (`@model_validator(mode='after')`): `validate_command_names_and_defaults` (command-names + command-defaults co-dependency), `validate_effort_level_opus_only` (effort-level `xhigh`/`max` require an Opus model), `validate_version_requires_command_names` (version requires non-empty command-names), `validate_link_projects_dir_requires_command_names` (link-projects-dir requires non-empty command-names), `validate_merge_keys_requires_inherit` (non-empty merge-keys requires inherit), `validate_profile_mcp_requires_command_names` (profile-scoped MCP servers require command-names), `validate_hooks_files_consistency` (hooks files/events cross-references).
 
 **Field validators**: `validate_model` accepts any non-empty string (supports Anthropic models, third-party models, and provider-prefixed identifiers). `validate_env_variables` and `validate_os_env_variables` both enforce key format `^[A-Za-z_][A-Za-z0-9_]*$` and reject null bytes in values.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Define your complete Claude Code environment in a single YAML file -- custom age
 - **User and global settings** -- direct control over `settings.json` and `~/.claude.json`
 - **Status line** -- custom status bar scripts for real-time session information
 - **Configuration inheritance** -- extend and override parent configurations with selective per-key merge
+- **Shared projects directory** -- optionally link an isolated profile's `projects/` to the base `~/.claude/projects/` so the isolated and default Claude share session history
 - **Dependency management** -- platform-specific package installation (apt, brew, choco, and more)
 - **File downloads** -- arbitrary files downloaded to specified destinations during setup
 - **Private repository support** -- GitHub and GitLab authentication with token-based access

--- a/docs/cross-shell-launcher-architecture.md
+++ b/docs/cross-shell-launcher-architecture.md
@@ -95,6 +95,8 @@ exec claude --append-system-prompt "$PROMPT_CONTENT" --settings "$SETTINGS_WIN" 
 
 This script is saved as `~/.claude/{command_name}/launch.sh` and called by all launchers.
 
+> **Two `CLAUDE_CONFIG_DIR` channels:** The `export CLAUDE_CONFIG_DIR="$HOME/.claude/{command_name}"` line in the launcher is the **runtime** channel -- it isolates the Claude Code session (and any tools it spawns) when you run the command. It is the sole authoritative runtime source. There is a separate, orthogonal **setup-time** channel: `setup_environment.py` exports `CLAUDE_CONFIG_DIR` into its own process environment during installation so that child processes it spawns (dependency installers, `npx`-based tooling, `claude mcp ...`, the IDE-extension installer) target the isolated profile directory. The setup-time export is transient, process-scoped, and never written to disk; it governs only installation-time processes, while the launcher export governs runtime. See [Setup-Time `CLAUDE_CONFIG_DIR` Export](environment-configuration-guide.md#setup-time-claude_config_dir-export) in the Environment Configuration Guide for the full picture.
+
 ### Implementation for Each Shell
 
 #### PowerShell Wrapper (`~/.claude/claude-python/start.ps1`)

--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -143,6 +143,7 @@ Quick-reference table of all configuration keys. Each key links to its detailed 
 | [`base-url`](#base-url)                               | `str`                  | No       | `None`  | Base URL for relative resource paths                       |
 | [`claude-code-version`](#claude-code-version)         | `str`                  | No       | `None`  | Specific Claude Code version or `"latest"`                 |
 | [`install-nodejs`](#install-nodejs)                   | `bool`                 | No       | `None`  | Install Node.js LTS before dependencies                    |
+| [`link-projects-dir`](#link-projects-dir)             | `bool`                 | No*      | `None`  | Link isolated `projects/` to base `~/.claude/projects/`    |
 | [`dependencies`](#dependencies)                       | `dict`                 | No       | `{}`    | Platform-specific dependency commands                      |
 | [`agents`](#agents)                                   | `list[str]`            | No       | `[]`    | Agent markdown file paths                                  |
 | [`slash-commands`](#slash-commands)                   | `list[str]`            | No       | `[]`    | Slash command file paths                                   |
@@ -165,6 +166,8 @@ Quick-reference table of all configuration keys. Each key links to its detailed 
 | [`status-line`](#status-line)                         | `StatusLine`           | No       | `None`  | Status line script configuration                           |
 
 > `command-names` and `command-defaults` have a co-dependency: if one is specified, the other must also be specified.
+>
+> `link-projects-dir` requires `command-names`: setting `link-projects-dir: true` without `command-names` produces a validation error, because the projects link only applies to an isolated profile (created only when `command-names` is present).
 
 ### Configuration key naming
 
@@ -355,6 +358,31 @@ Install Node.js LTS before processing dependencies. Used when MCP servers or too
 - **Note:** When `true`, only checks the minimum Node.js version (>= 18.0.0), not Claude Code npm compatibility
 - **Inheritance:** Standard override (child replaces parent)
 - **Example:** `install-nodejs: true`
+
+#### `link-projects-dir`
+
+Link the isolated profile's `projects/` directory to the base `~/.claude/projects/` so that the isolated profile (for example, `aegis`) and the default Claude share the same session history. By default (`None`/`false`), the two are kept separate -- the isolated profile uses its own `~/.claude/{cmd}/projects/` and sees a different set of conversations than the default Claude.
+
+- **Type:** `bool | None`
+- **Default:** `None` (no link; isolated and default Claude keep separate `projects/` directories)
+- **Requires:** `command-names`. Setting `link-projects-dir: true` without `command-names` produces a validation error, because the link only makes sense for an isolated profile.
+- **Mechanism:** Creates the base `~/.claude/projects/` first if absent, then links `~/.claude/{cmd}/projects/` to it -- a symbolic link on Linux/macOS, a directory junction on Windows (created elevation-free via `_winapi.CreateJunction`, with `mklink /J` as a fallback).
+- **Idempotent and non-clobbering:** An existing correct link is left as-is (no-op). A real, non-empty `projects/` directory in the isolated profile is preserved and the link is skipped (with a warning) to avoid losing any session history already written there. A stale or incorrect link, or an empty real directory, is replaced.
+- **Disabling the link:** Setting `link-projects-dir: false` (or removing the key) on a later run does NOT automatically tear down an existing link. To revert to separate directories, remove the link manually: delete `~/.claude/{cmd}/projects/` (on Windows, removing the junction with `rmdir` deletes only the link, not the shared target's contents).
+- **Inheritance:** Standard override (child replaces parent)
+- **Example:**
+
+```yaml
+command-names:
+  - "aegis"
+
+command-defaults:
+  system-prompt: "prompts/aegis.md"
+  mode: "append"
+
+# Share session history with the default Claude
+link-projects-dir: true
+```
 
 #### `dependencies`
 
@@ -549,7 +577,7 @@ mcp-servers:
     url: "http://localhost:3000/api"
 ```
 
-> **Isolated environments:** When `command-names` creates an isolated environment, `scope: user` MCP servers are configured with `CLAUDE_CONFIG_DIR` pointing to the isolated directory. This ensures `claude mcp add --scope user` writes to the isolated `.claude.json` instead of the home-directory one.
+> **Isolated environments:** When `command-names` creates an isolated environment, `scope: user` MCP servers are configured with `CLAUDE_CONFIG_DIR` pointing to the isolated directory. This ensures `claude mcp add --scope user` writes to the isolated `.claude.json` instead of the home-directory one. This per-call injection is one of the two `CLAUDE_CONFIG_DIR` channels described in [Setup-Time `CLAUDE_CONFIG_DIR` Export](#setup-time-claude_config_dir-export).
 
 #### The `env` Field
 
@@ -1685,6 +1713,21 @@ The setup script determines the configuration source by checking in this order:
 2. **Local file:** Contains path separators (`/`, `\`), starts with `./` or `../`, is an absolute path, or the file exists on disk -- loaded from the local filesystem
 3. **Repository config:** Everything else -- `.yaml` is added if missing, then fetched from `https://raw.githubusercontent.com/alex-feel/claude-code-artifacts-public/main/{name}.yaml`
 
+### Setup-Time `CLAUDE_CONFIG_DIR` Export
+
+When `command-names` creates an isolated profile, the setup script exports `CLAUDE_CONFIG_DIR` into its own process environment (set to the isolated profile directory, for example `~/.claude/{cmd}`) early in `main()`, before any resources are processed. Child processes spawned during setup -- dependency installers, `npx`-based tooling, `claude mcp ...` calls, and the IDE-extension installer -- inherit this value and therefore resolve against the isolated profile directory instead of the default `~/.claude/`. For example, `npx <skill-installer>` launched during setup installs into the isolated profile rather than the home-directory Claude.
+
+This setup-time export is transient and process-scoped: it lives only for the duration of the setup process and is deliberately never written to `config.json` or any other on-disk settings file. It exists purely so setup-time child processes target the correct directory.
+
+The two `CLAUDE_CONFIG_DIR` channels are orthogonal and serve different lifetimes:
+
+| Channel                          | When it applies            | Scope                                          | Source                                                |
+|----------------------------------|----------------------------|------------------------------------------------|-------------------------------------------------------|
+| Setup-time process export        | During `setup_environment` | Child processes spawned by the setup script    | `os.environ['CLAUDE_CONFIG_DIR']` set in `main()`     |
+| Runtime launcher export          | When you run the command   | The launched Claude Code session and its tools | `export CLAUDE_CONFIG_DIR` in the generated launcher  |
+
+The runtime launcher export (documented in [Cross-Shell Launcher Architecture](cross-shell-launcher-architecture.md)) remains the sole authoritative runtime source. The setup-time export only governs processes started during installation. The per-call MCP `CLAUDE_CONFIG_DIR` injection (see the [Isolated environments](#scope-options) note under MCP Servers) is retained independently, because the Windows MCP code path builds a curated environment for child processes rather than inheriting the full `os.environ`.
+
 ### Cross-Shell Command Registration (Windows)
 
 On Windows, the setup creates global commands that work across all shells (PowerShell, CMD, Git Bash) through a set of launcher and wrapper scripts:
@@ -1721,8 +1764,9 @@ Here is a conceptual overview of what the setup script does when you run it with
 19. **Write manifest** -- Creates an installation tracking manifest. (Only if `command-names` is specified.)
 20. **Create launcher** -- Creates the launcher script for the command. (Only if `command-names` is specified.)
 21. **Register commands** -- Creates global command wrappers. (Only if `command-names` is specified.)
+22. **Link projects directory** -- Links the isolated profile's `projects/` directory to the base `~/.claude/projects/`. (Only if `command-names` is specified and `link-projects-dir: true`.)
 
-Step 17 is skipped if no hooks, hook files, or status-line file are configured. Step 18 is a no-op if the profile delta is empty (no profile-owned keys declared at YAML root level). Steps 19-21 are skipped if `command-names` is not specified.
+Step 17 is skipped if no hooks, hook files, or status-line file are configured. Step 18 is a no-op if the profile delta is empty (no profile-owned keys declared at YAML root level). Steps 19-22 are skipped if `command-names` is not specified. Step 22 additionally requires `link-projects-dir: true`.
 
 ## Profile-Level Settings Routing
 
@@ -1975,6 +2019,9 @@ base-url: "https://raw.githubusercontent.com/myorg/my-configs/main"
 # Install Node.js for MCP servers that need npx
 install-nodejs: true
 
+# Share session history between this isolated profile and the default Claude
+link-projects-dir: true
+
 # Platform-specific dependencies
 dependencies:
   common:
@@ -2148,6 +2195,10 @@ The `merge-keys` directive controls merge semantics during inheritance resolutio
 ### command-defaults requires command-names
 
 Both `command-names` and `command-defaults` must be specified together. Provide both or neither.
+
+### link-projects-dir requires command-names
+
+The `link-projects-dir` flag links an isolated profile's `projects/` directory to the base `~/.claude/projects/`, and isolated profiles exist only when `command-names` is present. Either add `command-names` or remove `link-projects-dir`.
 
 ### effort-level 'xhigh'/'max' requires an Opus model
 

--- a/scripts/models/environment_config.py
+++ b/scripts/models/environment_config.py
@@ -784,6 +784,13 @@ class EnvironmentConfig(BaseModel):
         alias='install-nodejs',
         description='Whether to install Node.js LTS before processing dependencies (default: False)',
     )
+    link_projects_dir: bool | None = Field(
+        None,
+        alias='link-projects-dir',
+        description="When true (isolated profiles only), link the isolated profile's "
+        'projects/ directory to the base ~/.claude/projects/ so the isolated and base '
+        'Claude share session history. Default False keeps them separate. Requires command-names.',
+    )
     claude_code_version: str | None = Field(
         None,
         alias='claude-code-version',
@@ -1215,6 +1222,30 @@ class EnvironmentConfig(BaseModel):
                 'The version field controls update checking via manifest.json '
                 'and launcher scripts, which are only created when command-names '
                 'is present. Either add command-names or remove version.',
+            )
+        return self
+
+    @model_validator(mode='after')
+    def validate_link_projects_dir_requires_command_names(self) -> 'EnvironmentConfig':
+        """Validate that link-projects-dir requires command-names to be present.
+
+        The base ~/.claude/projects/ is already what the non-isolated Claude uses,
+        so linking only makes sense for an isolated profile (created only when
+        command-names is specified).
+
+        Returns:
+            The validated EnvironmentConfig instance.
+
+        Raises:
+            ValueError: If link-projects-dir is truthy without command-names.
+        """
+        if self.link_projects_dir and not self.command_names:
+            raise ValueError(
+                'link-projects-dir requires command-names to be specified. '
+                'The projects/ link binds an isolated profile to the base '
+                '~/.claude/projects/, and isolated profiles exist only when '
+                'command-names is present. Either add command-names or remove '
+                'link-projects-dir.',
             )
         return self
 

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -9983,8 +9983,11 @@ def _is_windows_reparse_point(link_path: Path) -> bool:
     import stat as stat_module
 
     try:
-        attrs = os.lstat(link_path).st_file_attributes
-    except (OSError, AttributeError):
+        # Access the Windows-only st_file_attributes via getattr so type
+        # checkers do not fail on non-Windows platforms, where the attribute is
+        # absent (defaulting to 0, i.e. no reparse-point bit).
+        attrs = getattr(os.lstat(link_path), 'st_file_attributes', 0)
+    except OSError:
         return False
     return bool(attrs & stat_module.FILE_ATTRIBUTE_REPARSE_POINT)
 
@@ -10066,12 +10069,22 @@ def link_projects_directory(artifact_base_dir: Path) -> bool:
         # this purpose. dst (link_path) must not pre-exist, which the state
         # resolution above guarantees.
         if is_windows:
-            try:
-                import _winapi
+            import _winapi
 
-                _winapi.CreateJunction(str(base_projects), str(link_path))
-            except (OSError, AttributeError) as junction_error:
-                warning(f'CreateJunction failed ({junction_error}); falling back to mklink /J')
+            # Access the Windows-only CreateJunction via getattr so type
+            # checkers do not fail on non-Windows platforms. When it is present,
+            # attempt it first; if it is unavailable or raises, fall back to
+            # mklink /J.
+            create_junction = getattr(_winapi, 'CreateJunction', None)
+            junction_error: OSError | None = None
+            if create_junction is not None:
+                try:
+                    create_junction(str(base_projects), str(link_path))
+                except OSError as error:
+                    junction_error = error
+            if create_junction is None or junction_error is not None:
+                reason = junction_error if junction_error is not None else 'CreateJunction is unavailable'
+                warning(f'CreateJunction failed ({reason}); falling back to mklink /J')
                 subprocess.run(
                     ['cmd', '/c', 'mklink', '/J', str(link_path), str(base_projects)],
                     check=True,

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -107,6 +107,7 @@ KNOWN_CONFIG_KEYS: frozenset[str] = frozenset({
     'base-url',
     'claude-code-version',
     'install-nodejs',
+    'link-projects-dir',
     'dependencies',
     'description',
     'agents',
@@ -9965,6 +9966,164 @@ exec "{bash_script_path}" "$@"
         return False
 
 
+def _is_windows_reparse_point(link_path: Path) -> bool:
+    """Return True if link_path is a Windows reparse point (junction or symlink).
+
+    Windows directory junctions report ``Path.is_symlink() == False`` while
+    ``Path.is_dir() == True``, so junctions cannot be detected with
+    ``Path.is_symlink()``. The reparse-point bit in the file attributes is the
+    reliable signal for both junctions and symlinks.
+
+    Args:
+        link_path: The path to inspect.
+
+    Returns:
+        True if the path exists and carries the reparse-point attribute.
+    """
+    import stat as stat_module
+
+    try:
+        attrs = os.lstat(link_path).st_file_attributes
+    except (OSError, AttributeError):
+        return False
+    return bool(attrs & stat_module.FILE_ATTRIBUTE_REPARSE_POINT)
+
+
+def _link_targets_base(link_path: Path, base_projects: Path) -> bool:
+    """Return True if the existing link at link_path resolves to base_projects.
+
+    Args:
+        link_path: The link (symlink or junction) to inspect.
+        base_projects: The expected target directory.
+
+    Returns:
+        True if the link resolves to base_projects, False otherwise.
+    """
+    try:
+        return Path(os.readlink(link_path)).resolve() == base_projects.resolve()
+    except OSError:
+        # Some junctions are not readable via os.readlink on all configurations;
+        # fall back to resolving the path itself.
+        try:
+            return link_path.resolve() == base_projects.resolve()
+        except OSError:
+            return False
+
+
+def link_projects_directory(artifact_base_dir: Path) -> bool:
+    """Link an isolated profile's projects/ dir to the base ~/.claude/projects/.
+
+    Creates the base ~/.claude/projects/ first if absent, then creates a link at
+    artifact_base_dir/projects pointing to it: a symlink on Unix, a directory
+    junction on Windows (elevation-free). Idempotent and non-clobbering: an
+    existing correct link is a no-op; a real non-empty directory is preserved
+    (warn + skip) to protect any session history already written there.
+
+    Args:
+        artifact_base_dir: The isolated profile's base directory
+            (e.g. ~/.claude/{command_name}).
+
+    Returns:
+        True on success or benign skip; False on failure (non-fatal to setup).
+    """
+    is_windows = platform.system() == 'Windows'
+
+    try:
+        base_projects = get_real_user_home() / '.claude' / 'projects'
+        link_path = artifact_base_dir / 'projects'
+        base_projects.mkdir(parents=True, exist_ok=True)
+
+        # Resolve the current state of link_path: existing correct link (no-op),
+        # stale/incorrect link (replace), real non-empty dir (preserve), real
+        # empty dir (replace), or absent (create).
+        is_link = _is_windows_reparse_point(link_path) if is_windows else link_path.is_symlink()
+        if is_link:
+            if _link_targets_base(link_path, base_projects):
+                info(f'projects/ already linked to {base_projects} (no-op)')
+                return True
+            # Stale or incorrect link: remove only the link, never its target.
+            if is_windows:
+                os.rmdir(link_path)
+            else:
+                link_path.unlink()
+        elif link_path.exists():
+            # A real (non-link) path exists. Preserve real non-empty directories
+            # to protect any session history; replace only empty directories.
+            if link_path.is_dir() and any(link_path.iterdir()):
+                warning(
+                    f'A real projects directory already exists at {link_path}; '
+                    'preserving it and skipping the link to avoid data loss.',
+                )
+                return True
+            if link_path.is_dir():
+                link_path.rmdir()
+            else:
+                link_path.unlink()
+
+        # Create the link. On Windows, a directory junction is elevation-free;
+        # _winapi.CreateJunction is the primary mechanism, with mklink /J as a
+        # last-resort fallback. _winapi is a private CPython module retained for
+        # this purpose. dst (link_path) must not pre-exist, which the state
+        # resolution above guarantees.
+        if is_windows:
+            try:
+                import _winapi
+
+                _winapi.CreateJunction(str(base_projects), str(link_path))
+            except (OSError, AttributeError) as junction_error:
+                warning(f'CreateJunction failed ({junction_error}); falling back to mklink /J')
+                subprocess.run(
+                    ['cmd', '/c', 'mklink', '/J', str(link_path), str(base_projects)],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+        else:
+            link_path.symlink_to(base_projects, target_is_directory=True)
+
+        success(f'Linked projects directory {link_path} -> {base_projects}')
+        return True
+
+    except (OSError, subprocess.CalledProcessError) as e:
+        warning(f'Failed to link projects directory: {e}')
+        return False
+
+
+def export_setup_time_config_dir(
+    primary_command_name: str | None,
+    artifact_base_dir: Path,
+) -> str | None:
+    """Export CLAUDE_CONFIG_DIR into the process env for setup-time child processes.
+
+    Child processes spawned during setup (dependency installers, npx-based
+    tooling, ``claude mcp ...``, IDE-extension install) inherit ``os.environ``,
+    so exporting CLAUDE_CONFIG_DIR makes them resolve against the isolated
+    profile directory rather than the default ~/.claude. The export is applied
+    only for an isolated profile (``primary_command_name`` truthy); a
+    non-isolated run leaves the process env untouched.
+
+    The exported value is transient and process-scoped only. The runtime
+    launcher export remains the sole authoritative runtime source, and this
+    value is deliberately never written to config.json.
+
+    Args:
+        primary_command_name: The primary command name when an isolated profile
+            is configured, otherwise None.
+        artifact_base_dir: The directory CLAUDE_CONFIG_DIR should point to for an
+            isolated profile (the isolated profile's base directory).
+
+    Returns:
+        The exported value (``str(artifact_base_dir)``) when an isolated profile
+        triggers the export, otherwise None.
+    """
+    if not primary_command_name:
+        return None
+    config_dir_value = str(artifact_base_dir)
+    os.environ['CLAUDE_CONFIG_DIR'] = config_dir_value
+    info(f'Exported CLAUDE_CONFIG_DIR={artifact_base_dir} for setup-time child processes')
+    return config_dir_value
+
+
 def restore_env_vars_from_args() -> tuple[list[str], bool]:
     """Restore environment variables from command-line arguments.
 
@@ -10539,6 +10698,13 @@ def main() -> None:
         else:
             artifact_base_dir = claude_user_dir
 
+        # Export CLAUDE_CONFIG_DIR (isolated profiles only) so setup-time child
+        # processes resolve against the isolated profile directory rather than
+        # the default ~/.claude. Transient and process-scoped; never written to
+        # config.json (the runtime launcher export is the authoritative runtime
+        # source).
+        export_setup_time_config_dir(primary_command_name, artifact_base_dir)
+
         # Derive all artifact directories from artifact_base_dir
         agents_dir = artifact_base_dir / 'agents'
         commands_dir = artifact_base_dir / 'commands'
@@ -10838,6 +11004,13 @@ def main() -> None:
                 )
             else:
                 warning('Launcher script was not created')
+
+            # Step 22: Optionally link the isolated profile's projects/ dir to the
+            # base ~/.claude/projects/ (shares session history when enabled).
+            if config.get('link-projects-dir'):
+                print()
+                print(f'{Colors.CYAN}Step 22: Linking projects directory to base...{Colors.NC}')
+                link_projects_directory(artifact_base_dir)
         else:
             # No command-names: route all profile-owned YAML keys to the
             # shared ~/.claude/settings.json via deep-merge with RFC 7396

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -169,6 +169,7 @@ def golden_config() -> dict[str, Any]:
     - base-url: Resource URL (uses local mock_repo)
     - claude-code-version: Version specification
     - install-nodejs: Node.js installation flag
+    - link-projects-dir: Link isolated profile's projects/ dir to base ~/.claude/projects/
     - dependencies: Platform-specific dependencies
     - agents: Agent markdown files
     - slash-commands: Slash command files

--- a/tests/e2e/golden_config.yaml
+++ b/tests/e2e/golden_config.yaml
@@ -36,6 +36,10 @@ claude-code-version: "latest"
 # Node.js installation flag
 install-nodejs: false
 
+# Link the isolated profile's projects/ dir to the base ~/.claude/projects/
+# (isolated profiles only; requires command-names)
+link-projects-dir: true
+
 # Platform-specific dependencies
 dependencies:
   common:

--- a/tests/e2e/test_artifact_isolation.py
+++ b/tests/e2e/test_artifact_isolation.py
@@ -7,9 +7,12 @@ launcher scripts) remain in the standard ~/.claude/ directory.
 """
 
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+import pytest
 
 from scripts import setup_environment
 
@@ -217,3 +220,70 @@ class TestConfigDirIsolation:
         env_block = settings.get('env', {})
         # OTHER_VAR should be present
         assert env_block.get('OTHER_VAR') == 'keep_this'
+
+    def test_setup_exports_claude_config_dir_for_children(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        golden_config: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify isolated setup exports CLAUDE_CONFIG_DIR into the process env.
+
+        Child processes spawned during setup (dependency installers, npx-based
+        tooling, ``claude mcp ...``) inherit os.environ, so the setup-time export
+        of CLAUDE_CONFIG_DIR makes them resolve against the isolated profile
+        directory. The value must equal ``str(artifact_base_dir)`` -- the same
+        form the runtime launcher exports.
+
+        Drives the production ``export_setup_time_config_dir`` (the same function
+        ``main()`` invokes), so a regression in the production export value or
+        guard is caught here.
+        """
+        paths = _run_isolated_setup(e2e_isolated_home, golden_config)
+        artifact_base = paths.artifact_base_dir
+
+        # Start from a clean slate; monkeypatch auto-restores after the test.
+        monkeypatch.delenv('CLAUDE_CONFIG_DIR', raising=False)
+
+        # Drive the real production export path (isolated profile -> exported).
+        exported = setup_environment.export_setup_time_config_dir(
+            paths.primary_command_name,
+            artifact_base,
+        )
+
+        assert exported == str(artifact_base), (
+            'Isolated setup must return the exported CLAUDE_CONFIG_DIR value'
+        )
+        assert os.environ.get('CLAUDE_CONFIG_DIR') == str(artifact_base), (
+            'Isolated setup must export CLAUDE_CONFIG_DIR equal to artifact_base_dir'
+        )
+
+    def test_setup_does_not_export_claude_config_dir_without_command_names(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify non-isolated setup does NOT export CLAUDE_CONFIG_DIR.
+
+        Without command-names there is no isolated profile, so the setup-time
+        export guard (primary_command_name falsy) is skipped and the process env
+        gains no CLAUDE_CONFIG_DIR from setup.
+
+        Drives the production ``export_setup_time_config_dir`` so a regression
+        weakening the guard is caught here.
+        """
+        claude_dir = e2e_isolated_home['claude_dir']
+
+        # Clean slate; monkeypatch auto-restores after the test.
+        monkeypatch.delenv('CLAUDE_CONFIG_DIR', raising=False)
+
+        # Drive the real production export path with no isolated profile
+        # (primary_command_name is None); the guard must skip the export.
+        exported = setup_environment.export_setup_time_config_dir(None, claude_dir)
+
+        assert exported is None, (
+            'Non-isolated setup must not return an exported value'
+        )
+        assert 'CLAUDE_CONFIG_DIR' not in os.environ, (
+            'Non-isolated setup must NOT export CLAUDE_CONFIG_DIR'
+        )

--- a/tests/e2e/test_projects_link.py
+++ b/tests/e2e/test_projects_link.py
@@ -1,0 +1,234 @@
+"""E2E tests for the optional link-projects-dir feature.
+
+Verifies link_projects_directory() correctly links an isolated profile's
+projects/ directory to the base ~/.claude/projects/:
+- Unix: a symlink (target_is_directory) resolving to the base.
+- Windows: a directory junction (reparse point) -- detected via the
+  reparse-point attribute bit, NOT Path.is_symlink() (junctions report
+  is_symlink() == False while is_dir() == True).
+
+Also covers idempotency, non-clobbering of real (non-link) directories,
+empty-directory replacement, and the mklink /J fallback path.
+"""
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts import setup_environment
+from scripts.setup_environment import link_projects_directory
+
+# Windows reparse-point attribute bit. A junction or symlink carries this bit;
+# a real directory does not. 0x400 == stat.FILE_ATTRIBUTE_REPARSE_POINT.
+REPARSE_POINT_BIT = stat.FILE_ATTRIBUTE_REPARSE_POINT
+
+
+def _artifact_base(e2e_isolated_home: dict[str, Path]) -> Path:
+    """Create and return an isolated profile base dir (~/.claude/{cmd})."""
+    claude_dir = e2e_isolated_home['claude_dir']
+    artifact_base_dir = claude_dir / 'e2e-cmd'
+    artifact_base_dir.mkdir(parents=True, exist_ok=True)
+    return artifact_base_dir
+
+
+class TestLinkProjectsDirectory:
+    """Test link_projects_directory() across platforms and edge cases."""
+
+    @pytest.mark.skipif(sys.platform == 'win32', reason='Unix symlink behavior')
+    def test_unix_creates_symlink(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """On Unix, the link is a symlink resolving to the base projects dir."""
+        home = e2e_isolated_home['home']
+        artifact_base_dir = _artifact_base(e2e_isolated_home)
+        base_projects = home / '.claude' / 'projects'
+        link_path = artifact_base_dir / 'projects'
+
+        result = link_projects_directory(artifact_base_dir)
+
+        assert result is True
+        assert base_projects.is_dir(), 'Base projects dir must be created'
+        assert link_path.is_symlink(), 'Link must be a symlink on Unix'
+        assert link_path.resolve() == base_projects.resolve(), (
+            'Symlink must resolve to the base projects dir'
+        )
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows junction behavior')
+    def test_windows_creates_junction(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """On Windows, the link is a junction (reparse point), not a symlink."""
+        home = e2e_isolated_home['home']
+        artifact_base_dir = _artifact_base(e2e_isolated_home)
+        base_projects = home / '.claude' / 'projects'
+        link_path = artifact_base_dir / 'projects'
+
+        result = link_projects_directory(artifact_base_dir)
+
+        assert result is True
+        assert base_projects.is_dir(), 'Base projects dir must be created'
+        # Junction is a directory at the link path.
+        assert link_path.is_dir(), 'Junction must present as a directory'
+        # Regression guard: a junction reports is_symlink() == False.
+        assert link_path.is_symlink() is False, (
+            'Windows junction must NOT report is_symlink() == True'
+        )
+        # The reparse-point bit must be set on a junction.
+        attrs = os.lstat(link_path).st_file_attributes
+        assert attrs & REPARSE_POINT_BIT, (
+            'Junction must carry the reparse-point attribute bit (0x400)'
+        )
+        # The junction must resolve to the base projects dir.
+        assert link_path.resolve() == base_projects.resolve(), (
+            'Junction must resolve to the base projects dir'
+        )
+
+    def test_idempotent_second_call_is_noop(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """Calling the helper twice is a no-op the second time and stays correct."""
+        home = e2e_isolated_home['home']
+        artifact_base_dir = _artifact_base(e2e_isolated_home)
+        base_projects = home / '.claude' / 'projects'
+        link_path = artifact_base_dir / 'projects'
+
+        first = link_projects_directory(artifact_base_dir)
+        second = link_projects_directory(artifact_base_dir)
+
+        assert first is True
+        assert second is True
+        # The link still resolves to the base projects dir after the second call.
+        assert link_path.resolve() == base_projects.resolve()
+        if sys.platform == 'win32':
+            assert link_path.is_symlink() is False
+            attrs = os.lstat(link_path).st_file_attributes
+            assert attrs & REPARSE_POINT_BIT
+        else:
+            assert link_path.is_symlink()
+
+    def test_non_clobber_real_non_empty_dir(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """A real non-empty projects/ dir is preserved (warn + skip), not replaced."""
+        artifact_base_dir = _artifact_base(e2e_isolated_home)
+        link_path = artifact_base_dir / 'projects'
+
+        # Pre-create a REAL projects directory holding session history.
+        link_path.mkdir(parents=True, exist_ok=True)
+        sentinel = link_path / 'session-history.json'
+        sentinel.write_text('{"existing": "data"}', encoding='utf-8')
+
+        result = link_projects_directory(artifact_base_dir)
+
+        # Benign skip returns True; the real dir and its contents survive.
+        assert result is True
+        assert link_path.is_dir()
+        assert link_path.is_symlink() is False
+        assert sentinel.exists(), 'Existing session history must be preserved'
+        assert sentinel.read_text(encoding='utf-8') == '{"existing": "data"}'
+
+    def test_empty_real_dir_replaced_with_link(
+        self,
+        e2e_isolated_home: dict[str, Path],
+    ) -> None:
+        """A real EMPTY projects/ dir is replaced with the link."""
+        home = e2e_isolated_home['home']
+        artifact_base_dir = _artifact_base(e2e_isolated_home)
+        base_projects = home / '.claude' / 'projects'
+        link_path = artifact_base_dir / 'projects'
+
+        # Pre-create an EMPTY real projects directory.
+        link_path.mkdir(parents=True, exist_ok=True)
+
+        result = link_projects_directory(artifact_base_dir)
+
+        assert result is True
+        assert link_path.resolve() == base_projects.resolve()
+        if sys.platform == 'win32':
+            assert link_path.is_symlink() is False
+            attrs = os.lstat(link_path).st_file_attributes
+            assert attrs & REPARSE_POINT_BIT
+        else:
+            assert link_path.is_symlink()
+
+    @pytest.mark.skipif(sys.platform != 'win32', reason='Windows mklink /J fallback')
+    def test_windows_fallback_to_mklink(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When _winapi.CreateJunction raises, the helper falls back to mklink /J."""
+        import _winapi
+
+        home = e2e_isolated_home['home']
+        artifact_base_dir = _artifact_base(e2e_isolated_home)
+        base_projects = home / '.claude' / 'projects'
+        link_path = artifact_base_dir / 'projects'
+
+        def _raise_create_junction(_src: str, _dst: str) -> None:
+            raise OSError('simulated CreateJunction failure')
+
+        monkeypatch.setattr(_winapi, 'CreateJunction', _raise_create_junction)
+
+        result = link_projects_directory(artifact_base_dir)
+
+        # The mklink /J fallback must produce a working junction.
+        assert result is True
+        assert link_path.is_dir()
+        assert link_path.is_symlink() is False
+        attrs = os.lstat(link_path).st_file_attributes
+        assert attrs & REPARSE_POINT_BIT
+        assert link_path.resolve() == base_projects.resolve()
+
+    @pytest.mark.skipif(sys.platform == 'win32', reason='Unix uses symlink, not junction')
+    def test_unix_uses_symlink_not_junction(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """On Unix the helper calls Path.symlink_to and never touches a junction path."""
+        artifact_base_dir = _artifact_base(e2e_isolated_home)
+        link_path = artifact_base_dir / 'projects'
+
+        calls: list[tuple[Path, Path]] = []
+        original_symlink_to = Path.symlink_to
+
+        def _tracking_symlink_to(
+            self: Path,
+            target: str | Path,
+            target_is_directory: bool = False,
+        ) -> None:
+            calls.append((self, Path(target)))
+            original_symlink_to(self, target, target_is_directory=target_is_directory)
+
+        monkeypatch.setattr(Path, 'symlink_to', _tracking_symlink_to)
+
+        result = link_projects_directory(artifact_base_dir)
+
+        assert result is True
+        assert calls, 'Path.symlink_to must be used on Unix'
+        assert calls[0][0] == link_path
+
+    def test_failure_is_non_fatal(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failure during linking returns False without raising (non-fatal)."""
+        artifact_base_dir = _artifact_base(e2e_isolated_home)
+
+        def _raise_get_home() -> Path:
+            raise OSError('simulated home resolution failure')
+
+        monkeypatch.setattr(setup_environment, 'get_real_user_home', _raise_get_home)
+
+        result = link_projects_directory(artifact_base_dir)
+
+        assert result is False

--- a/tests/scripts/models/test_environment_config.py
+++ b/tests/scripts/models/test_environment_config.py
@@ -1963,6 +1963,50 @@ class TestVersionRequiresCommandNames:
         assert config.version is None
 
 
+class TestLinkProjectsDirRequiresCommandNames:
+    """Tests for link-projects-dir + command-names cross-field validation."""
+
+    def test_link_projects_dir_without_command_names_raises(self) -> None:
+        """link-projects-dir true without command-names raises ValueError."""
+        with pytest.raises(ValidationError, match='link-projects-dir requires command-names'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'link-projects-dir': True,
+            })
+
+    def test_link_projects_dir_with_empty_command_names_raises(self) -> None:
+        """link-projects-dir true with empty command-names list raises ValueError."""
+        with pytest.raises(ValidationError, match='link-projects-dir requires command-names'):
+            EnvironmentConfig.model_validate({
+                'name': 'Test',
+                'link-projects-dir': True,
+                'command-names': [],
+            })
+
+    def test_link_projects_dir_with_command_names_valid(self) -> None:
+        """link-projects-dir true with command-names passes validation."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'link-projects-dir': True,
+            'command-names': ['my-cmd'],
+            'command-defaults': {'system-prompt': 'test.md'},
+        })
+        assert config.link_projects_dir is True
+
+    def test_link_projects_dir_false_without_command_names_valid(self) -> None:
+        """link-projects-dir false without command-names is valid (falsy is off)."""
+        config = EnvironmentConfig.model_validate({
+            'name': 'Test',
+            'link-projects-dir': False,
+        })
+        assert config.link_projects_dir is False
+
+    def test_no_link_projects_dir_without_command_names_valid(self) -> None:
+        """Omitting link-projects-dir without command-names is valid (defaults to None)."""
+        config = EnvironmentConfig.model_validate({'name': 'Test'})
+        assert config.link_projects_dir is None
+
+
 class TestMergeKeysRequiresInherit:
     """Tests for merge-keys + inherit cross-field validation."""
 


### PR DESCRIPTION
Setup-time child processes (dependency installers, npx tooling, claude mcp, the IDE-extension installer) inherited the default ~/.claude config home, so tooling run during installation of an isolated profile wrote to the wrong location.

main() now exports os.environ['CLAUDE_CONFIG_DIR'] = artifact_base_dir (guarded by primary_command_name) so those child processes target the isolated profile.

The export is process-scoped and transient and is never written to config.json; the runtime launcher export remains the sole authoritative runtime source, and the per-call MCP injections in configure_mcp_server are kept because the Windows curated-extra_env path does not inherit os.environ.

Add the optional link-projects-dir config key (isolated profiles only, default off) that links the isolated profile's projects/ directory to the base ~/.claude/projects/ so the isolated and default Claude can share session history.

Linking uses a Unix symlink and a Windows directory junction (_winapi.CreateJunction with mklink /J fallback), with reparse-aware detection, idempotent re-runs, non-clobbering preservation of a real non-empty projects/, and non-fatal failure.

A model validator requires command-names when the key is set.

All new functionality is covered by E2E tests.