### PR TITLE
Add components registry schema and inheritance merge support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,6 @@ exclude = ["tests"]
 asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
-norecursedirs = ["scripts"]
 pythonpath = ["."]
 timeout = 120
 filterwarnings = [

--- a/scripts/models/environment_config.py
+++ b/scripts/models/environment_config.py
@@ -4,6 +4,7 @@ Defines the schema for Claude Code environment YAML files.
 """
 
 import re
+from pathlib import PurePath
 from typing import Any
 from typing import Literal
 from typing import cast
@@ -975,12 +976,14 @@ class Hooks(BaseModel):
 def _download_selector_filename(source: str) -> str:
     """Derive the deployed filename a directory-form dest receives for a source.
 
-    Lexical mirror of _source_filename() in setup_environment.py (standalone
-    script policy prevents cross-import): strips query parameters and takes
-    the last path segment. GitLab API raw-file URLs carry the real filename
-    inside the URL-encoded path segment while their last path segment is the
-    literal 'raw', so for them the encoded segment is decoded and its
-    basename used instead.
+    Exact mirror of _source_filename() in setup_environment.py (standalone
+    script policy prevents cross-import; parity enforced by
+    tests/scripts/models/test_selectable_sections_parity.py): strips query
+    parameters and takes PurePath(...).name, which matches the runtime's
+    Path(...).name semantics on every host. GitLab API raw-file URLs carry
+    the real filename inside the URL-encoded path segment while their last
+    path segment is the literal 'raw', so for them the encoded segment is
+    decoded and its basename used instead.
 
     Args:
         source: Source path or URL from a files-to-download entry.
@@ -995,8 +998,8 @@ def _download_selector_filename(source: str) -> str:
         and '/repository/files/' in clean_source
     ):
         encoded_path = clean_source.split('/repository/files/')[-1].removesuffix('/raw')
-        return _extract_basename(unquote(encoded_path))
-    return _extract_basename(clean_source)
+        return PurePath(unquote(encoded_path)).name
+    return PurePath(clean_source).name
 
 
 def _download_selector_identity(source: str, dest: str) -> str:
@@ -1028,7 +1031,9 @@ class Component(BaseModel):
     selection prompt.
     """
 
-    model_config = ConfigDict(populate_by_name=True, extra='forbid')
+    # str_strip_whitespace matches EnvironmentConfig so includes selectors
+    # receive the same stripping as the section values they must match
+    model_config = ConfigDict(populate_by_name=True, extra='forbid', str_strip_whitespace=True)
 
     name: str = Field(
         ...,

--- a/scripts/models/environment_config.py
+++ b/scripts/models/environment_config.py
@@ -7,6 +7,7 @@ import re
 from typing import Any
 from typing import Literal
 from typing import cast
+from urllib.parse import unquote
 from urllib.parse import urlparse
 
 from pydantic import BaseModel
@@ -109,6 +110,30 @@ GLOBAL_CONFIG_SETTINGS_ONLY_KEYS: frozenset[str] = frozenset({
 
 # Environment variable names: letters, digits, underscores; no leading digit
 ENV_VAR_NAME_PATTERN: re.Pattern[str] = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+# Sections whose items may be claimed by entries in the top-level
+# `components:` registry. Any other key inside a component's `includes`
+# mapping is rejected. Inline copy of SELECTABLE_SECTIONS in
+# setup_environment.py (standalone script policy prevents cross-import);
+# parity enforced by tests/scripts/models/test_selectable_sections_parity.py.
+SELECTABLE_SECTIONS: frozenset[str] = frozenset({
+    'agents',
+    'slash-commands',
+    'rules',
+    'skills',
+    'files-to-download',
+    'mcp-servers',
+    'dependencies',
+    'hooks',
+})
+
+# Component names reserved as --select sentinels ('--select all' selects
+# every component, '--select none' selects no component)
+RESERVED_COMPONENT_NAMES: frozenset[str] = frozenset({'all', 'none'})
+
+# Component names: lowercase letters, digits, dots, underscores, hyphens;
+# must start with a letter or digit
+COMPONENT_NAME_PATTERN: re.Pattern[str] = re.compile(r'^[a-z0-9][a-z0-9._-]*$')
 
 
 def _extract_basename(path_or_url: str) -> str:
@@ -639,6 +664,11 @@ class HookEvent(BaseModel):
         None,
         description='Timeout in seconds (default varies by type: 600 for command, 30 for prompt, 60 for agent)',
     )
+    id: str | None = Field(
+        None,
+        description='Optional stable identifier used solely as a component selector for this event; '
+        'unique across events when present and never written to the generated hooks JSON',
+    )
 
     # Command hook fields
     command: str | None = Field(
@@ -942,6 +972,160 @@ class Hooks(BaseModel):
     events: list[HookEvent] = Field(default_factory=lambda: [], description='Hook event configurations')
 
 
+def _download_selector_filename(source: str) -> str:
+    """Derive the deployed filename a directory-form dest receives for a source.
+
+    Lexical mirror of _source_filename() in setup_environment.py (standalone
+    script policy prevents cross-import): strips query parameters and takes
+    the last path segment. GitLab API raw-file URLs carry the real filename
+    inside the URL-encoded path segment while their last path segment is the
+    literal 'raw', so for them the encoded segment is decoded and its
+    basename used instead.
+
+    Args:
+        source: Source path or URL from a files-to-download entry.
+
+    Returns:
+        The filename appended to a directory-form dest.
+    """
+    clean_source = source.split('?')[0]
+    if (
+        clean_source.endswith('/raw')
+        and '/api/v4/projects/' in clean_source
+        and '/repository/files/' in clean_source
+    ):
+        encoded_path = clean_source.split('/repository/files/')[-1].removesuffix('/raw')
+        return _extract_basename(unquote(encoded_path))
+    return _extract_basename(clean_source)
+
+
+def _download_selector_identity(source: str, dest: str) -> str:
+    """Compute the normalized final-path identity of a files-to-download entry.
+
+    Mirror of _files_download_identity() in setup_environment.py: a dest
+    ending with a path separator is a directory destination, so the source
+    filename is appended; any other dest is the identity as written.
+
+    Args:
+        source: Source path or URL of the entry.
+        dest: Destination path of the entry.
+
+    Returns:
+        The identity string used to match component selectors.
+    """
+    if dest.endswith(('/', '\\')):
+        return dest + _download_selector_filename(source)
+    return dest
+
+
+class Component(BaseModel):
+    """Named, user-selectable group of configuration items.
+
+    Components let a config author group items from the selectable sections
+    into units the end user can pick at setup time. An item claimed by at
+    least one component installs only when a selected component claims it;
+    an item claimed by no component is mandatory and never appears in any
+    selection prompt.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra='forbid')
+
+    name: str = Field(
+        ...,
+        description='Unique component identifier used with --select/--with/--without',
+    )
+    label: str | None = Field(
+        None,
+        description='Human-readable name shown in the picker and installation summary (falls back to name)',
+    )
+    description: str | None = Field(
+        None,
+        description='Hint line shown in the picker and in --list-components output',
+    )
+    default: bool = Field(
+        True,
+        description='Whether the component is selected by default (pre-checked in the picker, '
+        'included in --yes and non-interactive runs)',
+    )
+    requires: list[str] = Field(
+        default_factory=lambda: [],
+        description='Hard dependencies: component names transitively auto-included whenever this component is selected',
+    )
+    bundles: list[str] = Field(
+        default_factory=lambda: [],
+        description='Soft preset: component names pre-selected together with this component; '
+        'the user may still deselect them',
+    )
+    includes: dict[str, list[str]] = Field(
+        ...,
+        description='Mapping of selectable section name to the item selectors this component claims',
+    )
+
+    @field_validator('name')
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Validate the component name format and reserved literals.
+
+        Args:
+            v: Component name to validate.
+
+        Returns:
+            The validated component name.
+
+        Raises:
+            ValueError: If the name is reserved or does not match the allowed pattern.
+        """
+        if v in RESERVED_COMPONENT_NAMES:
+            raise ValueError(
+                f"Component name '{v}' is reserved (used as a --select sentinel). Choose another name.",
+            )
+        if not COMPONENT_NAME_PATTERN.match(v):
+            raise ValueError(
+                f"Component name '{v}' is invalid. Names must use lowercase letters, digits, "
+                'dots, underscores, and hyphens, and start with a letter or digit.',
+            )
+        return v
+
+    @field_validator('includes')
+    @classmethod
+    def validate_includes(cls, v: dict[str, list[str]]) -> dict[str, list[str]]:
+        """Validate the includes mapping keys and selector lists.
+
+        Args:
+            v: Mapping of section name to selector strings.
+
+        Returns:
+            The validated mapping.
+
+        Raises:
+            ValueError: If the mapping is empty, references a non-selectable
+                section, or contains an empty selector list or selector string.
+        """
+        if not v:
+            raise ValueError(
+                'includes must claim at least one item. '
+                f'Selectable sections: {sorted(SELECTABLE_SECTIONS)}',
+            )
+        errors: list[str] = []
+        for section, selectors in v.items():
+            if section not in SELECTABLE_SECTIONS:
+                errors.append(
+                    f"includes key '{section}' is not selectable. "
+                    f'Selectable sections: {sorted(SELECTABLE_SECTIONS)}',
+                )
+            if not selectors:
+                errors.append(f'includes.{section} must list at least one selector')
+            else:
+                errors.extend(
+                    f'includes.{section}[{i}] cannot be empty'
+                    for i, selector in enumerate(selectors)
+                    if not selector or not selector.strip()
+                )
+        if errors:
+            raise ValueError('; '.join(errors))
+        return v
+
+
 class CommandDefaults(BaseModel):
     """Command launch configuration."""
 
@@ -1003,7 +1187,7 @@ class InheritEntry(BaseModel):
         # Inline definition avoids circular import from setup_environment.py
         mergeable: frozenset[str] = frozenset({
             'dependencies', 'agents', 'slash-commands', 'rules', 'skills',
-            'files-to-download', 'hooks', 'mcp-servers',
+            'files-to-download', 'hooks', 'mcp-servers', 'components',
             'global-config', 'user-settings', 'os-env-variables',
         })
         invalid = [k for k in v if k not in mergeable]
@@ -1071,6 +1255,12 @@ class EnvironmentConfig(BaseModel):
         description='Files to download during environment setup',
     )
     hooks: Hooks | None = Field(None, description='Hook configurations')
+    components: list[Component] | None = Field(
+        default_factory=lambda: [],
+        description='Author-defined selectable component groups. Items claimed by '
+        'at least one component install only when a selected component claims them; '
+        'unclaimed items are mandatory and never appear in any selection prompt.',
+    )
     command_defaults: CommandDefaults | None = Field(
         None,
         alias='command-defaults',
@@ -1357,7 +1547,7 @@ class EnvironmentConfig(BaseModel):
         # Inline definition avoids circular import from setup_environment.py
         mergeable: frozenset[str] = frozenset({
             'dependencies', 'agents', 'slash-commands', 'rules', 'skills',
-            'files-to-download', 'hooks', 'mcp-servers',
+            'files-to-download', 'hooks', 'mcp-servers', 'components',
             'global-config', 'user-settings', 'os-env-variables',
         })
         invalid = [k for k in v if k not in mergeable]
@@ -1527,6 +1717,118 @@ class EnvironmentConfig(BaseModel):
                 'Profile-scoped servers need a launcher script with --mcp-config flag, '
                 'which is only created when command-names is present. '
                 'Either add command-names or change the server scope to user/local/project.',
+            )
+        return self
+
+    def _selectable_item_identities(self) -> dict[str, set[str]]:
+        """Compute the set of claimable item identities for each selectable section.
+
+        Identities mirror each section's merge identity in
+        setup_environment.py: the exact path string for agents,
+        slash-commands, and rules; the entry name for skills and
+        mcp-servers; the dest (with directory dests also matchable by their
+        normalized final file path) for files-to-download; the exact command
+        string across all platform lists for dependencies; and the event id
+        or hooks.files path for hooks.
+
+        Returns:
+            Mapping of section name to the set of accepted selector strings.
+        """
+        identities: dict[str, set[str]] = {
+            'agents': set(self.agents or []),
+            'slash-commands': set(self.slash_commands or []),
+            'rules': set(self.rules or []),
+            'skills': {skill.name for skill in self.skills or []},
+            'mcp-servers': {
+                str(server['name'])
+                for server in self.mcp_servers or []
+                if server.get('name') is not None
+            },
+            'dependencies': {
+                command
+                for commands in (self.dependencies or {}).values()
+                for command in commands
+            },
+        }
+
+        file_keys: set[str] = set()
+        for entry in self.files_to_download or []:
+            file_keys.add(entry.dest)
+            file_keys.add(_download_selector_identity(entry.source, entry.dest))
+        identities['files-to-download'] = file_keys
+
+        hook_keys: set[str] = set()
+        if self.hooks:
+            hook_keys.update(self.hooks.files)
+            hook_keys.update(event.id for event in self.hooks.events if event.id is not None)
+        identities['hooks'] = hook_keys
+
+        return identities
+
+    @model_validator(mode='after')
+    def validate_components_graph(self) -> 'EnvironmentConfig':
+        """Validate the components registry against the rest of the config.
+
+        Checks, aggregated into a single error so authors see every problem
+        at once: hooks.events ids are unique when present (ids exist solely
+        as component selectors for hook events), component names are unique,
+        requires/bundles reference existing component names, and every
+        includes selector matches at least one item in its section.
+
+        Returns:
+            The validated EnvironmentConfig instance.
+
+        Raises:
+            ValueError: If any components-graph rule is violated.
+        """
+        errors: list[str] = []
+
+        seen_hook_ids: set[str] = set()
+        if self.hooks:
+            for event in self.hooks.events:
+                if event.id is None:
+                    continue
+                if event.id in seen_hook_ids:
+                    errors.append(
+                        f"Duplicate hook event id '{event.id}'. Hook ids must be unique across events.",
+                    )
+                seen_hook_ids.add(event.id)
+
+        components = self.components or []
+        if components:
+            seen_names: set[str] = set()
+            for component in components:
+                if component.name in seen_names:
+                    errors.append(
+                        f"Duplicate component name '{component.name}'. Component names must be unique.",
+                    )
+                seen_names.add(component.name)
+
+            known_names = {component.name for component in components}
+            identities = self._selectable_item_identities()
+            for component in components:
+                errors.extend(
+                    f"Component '{component.name}': requires unknown component '{ref}'"
+                    for ref in component.requires
+                    if ref not in known_names
+                )
+                errors.extend(
+                    f"Component '{component.name}': bundles unknown component '{ref}'"
+                    for ref in component.bundles
+                    if ref not in known_names
+                )
+                for section, selectors in component.includes.items():
+                    available = identities.get(section, set())
+                    errors.extend(
+                        f"Component '{component.name}': includes.{section} selector "
+                        f"'{selector}' matches no item in {section}"
+                        for selector in selectors
+                        if selector not in available
+                    )
+
+        if errors:
+            raise ValueError(
+                'components validation failed:\n' + '\n'.join(f'  - {e}' for e in errors),
             )
         return self
 

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -72,6 +72,7 @@ MERGEABLE_CONFIG_KEYS: frozenset[str] = frozenset({
     'files-to-download',
     'hooks',
     'mcp-servers',
+    'components',
     'global-config',
     'user-settings',
     'os-env-variables',
@@ -124,11 +125,29 @@ KNOWN_CONFIG_KEYS: frozenset[str] = frozenset({
     'global-config',
     'hooks',
     'mcp-servers',
+    'components',
     'post-install-notes',
     'os-env-variables',
     'command-defaults',
     'user-settings',
     'status-line',
+})
+
+# Sections whose items may be claimed by entries in the top-level
+# `components:` registry. Any other key inside a component's `includes`
+# mapping is rejected. Inline copy of SELECTABLE_SECTIONS in
+# scripts/models/environment_config.py (standalone script policy prevents
+# cross-import); parity enforced by
+# tests/scripts/models/test_selectable_sections_parity.py.
+SELECTABLE_SECTIONS: frozenset[str] = frozenset({
+    'agents',
+    'slash-commands',
+    'rules',
+    'skills',
+    'files-to-download',
+    'mcp-servers',
+    'dependencies',
+    'hooks',
 })
 
 # Path prefixes indicating sensitive filesystem destinations
@@ -5558,7 +5577,7 @@ def _merge_config_key(
         return _merge_string_list(p_list, c_list)
 
     # Named list keys with identity by 'name'
-    if key in ('mcp-servers', 'skills'):
+    if key in ('mcp-servers', 'skills', 'components'):
         p_named = cast(list[dict[str, object]], parent_value) if isinstance(parent_value, list) else []
         c_named = cast(list[dict[str, object]], child_value) if isinstance(child_value, list) else []
         return _merge_named_list(p_named, c_named, _name_identity, key)

--- a/tests/scripts/models/test_environment_config.py
+++ b/tests/scripts/models/test_environment_config.py
@@ -2474,6 +2474,13 @@ class TestComponentsGraphValidation:
         ]))
         assert config.components is not None
 
+    def test_selector_whitespace_stripped_like_section_values(self):
+        """Selectors receive the same whitespace stripping as section values."""
+        config = EnvironmentConfig.model_validate(self._config(components=[
+            {'name': 'core', 'includes': {'dependencies': [' echo hi ']}},
+        ]))
+        assert config.components is not None
+
     def test_duplicate_component_names_rejected(self):
         """Two components with the same name are rejected."""
         with pytest.raises(ValidationError, match='Duplicate component name'):

--- a/tests/scripts/models/test_environment_config.py
+++ b/tests/scripts/models/test_environment_config.py
@@ -14,7 +14,9 @@ properly with static type checkers while testing runtime validation.
 import pytest
 from pydantic import ValidationError
 
+from scripts.models.environment_config import Component
 from scripts.models.environment_config import EnvironmentConfig
+from scripts.models.environment_config import HookEvent
 from scripts.models.environment_config import InheritEntry
 from scripts.models.environment_config import MCPServerStdio
 
@@ -318,7 +320,6 @@ class TestHookEventValidation:
     # Valid command hooks
     def test_command_hook_with_command(self) -> None:
         """Command hook with command field is valid."""
-        from scripts.models.environment_config import HookEvent
         event = HookEvent.model_validate({
             'event': 'PreToolUse',
             'matcher': 'Task',
@@ -330,7 +331,6 @@ class TestHookEventValidation:
 
     def test_command_hook_with_config(self) -> None:
         """Command hook with command and config is valid."""
-        from scripts.models.environment_config import HookEvent
         event = HookEvent.model_validate({
             'event': 'PreToolUse',
             'matcher': 'Task',
@@ -343,7 +343,6 @@ class TestHookEventValidation:
     # Valid prompt hooks
     def test_prompt_hook_with_prompt(self) -> None:
         """Prompt hook with prompt field is valid."""
-        from scripts.models.environment_config import HookEvent
         event = HookEvent.model_validate({
             'event': 'PreToolUse',
             'matcher': 'Search|Grep',
@@ -355,7 +354,6 @@ class TestHookEventValidation:
 
     def test_prompt_hook_with_timeout(self) -> None:
         """Prompt hook with timeout is valid."""
-        from scripts.models.environment_config import HookEvent
         event = HookEvent.model_validate({
             'event': 'PreToolUse',
             'matcher': 'Search|Grep',
@@ -368,7 +366,6 @@ class TestHookEventValidation:
     # Invalid: command hook without command
     def test_command_hook_without_command_raises(self) -> None:
         """Command hook without command raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PreToolUse',
@@ -379,7 +376,6 @@ class TestHookEventValidation:
     # Invalid: command hook with prompt
     def test_command_hook_with_prompt_raises(self) -> None:
         """Command hook with prompt field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PreToolUse',
@@ -392,7 +388,6 @@ class TestHookEventValidation:
     # Invalid: prompt hook without prompt
     def test_prompt_hook_without_prompt_raises(self) -> None:
         """Prompt hook without prompt raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PreToolUse',
@@ -403,7 +398,6 @@ class TestHookEventValidation:
     # Invalid: prompt hook with command
     def test_prompt_hook_with_command_raises(self) -> None:
         """Prompt hook with command field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PreToolUse',
@@ -416,7 +410,6 @@ class TestHookEventValidation:
     # Invalid: prompt hook with config
     def test_prompt_hook_with_config_raises(self) -> None:
         """Prompt hook with config field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PreToolUse',
@@ -429,7 +422,6 @@ class TestHookEventValidation:
     # Backward compatibility: default type is command
     def test_default_type_is_command(self) -> None:
         """Default type should be 'command' for backward compatibility."""
-        from scripts.models.environment_config import HookEvent
         event = HookEvent.model_validate({
             'event': 'PreToolUse',
             'command': 'test.py',
@@ -443,7 +435,6 @@ class TestHookEventAllTypes:
     # --- HTTP hook valid cases ---
     def test_http_hook_with_url(self) -> None:
         """HTTP hook with url field is valid."""
-        from scripts.models.environment_config import HookEvent
         event = HookEvent.model_validate({
             'event': 'PostToolUse',
             'matcher': 'Write',
@@ -455,7 +446,6 @@ class TestHookEventAllTypes:
 
     def test_http_hook_with_headers_and_allowed_env_vars(self) -> None:
         """HTTP hook with all optional fields is valid."""
-        from scripts.models.environment_config import HookEvent
         event = HookEvent.model_validate({
             'event': 'PostToolUse',
             'type': 'http',
@@ -469,7 +459,6 @@ class TestHookEventAllTypes:
     # --- Agent hook valid cases ---
     def test_agent_hook_with_prompt(self) -> None:
         """Agent hook with prompt field is valid."""
-        from scripts.models.environment_config import HookEvent
         event = HookEvent.model_validate({
             'event': 'PreToolUse',
             'matcher': 'Bash',
@@ -481,7 +470,6 @@ class TestHookEventAllTypes:
 
     def test_agent_hook_with_model(self) -> None:
         """Agent hook with model field is valid."""
-        from scripts.models.environment_config import HookEvent
         event = HookEvent.model_validate({
             'event': 'PreToolUse',
             'type': 'agent',
@@ -493,7 +481,6 @@ class TestHookEventAllTypes:
     # --- Command hook with new fields ---
     def test_command_hook_with_async_and_shell(self) -> None:
         """Command hook with async and shell fields is valid."""
-        from scripts.models.environment_config import HookEvent
         event = HookEvent.model_validate({
             'event': 'Notification',
             'type': 'command',
@@ -506,7 +493,6 @@ class TestHookEventAllTypes:
 
     def test_command_hook_shell_powershell(self) -> None:
         """Command hook with shell=powershell is valid."""
-        from scripts.models.environment_config import HookEvent
         event = HookEvent.model_validate({
             'event': 'Notification',
             'type': 'command',
@@ -518,7 +504,6 @@ class TestHookEventAllTypes:
     # --- Alias tests (populate_by_name) ---
     def test_hook_with_if_condition_alias(self) -> None:
         """The 'if' alias maps to if_condition field."""
-        from scripts.models.environment_config import HookEvent
         event = HookEvent.model_validate({
             'event': 'PreToolUse',
             'type': 'command',
@@ -529,7 +514,6 @@ class TestHookEventAllTypes:
 
     def test_hook_with_status_message_alias(self) -> None:
         """The 'status-message' alias maps to status_message field."""
-        from scripts.models.environment_config import HookEvent
         event = HookEvent.model_validate({
             'event': 'PreToolUse',
             'type': 'command',
@@ -540,7 +524,6 @@ class TestHookEventAllTypes:
 
     def test_hook_with_async_alias(self) -> None:
         """The 'async' alias maps to async_execution field."""
-        from scripts.models.environment_config import HookEvent
         event = HookEvent.model_validate({
             'event': 'Notification',
             'type': 'command',
@@ -551,7 +534,6 @@ class TestHookEventAllTypes:
 
     def test_hook_with_allowed_env_vars_alias(self) -> None:
         """The 'allowed-env-vars' alias maps to allowed_env_vars field."""
-        from scripts.models.environment_config import HookEvent
         event = HookEvent.model_validate({
             'event': 'PostToolUse',
             'type': 'http',
@@ -562,7 +544,6 @@ class TestHookEventAllTypes:
 
     def test_hook_with_once_field(self) -> None:
         """The once field is accepted on all types."""
-        from scripts.models.environment_config import HookEvent
         event = HookEvent.model_validate({
             'event': 'PreToolUse',
             'type': 'agent',
@@ -573,7 +554,6 @@ class TestHookEventAllTypes:
 
     def test_common_fields_on_all_types(self) -> None:
         """Common fields (if, status-message, once, timeout) work on all types."""
-        from scripts.models.environment_config import HookEvent
         common = {'if': 'Bash(*)', 'status-message': 'Working...', 'once': True, 'timeout': 30}
 
         for hook_data in [
@@ -591,7 +571,6 @@ class TestHookEventAllTypes:
     # --- HTTP hook forbidden cases ---
     def test_http_hook_without_url_raises(self) -> None:
         """HTTP hook without url raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PostToolUse',
@@ -601,7 +580,6 @@ class TestHookEventAllTypes:
 
     def test_http_hook_with_command_raises(self) -> None:
         """HTTP hook with command field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PostToolUse',
@@ -613,7 +591,6 @@ class TestHookEventAllTypes:
 
     def test_http_hook_with_config_raises(self) -> None:
         """HTTP hook with config field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PostToolUse',
@@ -625,7 +602,6 @@ class TestHookEventAllTypes:
 
     def test_http_hook_with_async_raises(self) -> None:
         """HTTP hook with async field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PostToolUse',
@@ -637,7 +613,6 @@ class TestHookEventAllTypes:
 
     def test_http_hook_with_shell_raises(self) -> None:
         """HTTP hook with shell field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PostToolUse',
@@ -649,7 +624,6 @@ class TestHookEventAllTypes:
 
     def test_http_hook_with_prompt_raises(self) -> None:
         """HTTP hook with prompt field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PostToolUse',
@@ -661,7 +635,6 @@ class TestHookEventAllTypes:
 
     def test_http_hook_with_model_raises(self) -> None:
         """HTTP hook with model field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PostToolUse',
@@ -674,7 +647,6 @@ class TestHookEventAllTypes:
     # --- Agent hook forbidden cases ---
     def test_agent_hook_without_prompt_raises(self) -> None:
         """Agent hook without prompt raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PreToolUse',
@@ -684,7 +656,6 @@ class TestHookEventAllTypes:
 
     def test_agent_hook_with_command_raises(self) -> None:
         """Agent hook with command field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PreToolUse',
@@ -696,7 +667,6 @@ class TestHookEventAllTypes:
 
     def test_agent_hook_with_url_raises(self) -> None:
         """Agent hook with url field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PreToolUse',
@@ -709,7 +679,6 @@ class TestHookEventAllTypes:
     # --- Command hook forbidden cases ---
     def test_command_hook_with_url_raises(self) -> None:
         """Command hook with url field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PreToolUse',
@@ -721,7 +690,6 @@ class TestHookEventAllTypes:
 
     def test_command_hook_with_headers_raises(self) -> None:
         """Command hook with headers field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PreToolUse',
@@ -733,7 +701,6 @@ class TestHookEventAllTypes:
 
     def test_command_hook_with_model_raises(self) -> None:
         """Command hook with model field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PreToolUse',
@@ -746,7 +713,6 @@ class TestHookEventAllTypes:
     # --- Prompt hook forbidden cases (new fields) ---
     def test_prompt_hook_with_url_raises(self) -> None:
         """Prompt hook with url field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PreToolUse',
@@ -758,7 +724,6 @@ class TestHookEventAllTypes:
 
     def test_prompt_hook_with_async_raises(self) -> None:
         """Prompt hook with async field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PreToolUse',
@@ -770,7 +735,6 @@ class TestHookEventAllTypes:
 
     def test_prompt_hook_with_shell_raises(self) -> None:
         """Prompt hook with shell field raises ValueError."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError) as exc_info:
             HookEvent.model_validate({
                 'event': 'PreToolUse',
@@ -783,7 +747,6 @@ class TestHookEventAllTypes:
     # --- Literal validation ---
     def test_shell_literal_validation(self) -> None:
         """Invalid shell value is rejected by Pydantic Literal."""
-        from scripts.models.environment_config import HookEvent
         with pytest.raises(ValidationError):
             HookEvent.model_validate({
                 'event': 'PreToolUse',
@@ -2313,3 +2276,275 @@ class TestSettingsValidationValueFunctions:
         from scripts.models.environment_config import validate_global_config_values
         errors = validate_global_config_values({'model': 'opus', 'hooks': {}})
         assert len(errors) == 2
+
+
+class TestHookEventIdField:
+    """Tests for the optional HookEvent id field (component selector identity)."""
+
+    def test_id_defaults_to_none(self):
+        """HookEvent without id defaults to None."""
+        event = HookEvent.model_validate({'event': 'PostToolUse', 'type': 'command', 'command': 'h.py'})
+        assert event.id is None
+
+    def test_id_accepted_on_all_hook_types(self):
+        """The id field is a common field accepted on every hook type."""
+        payloads: list[dict[str, str]] = [
+            {'event': 'PostToolUse', 'type': 'command', 'command': 'h.py', 'id': 'cmd-hook'},
+            {'event': 'PostToolUse', 'type': 'http', 'url': 'http://localhost:8080/x', 'id': 'web-hook'},
+            {'event': 'PreToolUse', 'type': 'prompt', 'prompt': 'Check safety', 'id': 'llm-hook'},
+            {'event': 'PreToolUse', 'type': 'agent', 'prompt': 'Verify: $ARGUMENTS', 'id': 'agent-hook'},
+        ]
+        for payload in payloads:
+            event = HookEvent.model_validate(payload)
+            assert event.id == payload['id']
+
+
+class TestComponentModel:
+    """Tests for the Component Pydantic model field-level validation."""
+
+    def test_minimal_component_defaults(self):
+        """Component with only name and includes gets documented defaults."""
+        component = Component.model_validate({'name': 'core', 'includes': {'agents': ['a.md']}})
+        assert component.name == 'core'
+        assert component.label is None
+        assert component.description is None
+        assert component.default is True
+        assert component.requires == []
+        assert component.bundles == []
+
+    def test_full_component_valid(self):
+        """Component with every field populated validates."""
+        component = Component.model_validate({
+            'name': 'mcp-http',
+            'label': 'HTTP MCP servers',
+            'description': 'Optional HTTP servers',
+            'default': False,
+            'requires': ['core'],
+            'bundles': ['extras'],
+            'includes': {'mcp-servers': ['srv']},
+        })
+        assert component.default is False
+        assert component.requires == ['core']
+        assert component.bundles == ['extras']
+
+    def test_name_pattern_accepts_valid_names(self):
+        """Lowercase names with digits, dots, underscores, and hyphens pass."""
+        for name in ('core', 'mcp-http', 'a.b_c-1', '0start'):
+            component = Component.model_validate({'name': name, 'includes': {'agents': ['a.md']}})
+            assert component.name == name
+
+    def test_name_rejects_uppercase(self):
+        """Uppercase letters in the name are rejected."""
+        with pytest.raises(ValidationError, match='invalid'):
+            Component.model_validate({'name': 'Core', 'includes': {'agents': ['a.md']}})
+
+    def test_name_rejects_leading_hyphen(self):
+        """Names must start with a letter or digit."""
+        with pytest.raises(ValidationError, match='invalid'):
+            Component.model_validate({'name': '-core', 'includes': {'agents': ['a.md']}})
+
+    def test_name_rejects_spaces(self):
+        """Names with spaces are rejected."""
+        with pytest.raises(ValidationError, match='invalid'):
+            Component.model_validate({'name': 'my core', 'includes': {'agents': ['a.md']}})
+
+    def test_name_rejects_reserved_all(self):
+        """The literal 'all' is reserved as a --select sentinel."""
+        with pytest.raises(ValidationError, match='reserved'):
+            Component.model_validate({'name': 'all', 'includes': {'agents': ['a.md']}})
+
+    def test_name_rejects_reserved_none(self):
+        """The literal 'none' is reserved as a --select sentinel."""
+        with pytest.raises(ValidationError, match='reserved'):
+            Component.model_validate({'name': 'none', 'includes': {'agents': ['a.md']}})
+
+    def test_extra_fields_forbidden(self):
+        """Unknown component fields are rejected (extra='forbid')."""
+        with pytest.raises(ValidationError):
+            Component.model_validate({'name': 'core', 'includes': {'agents': ['a.md']}, 'unknown': True})
+
+    def test_includes_required(self):
+        """A component without includes is rejected."""
+        with pytest.raises(ValidationError):
+            Component.model_validate({'name': 'core'})
+
+    def test_includes_empty_dict_rejected(self):
+        """An empty includes mapping is rejected."""
+        with pytest.raises(ValidationError, match='at least one item'):
+            Component.model_validate({'name': 'core', 'includes': {}})
+
+    def test_includes_unknown_section_rejected(self):
+        """Keys outside SELECTABLE_SECTIONS are rejected."""
+        with pytest.raises(ValidationError, match='not selectable'):
+            Component.model_validate({'name': 'core', 'includes': {'command-names': ['x']}})
+
+    def test_includes_components_section_rejected(self):
+        """The components registry itself is never claimable."""
+        with pytest.raises(ValidationError, match='not selectable'):
+            Component.model_validate({'name': 'core', 'includes': {'components': ['other']}})
+
+    def test_includes_empty_selector_list_rejected(self):
+        """An empty selector list for a section is rejected."""
+        with pytest.raises(ValidationError, match='at least one selector'):
+            Component.model_validate({'name': 'core', 'includes': {'agents': []}})
+
+    def test_includes_empty_selector_string_rejected(self):
+        """An empty selector string is rejected."""
+        with pytest.raises(ValidationError, match='cannot be empty'):
+            Component.model_validate({'name': 'core', 'includes': {'agents': ['']}})
+
+
+class TestComponentsGraphValidation:
+    """Tests for the EnvironmentConfig components cross-field graph validator."""
+
+    @staticmethod
+    def _config(**overrides: object) -> dict[str, object]:
+        """Build a valid config dict with items in every selectable section.
+
+        Args:
+            overrides: Top-level keys to add or replace in the base config.
+
+        Returns:
+            A config dict suitable for EnvironmentConfig.model_validate().
+        """
+        base: dict[str, object] = {
+            'name': 'Test',
+            'agents': ['agents/a.md'],
+            'slash-commands': ['commands/c.md'],
+            'rules': ['rules/r.md'],
+            'skills': [{'name': 'sk', 'base': 'skills/sk', 'files': ['SKILL.md']}],
+            'mcp-servers': [{'name': 'srv', 'scope': 'user', 'command': 'python -m x'}],
+            'dependencies': {'common': ['echo hi']},
+            'files-to-download': [
+                {'source': 'files/f.txt', 'dest': '~/.claude/f.txt'},
+                {'source': 'files/g.txt', 'dest': '~/.claude/gdir/'},
+            ],
+            'hooks': {
+                'files': ['hooks/h.py'],
+                'events': [
+                    {
+                        'event': 'PostToolUse',
+                        'matcher': 'Edit',
+                        'type': 'command',
+                        'command': 'h.py',
+                        'id': 'post-edit',
+                    },
+                ],
+            },
+        }
+        base.update(overrides)
+        return base
+
+    def test_components_absent_is_inert(self):
+        """A config without components validates and defaults to an empty list."""
+        config = EnvironmentConfig.model_validate(self._config())
+        assert config.components == []
+
+    def test_valid_components_all_sections(self):
+        """Components claiming items in every selectable section validate."""
+        config = EnvironmentConfig.model_validate(self._config(components=[
+            {
+                'name': 'core',
+                'includes': {
+                    'agents': ['agents/a.md'],
+                    'slash-commands': ['commands/c.md'],
+                    'rules': ['rules/r.md'],
+                    'skills': ['sk'],
+                    'mcp-servers': ['srv'],
+                    'dependencies': ['echo hi'],
+                    'files-to-download': ['~/.claude/f.txt'],
+                    'hooks': ['post-edit', 'hooks/h.py'],
+                },
+            },
+            {
+                'name': 'extra',
+                'default': False,
+                'requires': ['core'],
+                'bundles': ['core'],
+                'includes': {'files-to-download': ['~/.claude/gdir/']},
+            },
+        ]))
+        assert config.components is not None
+        assert len(config.components) == 2
+
+    def test_directory_dest_matches_by_normalized_identity(self):
+        """A directory dest is claimable by its normalized final file path."""
+        config = EnvironmentConfig.model_validate(self._config(components=[
+            {'name': 'core', 'includes': {'files-to-download': ['~/.claude/gdir/g.txt']}},
+        ]))
+        assert config.components is not None
+
+    def test_duplicate_component_names_rejected(self):
+        """Two components with the same name are rejected."""
+        with pytest.raises(ValidationError, match='Duplicate component name'):
+            EnvironmentConfig.model_validate(self._config(components=[
+                {'name': 'core', 'includes': {'agents': ['agents/a.md']}},
+                {'name': 'core', 'includes': {'rules': ['rules/r.md']}},
+            ]))
+
+    def test_dangling_requires_rejected(self):
+        """A requires edge naming an unknown component is rejected."""
+        with pytest.raises(ValidationError, match="requires unknown component 'nope'"):
+            EnvironmentConfig.model_validate(self._config(components=[
+                {'name': 'core', 'requires': ['nope'], 'includes': {'agents': ['agents/a.md']}},
+            ]))
+
+    def test_dangling_bundles_rejected(self):
+        """A bundles edge naming an unknown component is rejected."""
+        with pytest.raises(ValidationError, match="bundles unknown component 'nope'"):
+            EnvironmentConfig.model_validate(self._config(components=[
+                {'name': 'core', 'bundles': ['nope'], 'includes': {'agents': ['agents/a.md']}},
+            ]))
+
+    def test_agents_selector_matching_no_item_rejected(self):
+        """A selector matching no agents entry is rejected."""
+        with pytest.raises(ValidationError, match='matches no item in agents'):
+            EnvironmentConfig.model_validate(self._config(components=[
+                {'name': 'core', 'includes': {'agents': ['agents/missing.md']}},
+            ]))
+
+    def test_skills_selector_matching_no_item_rejected(self):
+        """A selector matching no skill name is rejected."""
+        with pytest.raises(ValidationError, match='matches no item in skills'):
+            EnvironmentConfig.model_validate(self._config(components=[
+                {'name': 'core', 'includes': {'skills': ['unknown']}},
+            ]))
+
+    def test_dependencies_selector_matching_no_item_rejected(self):
+        """A selector matching no dependency command is rejected."""
+        with pytest.raises(ValidationError, match='matches no item in dependencies'):
+            EnvironmentConfig.model_validate(self._config(components=[
+                {'name': 'core', 'includes': {'dependencies': ['echo other']}},
+            ]))
+
+    def test_hooks_selector_matching_no_item_rejected(self):
+        """A selector matching no hook id and no hooks.files path is rejected."""
+        with pytest.raises(ValidationError, match='matches no item in hooks'):
+            EnvironmentConfig.model_validate(self._config(components=[
+                {'name': 'core', 'includes': {'hooks': ['nope']}},
+            ]))
+
+    def test_duplicate_hook_ids_rejected_without_components(self):
+        """Duplicate hook event ids are rejected even when no components exist."""
+        with pytest.raises(ValidationError, match='Duplicate hook event id'):
+            EnvironmentConfig.model_validate(self._config(hooks={
+                'files': ['hooks/h.py'],
+                'events': [
+                    {'event': 'PostToolUse', 'type': 'command', 'command': 'h.py', 'id': 'dup'},
+                    {'event': 'PreToolUse', 'type': 'command', 'command': 'h.py', 'id': 'dup'},
+                ],
+            }))
+
+    def test_multiple_errors_aggregated(self):
+        """Every graph error is reported in a single aggregated message."""
+        with pytest.raises(ValidationError) as exc_info:
+            EnvironmentConfig.model_validate(self._config(components=[
+                {
+                    'name': 'core',
+                    'requires': ['nope'],
+                    'includes': {'agents': ['agents/missing.md']},
+                },
+            ]))
+        message = str(exc_info.value)
+        assert "requires unknown component 'nope'" in message
+        assert 'matches no item in agents' in message

--- a/tests/scripts/models/test_selectable_sections_parity.py
+++ b/tests/scripts/models/test_selectable_sections_parity.py
@@ -1,0 +1,55 @@
+"""Parity test: SELECTABLE_SECTIONS must be identical in both scripts.
+
+The Component model in environment_config.py necessarily duplicates the
+SELECTABLE_SECTIONS frozenset from setup_environment.py (standalone script
+policy prevents cross-import). This test enforces strict parity and the
+structural invariants the components registry relies on.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from scripts.models.environment_config import SELECTABLE_SECTIONS as MODEL_SELECTABLE_SECTIONS
+from scripts.models.environment_config import Component
+from scripts.setup_environment import KNOWN_CONFIG_KEYS
+from scripts.setup_environment import MERGEABLE_CONFIG_KEYS
+from scripts.setup_environment import SELECTABLE_SECTIONS
+
+
+def test_selectable_sections_match_between_scripts() -> None:
+    """Both SELECTABLE_SECTIONS copies must be identical sets."""
+    assert SELECTABLE_SECTIONS == MODEL_SELECTABLE_SECTIONS, (
+        f'SELECTABLE_SECTIONS out of sync between scripts.\n'
+        f'Only in setup_environment.py: {sorted(SELECTABLE_SECTIONS - MODEL_SELECTABLE_SECTIONS)}\n'
+        f'Only in environment_config.py: {sorted(MODEL_SELECTABLE_SECTIONS - SELECTABLE_SECTIONS)}'
+    )
+
+
+def test_selectable_sections_subset_of_known_config_keys() -> None:
+    """Every selectable section must be a real top-level config key."""
+    unknown = SELECTABLE_SECTIONS - KNOWN_CONFIG_KEYS
+    assert not unknown, (
+        f'SELECTABLE_SECTIONS contains keys not in KNOWN_CONFIG_KEYS: {sorted(unknown)}'
+    )
+
+
+def test_components_key_registered_but_not_selectable() -> None:
+    """The components registry itself is a known, mergeable, non-selectable key."""
+    assert 'components' in KNOWN_CONFIG_KEYS
+    assert 'components' in MERGEABLE_CONFIG_KEYS
+    assert 'components' not in SELECTABLE_SECTIONS
+
+
+def test_component_includes_accepts_every_selectable_section() -> None:
+    """The Component includes validator must accept every runtime section key."""
+    for section in SELECTABLE_SECTIONS:
+        component = Component.model_validate({'name': 'probe', 'includes': {section: ['x']}})
+        assert section in component.includes
+
+
+def test_component_includes_rejects_non_selectable_key() -> None:
+    """The Component includes validator must reject keys outside the allowlist."""
+    with pytest.raises(ValidationError, match='not selectable'):
+        Component.model_validate({'name': 'probe', 'includes': {'command-names': ['x']}})

--- a/tests/scripts/models/test_selectable_sections_parity.py
+++ b/tests/scripts/models/test_selectable_sections_parity.py
@@ -1,8 +1,10 @@
-"""Parity test: SELECTABLE_SECTIONS must be identical in both scripts.
+"""Parity tests: components schema duplicates in both scripts must match.
 
-The Component model in environment_config.py necessarily duplicates the
-SELECTABLE_SECTIONS frozenset from setup_environment.py (standalone script
-policy prevents cross-import). This test enforces strict parity and the
+The components schema in environment_config.py necessarily duplicates two
+pieces of setup_environment.py (standalone script policy prevents
+cross-import): the SELECTABLE_SECTIONS frozenset and the files-to-download
+selector identity computation (_download_selector_identity mirrors
+_files_download_identity). These tests enforce strict parity and the
 structural invariants the components registry relies on.
 """
 
@@ -13,9 +15,11 @@ from pydantic import ValidationError
 
 from scripts.models.environment_config import SELECTABLE_SECTIONS as MODEL_SELECTABLE_SECTIONS
 from scripts.models.environment_config import Component
+from scripts.models.environment_config import _download_selector_identity
 from scripts.setup_environment import KNOWN_CONFIG_KEYS
 from scripts.setup_environment import MERGEABLE_CONFIG_KEYS
 from scripts.setup_environment import SELECTABLE_SECTIONS
+from scripts.setup_environment import _files_download_identity
 
 
 def test_selectable_sections_match_between_scripts() -> None:
@@ -53,3 +57,24 @@ def test_component_includes_rejects_non_selectable_key() -> None:
     """The Component includes validator must reject keys outside the allowlist."""
     with pytest.raises(ValidationError, match='not selectable'):
         Component.model_validate({'name': 'probe', 'includes': {'command-names': ['x']}})
+
+
+@pytest.mark.parametrize(
+    ('source', 'dest'),
+    [
+        ('files/f.txt', '~/.claude/f.txt'),
+        ('files/f.txt', '~/.claude/dir/'),
+        ('files/f.txt', '~/.claude/dir\\'),
+        ('https://example.com/a/b.txt?x=1', '~/.claude/dir/'),
+        ('some\\path\\file.py', '~/.claude/dir/'),
+        (
+            'https://gitlab.com/api/v4/projects/123/repository/files/sub%2Ffile.py/raw?ref=main',
+            '~/.claude/dir/',
+        ),
+    ],
+)
+def test_download_selector_identity_matches_runtime(source: str, dest: str) -> None:
+    """The model's selector identity must equal the runtime merge identity."""
+    assert _download_selector_identity(source, dest) == _files_download_identity(
+        {'source': source, 'dest': dest},
+    )

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -6075,6 +6075,19 @@ class TestMergeKeys:
         result = setup_environment._merge_config_key('skills', parent, child)
         assert result == [{'name': 'sk1', 'base': '/a'}, {'name': 'sk2', 'base': '/b'}]
 
+    def test_merge_config_key_components(self):
+        """Dispatch: components uses named list merge by 'name'."""
+        parent = [{'name': 'core', 'includes': {'agents': ['a.md']}}]
+        child = [
+            {'name': 'core', 'includes': {'agents': ['b.md']}},
+            {'name': 'extra', 'includes': {'rules': ['r.md']}},
+        ]
+        result = setup_environment._merge_config_key('components', parent, child)
+        assert result == [
+            {'name': 'core', 'includes': {'agents': ['b.md']}},
+            {'name': 'extra', 'includes': {'rules': ['r.md']}},
+        ]
+
     def test_merge_config_key_files_to_download(self):
         """Dispatch: files-to-download uses named list merge by final file path."""
         parent = [{'source': 'a', 'dest': '~/.claude/a.txt'}]


### PR DESCRIPTION
## What

First of three PRs implementing author-controlled component selection for environment configs.

- New top-level `components:` key in the environment YAML schema: named groups of items from the eight selectable sections (`agents`, `slash-commands`, `rules`, `skills`, `files-to-download`, `mcp-servers`, `dependencies`, `hooks`), with `label`, `description`, `default`, hard `requires` edges, soft `bundles` edges, and an `includes` selector map.
- `Component` Pydantic model (`extra='forbid'`): name pattern validation, reserved `all`/`none` sentinels, `includes` keys restricted to the `SELECTABLE_SECTIONS` allowlist.
- Cross-field graph validator on `EnvironmentConfig`: unique component names, no dangling `requires`/`bundles`, every selector resolves to an item via its section's merge identity, unique hook event ids — all aggregated into one error.
- New optional `hooks.events[].id` field serving solely as the hooks selector identity (the hooks JSON builder is a whitelist, so the id never reaches generated output).
- Runtime: `components` added to `KNOWN_CONFIG_KEYS` and `MERGEABLE_CONFIG_KEYS`, merged by `name` through the existing named-list dispatch; byte-identical `SELECTABLE_SECTIONS` constant in both scripts.
- Fix: removed the stale `norecursedirs = ["scripts"]` pytest setting that silently pruned `tests/scripts/` (323 tests, including every parity test) from default and CI collection.

## Verification

- Full suite: 2711 passed, 47 platform-skipped (includes the 323 restored tests, all green).
- New tests: `Component` field validation per rejection class, cross-field graph validation per error class, `HookEvent.id` on all four hook types, components merge dispatch, and a new `test_selectable_sections_parity.py`.
- `uv run pre-commit run --all-files` clean.

Selection resolution, CLI flags, and the interactive picker follow in the next two PRs; until then the new key is validated and merged but intentionally inert at setup time.