### PR TITLE
Resolve and apply component selection with CLI selectors and summary

### DIFF
--- a/scripts/models/environment_config.py
+++ b/scripts/models/environment_config.py
@@ -1739,18 +1739,23 @@ class EnvironmentConfig(BaseModel):
         Returns:
             Mapping of section name to the set of accepted selector strings.
         """
+        # Every identity is whitespace-stripped: nested submodels (HookEvent,
+        # FileToDownload, Skill) and raw mcp-servers dicts do not inherit
+        # str_strip_whitespace, while Component selectors are stripped, so
+        # stripping here keeps selector matching symmetric with the runtime
+        # twin in setup_environment.py.
         identities: dict[str, set[str]] = {
-            'agents': set(self.agents or []),
-            'slash-commands': set(self.slash_commands or []),
-            'rules': set(self.rules or []),
-            'skills': {skill.name for skill in self.skills or []},
+            'agents': {item.strip() for item in self.agents or []},
+            'slash-commands': {item.strip() for item in self.slash_commands or []},
+            'rules': {item.strip() for item in self.rules or []},
+            'skills': {skill.name.strip() for skill in self.skills or []},
             'mcp-servers': {
-                str(server['name'])
+                str(server['name']).strip()
                 for server in self.mcp_servers or []
                 if server.get('name') is not None
             },
             'dependencies': {
-                command
+                command.strip()
                 for commands in (self.dependencies or {}).values()
                 for command in commands
             },
@@ -1758,14 +1763,16 @@ class EnvironmentConfig(BaseModel):
 
         file_keys: set[str] = set()
         for entry in self.files_to_download or []:
-            file_keys.add(entry.dest)
-            file_keys.add(_download_selector_identity(entry.source, entry.dest))
+            file_keys.add(entry.dest.strip())
+            file_keys.add(_download_selector_identity(entry.source.strip(), entry.dest.strip()))
         identities['files-to-download'] = file_keys
 
         hook_keys: set[str] = set()
         if self.hooks:
-            hook_keys.update(self.hooks.files)
-            hook_keys.update(event.id for event in self.hooks.events if event.id is not None)
+            hook_keys.update(file_path.strip() for file_path in self.hooks.files)
+            hook_keys.update(
+                event.id.strip() for event in self.hooks.events if event.id is not None
+            )
         identities['hooks'] = hook_keys
 
         return identities
@@ -1793,11 +1800,12 @@ class EnvironmentConfig(BaseModel):
             for event in self.hooks.events:
                 if event.id is None:
                     continue
-                if event.id in seen_hook_ids:
+                id_str = event.id.strip()
+                if id_str in seen_hook_ids:
                     errors.append(
-                        f"Duplicate hook event id '{event.id}'. Hook ids must be unique across events.",
+                        f"Duplicate hook event id '{id_str}'. Hook ids must be unique across events.",
                     )
-                seen_hook_ids.add(event.id)
+                seen_hook_ids.add(id_str)
 
         components = self.components or []
         if components:
@@ -1808,6 +1816,21 @@ class EnvironmentConfig(BaseModel):
                         f"Duplicate component name '{component.name}'. Component names must be unique.",
                     )
                 seen_names.add(component.name)
+
+            # Distinct files-to-download entries deploying to the same final
+            # path make component selectors ambiguous (one selector would
+            # claim both), silently defeating deselection.
+            identity_owners: dict[str, int] = {}
+            for entry_index, entry in enumerate(self.files_to_download or []):
+                identity = _download_selector_identity(entry.source.strip(), entry.dest.strip())
+                if identity in identity_owners:
+                    errors.append(
+                        f'files-to-download entries {identity_owners[identity]} and '
+                        f"{entry_index} share the final path '{identity}', making component "
+                        f'selectors ambiguous. Give them distinct destinations.',
+                    )
+                else:
+                    identity_owners[identity] = entry_index
 
             known_names = {component.name for component in components}
             identities = self._selectable_item_identities()

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -150,6 +150,14 @@ SELECTABLE_SECTIONS: frozenset[str] = frozenset({
     'hooks',
 })
 
+# Component names reserved as --select sentinels ('--select all' selects
+# every component, '--select none' selects no component)
+RESERVED_COMPONENT_NAMES: frozenset[str] = frozenset({'all', 'none'})
+
+# Component names: lowercase letters, digits, dots, underscores, hyphens;
+# must start with a letter or digit
+COMPONENT_NAME_PATTERN: re.Pattern[str] = re.compile(r'^[a-z0-9][a-z0-9._-]*$')
+
 # Path prefixes indicating sensitive filesystem destinations
 SENSITIVE_PATH_PREFIXES: tuple[str, ...] = (
     '~/.ssh/',
@@ -743,6 +751,33 @@ class InheritanceChainEntry:
 
 
 @dataclass
+class ComponentSelection:
+    """Resolved component selection state threaded into the installation plan.
+
+    is_active is False when the configuration defines no components, in
+    which case every other field is empty and no filtering occurs.
+    """
+
+    is_active: bool = False
+    # Component names in registry order
+    available: list[str] = field(default_factory=lambda: list[str]())
+    # Display label per component name (falls back to the name itself)
+    labels: dict[str, str] = field(default_factory=lambda: dict[str, str]())
+    # Final selected names (after selectors and closures), registry order
+    selected: list[str] = field(default_factory=lambda: list[str]())
+    # Names added by the hard requires closure, mapped to their cause
+    auto_included: dict[str, str] = field(default_factory=lambda: dict[str, str]())
+    # Copy-pasteable --select flag reproducing this selection
+    replay: str = ''
+
+    @property
+    def skipped(self) -> list[str]:
+        """Component names not selected, in registry order."""
+        selected_set = set(self.selected)
+        return [name for name in self.available if name not in selected_set]
+
+
+@dataclass
 class InstallationPlan:
     """Structured representation of what the setup will install.
 
@@ -801,6 +836,9 @@ class InstallationPlan:
 
     # Auto-injected items (auto-update controls)
     auto_injected_items: list[str] = field(default_factory=lambda: list[str]())
+
+    # Component selection (inactive when the config defines no components)
+    component_selection: ComponentSelection | None = None
 
     @property
     def total_resources(self) -> int:
@@ -2157,6 +2195,604 @@ def validate_global_config(global_config: dict[str, Any]) -> list[str]:
             )
 
     return errors
+
+
+def _component_item_keys(section: str, item: object) -> set[str]:
+    """Compute the identity keys a component selector can match for one item.
+
+    Mirrors each section's merge identity: the exact string for agents,
+    slash-commands, rules, and dependencies; the entry name for skills and
+    mcp-servers; and both the raw dest and the normalized final file path
+    (via _files_download_identity) for files-to-download. Hook events and
+    hook files are handled by _component_section_identities because hooks
+    is a composite section. Keys are whitespace-stripped to match the
+    Pydantic model's str_strip_whitespace behavior.
+
+    Args:
+        section: Selectable section name.
+        item: One item from that section.
+
+    Returns:
+        Set of identity keys; empty when the item has no identity (such
+        items are mandatory and never claimable).
+    """
+    if section in ('agents', 'slash-commands', 'rules', 'dependencies'):
+        return {str(item).strip()}
+    if section in ('skills', 'mcp-servers'):
+        if isinstance(item, dict):
+            name = cast(dict[str, Any], item).get('name')
+            if name is not None:
+                return {str(name).strip()}
+        return set()
+    if section == 'files-to-download':
+        if not isinstance(item, dict):
+            return set()
+        entry = cast(dict[str, Any], item)
+        keys: set[str] = set()
+        dest = entry.get('dest')
+        if dest is not None:
+            keys.add(str(dest).strip())
+        identity = _files_download_identity(entry)
+        if identity:
+            keys.add(identity.strip())
+        return keys
+    return set()
+
+
+def _component_section_identities(config: dict[str, Any], section: str) -> set[str]:
+    """Compute all claimable item identities for a selectable section.
+
+    Args:
+        config: Fully resolved configuration dictionary.
+        section: Selectable section name.
+
+    Returns:
+        Set of identity strings component selectors may reference.
+    """
+    keys: set[str] = set()
+    if section == 'hooks':
+        hooks_raw = config.get('hooks')
+        if isinstance(hooks_raw, dict):
+            hooks_dict = cast(dict[str, Any], hooks_raw)
+            keys.update(str(file_path).strip() for file_path in hooks_dict.get('files') or [])
+            keys.update(
+                str(cast(dict[str, Any], event)['id']).strip()
+                for event in hooks_dict.get('events') or []
+                if isinstance(event, dict) and cast(dict[str, Any], event).get('id') is not None
+            )
+        return keys
+    if section == 'dependencies':
+        deps_raw = config.get('dependencies')
+        if isinstance(deps_raw, dict):
+            for commands in cast(dict[str, Any], deps_raw).values():
+                if isinstance(commands, list):
+                    for command in cast(list[object], commands):
+                        keys |= _component_item_keys(section, command)
+        return keys
+    section_raw = config.get(section)
+    if isinstance(section_raw, list):
+        for item in cast(list[object], section_raw):
+            keys |= _component_item_keys(section, item)
+    return keys
+
+
+def _warn_hook_claim_asymmetry(
+    config: dict[str, Any],
+    components: list[dict[str, Any]],
+) -> None:
+    """Warn when claimed hooks files are not covered by their events' claims.
+
+    A command hook event references its script by basename. When a hooks
+    file is claimed by components that do not also cover every event
+    referencing it, a selection can drop the file while a surviving event
+    still needs it, breaking the hook at runtime. This is a soft warning,
+    not an error, because the asymmetry can also be a deliberate author
+    choice.
+
+    Args:
+        config: Fully resolved configuration dictionary.
+        components: Component entries from the configuration.
+    """
+    hooks_raw = config.get('hooks')
+    if not isinstance(hooks_raw, dict):
+        return
+    hooks_dict = cast(dict[str, Any], hooks_raw)
+    files = [str(f).strip() for f in hooks_dict.get('files') or []]
+    events = [
+        cast(dict[str, Any], e)
+        for e in hooks_dict.get('events') or []
+        if isinstance(e, dict)
+    ]
+    if not files or not events:
+        return
+
+    file_claims: dict[str, set[str]] = {f: set() for f in files}
+    event_claims: dict[str, set[str]] = {}
+    for comp in components:
+        comp_name = str(comp.get('name', '')).strip()
+        includes_raw = comp.get('includes')
+        if not isinstance(includes_raw, dict):
+            continue
+        selectors_raw = cast(dict[str, Any], includes_raw).get('hooks')
+        if not isinstance(selectors_raw, list):
+            continue
+        selectors = {str(s).strip() for s in cast(list[object], selectors_raw)}
+        for file_path in file_claims:
+            if file_path in selectors:
+                file_claims[file_path].add(comp_name)
+        for event in events:
+            event_id = event.get('id')
+            if event_id is not None and str(event_id).strip() in selectors:
+                event_claims.setdefault(str(event_id).strip(), set()).add(comp_name)
+
+    for file_path, file_claimers in file_claims.items():
+        if not file_claimers:
+            continue
+        file_basename = Path(file_path.split('?')[0]).name
+        for event in events:
+            if event.get('type', 'command') != 'command':
+                continue
+            command = str(event.get('command') or '').split('?')[0]
+            if not command or ' ' in command or Path(command).name != file_basename:
+                continue
+            event_id = event.get('id')
+            claimers = event_claims.get(str(event_id).strip(), set()) if event_id is not None else set()
+            if not claimers or claimers - file_claimers:
+                warning(
+                    f"hooks file '{file_path}' is claimed by component(s) "
+                    f'{sorted(file_claimers)} but a hook event referencing it is not '
+                    f'covered by the same component(s); deselecting the file could '
+                    f'break that event. Claim the file and its events together.',
+                )
+
+
+def validate_components(config: dict[str, Any]) -> list[str]:
+    """Validate the components registry against the resolved configuration.
+
+    Runtime twin of the Pydantic components validation in
+    scripts/models/environment_config.py (standalone script policy prevents
+    importing the model). Checks component entry shape, name format and
+    reserved literals, includes keys against SELECTABLE_SECTIONS, selector
+    resolution against the config's actual items, requires/bundles
+    references, duplicate component names, and duplicate hook event ids
+    (the id check runs even without components, matching the model). Emits
+    a hook-claim asymmetry warning as a side effect; never raises.
+
+    Args:
+        config: Fully resolved configuration dictionary.
+
+    Returns:
+        List of error messages; empty when the registry is valid.
+    """
+    import difflib
+
+    errors: list[str] = []
+
+    hooks_raw = config.get('hooks')
+    seen_ids: set[str] = set()
+    if isinstance(hooks_raw, dict):
+        for event in cast(dict[str, Any], hooks_raw).get('events') or []:
+            if not isinstance(event, dict):
+                continue
+            event_id = cast(dict[str, Any], event).get('id')
+            if event_id is None:
+                continue
+            id_str = str(event_id).strip()
+            if id_str in seen_ids:
+                errors.append(
+                    f"Duplicate hook event id '{id_str}'. Hook ids must be unique across events.",
+                )
+            seen_ids.add(id_str)
+
+    components_raw = config.get('components') or []
+    if not isinstance(components_raw, list):
+        errors.append("'components' must be a list of component entries")
+        return errors
+
+    allowed_fields = {'name', 'label', 'description', 'default', 'requires', 'bundles', 'includes'}
+    component_entries: list[dict[str, Any]] = []
+    seen_names: set[str] = set()
+    for index, entry_raw in enumerate(cast(list[object], components_raw)):
+        if not isinstance(entry_raw, dict):
+            errors.append(f'components[{index}] must be a mapping')
+            continue
+        entry = cast(dict[str, Any], entry_raw)
+        component_entries.append(entry)
+
+        name = str(entry.get('name') or '').strip()
+        display = name or f'components[{index}]'
+        if not name:
+            errors.append(f'components[{index}] requires a name')
+        elif name in RESERVED_COMPONENT_NAMES:
+            errors.append(
+                f"Component name '{name}' is reserved (used as a --select sentinel). "
+                f'Choose another name.',
+            )
+        elif not COMPONENT_NAME_PATTERN.match(name):
+            errors.append(
+                f"Component name '{name}' is invalid. Names must use lowercase letters, "
+                f'digits, dots, underscores, and hyphens, and start with a letter or digit.',
+            )
+        if name:
+            if name in seen_names:
+                errors.append(
+                    f"Duplicate component name '{name}'. Component names must be unique.",
+                )
+            seen_names.add(name)
+
+        unknown_fields = sorted(set(entry) - allowed_fields)
+        if unknown_fields:
+            errors.append(f"Component '{display}': unknown field(s): {', '.join(unknown_fields)}")
+        label_raw = entry.get('label')
+        if label_raw is not None and not isinstance(label_raw, str):
+            errors.append(f"Component '{display}': label must be a string")
+        description_raw = entry.get('description')
+        if description_raw is not None and not isinstance(description_raw, str):
+            errors.append(f"Component '{display}': description must be a string")
+        default_raw = entry.get('default')
+        if default_raw is not None and not isinstance(default_raw, bool):
+            errors.append(f"Component '{display}': default must be a boolean")
+
+        includes_raw = entry.get('includes')
+        if not isinstance(includes_raw, dict) or not includes_raw:
+            errors.append(
+                f"Component '{display}': includes must claim at least one item. "
+                f'Selectable sections: {sorted(SELECTABLE_SECTIONS)}',
+            )
+            continue
+        for section, selectors in cast(dict[str, Any], includes_raw).items():
+            if section not in SELECTABLE_SECTIONS:
+                close = difflib.get_close_matches(
+                    str(section), sorted(SELECTABLE_SECTIONS), n=1, cutoff=0.6,
+                )
+                hint = f' (did you mean {close[0]!r}?)' if close else ''
+                errors.append(
+                    f"Component '{display}': includes key '{section}' is not selectable{hint}. "
+                    f'Selectable sections: {sorted(SELECTABLE_SECTIONS)}',
+                )
+                continue
+            if not isinstance(selectors, list) or not selectors:
+                errors.append(
+                    f"Component '{display}': includes.{section} must list at least one selector",
+                )
+                continue
+            available = _component_section_identities(config, section)
+            for selector in cast(list[object], selectors):
+                selector_str = str(selector).strip()
+                if not selector_str:
+                    errors.append(
+                        f"Component '{display}': includes.{section} contains an empty selector",
+                    )
+                elif selector_str not in available:
+                    errors.append(
+                        f"Component '{display}': includes.{section} selector "
+                        f"'{selector_str}' matches no item in {section}",
+                    )
+
+    for entry in component_entries:
+        display = str(entry.get('name') or '').strip() or '<unnamed>'
+        for edge_key, verb in (('requires', 'requires'), ('bundles', 'bundles')):
+            edges_raw = entry.get(edge_key)
+            if edges_raw is None:
+                continue
+            if not isinstance(edges_raw, list):
+                errors.append(f"Component '{display}': {edge_key} must be a list of component names")
+                continue
+            errors.extend(
+                f"Component '{display}': {verb} unknown component '{str(ref).strip()}'"
+                for ref in cast(list[object], edges_raw)
+                if str(ref).strip() not in seen_names
+            )
+
+    if not errors:
+        _warn_hook_claim_asymmetry(config, component_entries)
+    return errors
+
+
+def _parse_component_csv(value: str | None) -> list[str] | None:
+    """Parse a comma-separated component list, distinguishing absent from empty.
+
+    Args:
+        value: Raw flag or environment variable value, or None when absent.
+
+    Returns:
+        None when the input is absent; otherwise the list of non-empty,
+        whitespace-stripped tokens (possibly empty).
+    """
+    if value is None:
+        return None
+    return [token.strip() for token in value.split(',') if token.strip()]
+
+
+def _validate_component_selector_args(
+    component_names: list[str],
+    args: argparse.Namespace,
+) -> list[str]:
+    """Validate --select/--with/--without values against the registry.
+
+    Args:
+        component_names: Known component names from the configuration.
+        args: Parsed CLI arguments (after resolve_args env merging).
+
+    Returns:
+        List of error messages; empty when every selector is valid.
+    """
+    import difflib
+
+    errors: list[str] = []
+    known = set(component_names)
+    for flag, raw in (
+        ('--select', args.select),
+        ('--with', args.with_),
+        ('--without', args.without),
+    ):
+        tokens = _parse_component_csv(raw)
+        if tokens is None:
+            continue
+        if not tokens:
+            sentinel_hint = ' or a sentinel (all, none)' if flag == '--select' else ''
+            errors.append(f'{flag} requires at least one component name{sentinel_hint}')
+            continue
+        for token in tokens:
+            if token in RESERVED_COMPONENT_NAMES:
+                if flag != '--select':
+                    errors.append(
+                        f"{flag} does not accept the sentinel '{token}' (only --select does)",
+                    )
+                elif len(tokens) > 1:
+                    errors.append(
+                        f"--select sentinel '{token}' cannot be combined with other names",
+                    )
+                continue
+            if token not in known:
+                close = difflib.get_close_matches(token, sorted(known), n=1, cutoff=0.6)
+                hint = f" (did you mean '{close[0]}'?)" if close else ''
+                errors.append(f"{flag}: unknown component '{token}'{hint}")
+    return errors
+
+
+def _bundle_closure(seed: set[str], bundles_map: dict[str, list[str]]) -> set[str]:
+    """Expand a selection along soft bundle edges to a fixpoint.
+
+    Cycles are tolerated via the visited set.
+
+    Args:
+        seed: Initially selected component names.
+        bundles_map: Component name to its bundled component names.
+
+    Returns:
+        The seed expanded with every transitively bundled name.
+    """
+    result = set(seed)
+    stack = list(seed)
+    while stack:
+        current = stack.pop()
+        for bundled in bundles_map.get(current, []):
+            if bundled not in result:
+                result.add(bundled)
+                stack.append(bundled)
+    return result
+
+
+def _requires_closure(
+    seed: set[str],
+    requires_map: dict[str, list[str]],
+) -> tuple[set[str], dict[str, str]]:
+    """Expand a selection along hard requires edges, recording causes.
+
+    Cycles are tolerated via the visited set; each auto-included name
+    records the first requester that pulled it in.
+
+    Args:
+        seed: Selected component names before the closure.
+        requires_map: Component name to its required component names.
+
+    Returns:
+        Tuple of (expanded name set, auto-included name to requester map).
+    """
+    result = set(seed)
+    causes: dict[str, str] = {}
+    stack = list(seed)
+    while stack:
+        current = stack.pop()
+        for required in requires_map.get(current, []):
+            if required not in result:
+                result.add(required)
+                causes[required] = current
+                stack.append(required)
+    return result, causes
+
+
+def resolve_component_selection(
+    components: list[dict[str, Any]],
+    args: argparse.Namespace,
+) -> ComponentSelection:
+    """Resolve which components are selected for this run.
+
+    Selection inputs in precedence order: author defaults, then the
+    --select/--with/--without selectors (env var equivalents already merged
+    by resolve_args). --select replaces the default set entirely (with the
+    sentinels all/none); --with adds to it; bundle edges softly expand the
+    seeded set; --without then removes names; the hard requires closure
+    runs last and wins over --without with a warning.
+
+    Args:
+        components: Component entries from the validated configuration.
+        args: Parsed CLI arguments (after resolve_args env merging).
+
+    Returns:
+        ComponentSelection describing the final selection; inactive when
+        the configuration defines no components.
+    """
+    if not components:
+        return ComponentSelection()
+
+    names = [str(c.get('name', '')).strip() for c in components]
+    labels = {
+        name: str(c.get('label') or '').strip() or name
+        for name, c in zip(names, components, strict=True)
+    }
+    bundles_map = {
+        name: [str(b).strip() for b in c.get('bundles') or []]
+        for name, c in zip(names, components, strict=True)
+    }
+    requires_map = {
+        name: [str(r).strip() for r in c.get('requires') or []]
+        for name, c in zip(names, components, strict=True)
+    }
+
+    select_tokens = _parse_component_csv(args.select)
+    with_tokens = _parse_component_csv(args.with_) or []
+    without_set = set(_parse_component_csv(args.without) or [])
+
+    if select_tokens is not None:
+        if select_tokens == ['all']:
+            base = set(names)
+        elif select_tokens == ['none']:
+            base = set()
+        else:
+            base = set(select_tokens)
+    else:
+        base = {name for name, c in zip(names, components, strict=True) if c.get('default', True)}
+
+    base |= set(with_tokens)
+    expanded = _bundle_closure(base, bundles_map)
+    trimmed = expanded - without_set
+    final, causes = _requires_closure(trimmed, requires_map)
+
+    for name in sorted(final & without_set):
+        warning(
+            f"--without '{name}' overridden: component "
+            f"'{causes.get(name, '?')}' requires it",
+        )
+
+    selected = [name for name in names if name in final]
+    replay = '--select ' + (','.join(selected) if selected else 'none')
+    return ComponentSelection(
+        is_active=True,
+        available=names,
+        labels=labels,
+        selected=selected,
+        auto_included={name: f"required by '{cause}'" for name, cause in causes.items()},
+        replay=replay,
+    )
+
+
+def apply_component_selection(
+    config: dict[str, Any],
+    selection: ComponentSelection,
+) -> None:
+    """Filter the resolved config in place according to the selection.
+
+    Per section: an item is dropped iff at least one component claims it
+    and no selected component claims it. Items claimed by no component are
+    mandatory and always survive, as do items without an identity. Section
+    keys are never deleted; emptied lists stay in place preserving shape.
+
+    Args:
+        config: Fully resolved configuration dictionary (mutated in place).
+        selection: The resolved component selection.
+    """
+    components = [
+        cast(dict[str, Any], c)
+        for c in config.get('components') or []
+        if isinstance(c, dict)
+    ]
+    if not components or not selection.is_active:
+        return
+
+    selected = set(selection.selected)
+    claimed: dict[str, set[str]] = {section: set() for section in SELECTABLE_SECTIONS}
+    kept: dict[str, set[str]] = {section: set() for section in SELECTABLE_SECTIONS}
+    for comp in components:
+        includes_raw = comp.get('includes')
+        if not isinstance(includes_raw, dict):
+            continue
+        is_selected = str(comp.get('name', '')).strip() in selected
+        for section, selectors in cast(dict[str, Any], includes_raw).items():
+            if section not in SELECTABLE_SECTIONS or not isinstance(selectors, list):
+                continue
+            selector_set = {str(s).strip() for s in cast(list[object], selectors)}
+            claimed[section] |= selector_set
+            if is_selected:
+                kept[section] |= selector_set
+
+    def _survives(section: str, keys: set[str]) -> bool:
+        return not keys or not (keys & claimed[section]) or bool(keys & kept[section])
+
+    for section in ('agents', 'slash-commands', 'rules', 'skills', 'mcp-servers', 'files-to-download'):
+        section_raw = config.get(section)
+        if isinstance(section_raw, list):
+            config[section] = [
+                item for item in cast(list[object], section_raw)
+                if _survives(section, _component_item_keys(section, item))
+            ]
+
+    deps_raw = config.get('dependencies')
+    if isinstance(deps_raw, dict):
+        deps_dict = cast(dict[str, Any], deps_raw)
+        for platform_key, commands in deps_dict.items():
+            if isinstance(commands, list):
+                deps_dict[platform_key] = [
+                    command for command in cast(list[object], commands)
+                    if _survives('dependencies', _component_item_keys('dependencies', command))
+                ]
+
+    hooks_raw = config.get('hooks')
+    if isinstance(hooks_raw, dict):
+        hooks_dict = cast(dict[str, Any], hooks_raw)
+        files_raw = hooks_dict.get('files')
+        if isinstance(files_raw, list):
+            hooks_dict['files'] = [
+                file_path for file_path in cast(list[object], files_raw)
+                if _survives('hooks', {str(file_path).strip()})
+            ]
+        events_raw = hooks_dict.get('events')
+        if isinstance(events_raw, list):
+            kept_events: list[object] = []
+            for event in cast(list[object], events_raw):
+                event_id = cast(dict[str, Any], event).get('id') if isinstance(event, dict) else None
+                event_keys = {str(event_id).strip()} if event_id is not None else set[str]()
+                if _survives('hooks', event_keys):
+                    kept_events.append(event)
+            hooks_dict['events'] = kept_events
+
+
+def display_component_registry(components: list[dict[str, Any]]) -> None:
+    """Print the component registry for --list-components.
+
+    Args:
+        components: Component entries from the validated configuration.
+    """
+    print()
+    print(f'{Colors.BOLD}Components:{Colors.NC}')
+    if not components:
+        info('This configuration defines no components; every item is mandatory.')
+        return
+    for comp in components:
+        name = str(comp.get('name', '')).strip()
+        label = str(comp.get('label') or '').strip()
+        default_marker = ' [default]' if comp.get('default', True) else ''
+        title = name + (f' -- {label}' if label and label != name else '') + default_marker
+        print(f'  * {title}')
+        description = str(comp.get('description') or '').strip()
+        if description:
+            print(f'      {description}')
+        requires = [str(r).strip() for r in comp.get('requires') or []]
+        if requires:
+            print(f'      requires: {", ".join(requires)}')
+        bundles = [str(b).strip() for b in comp.get('bundles') or []]
+        if bundles:
+            print(f'      bundles: {", ".join(bundles)}')
+        includes_raw = comp.get('includes')
+        if isinstance(includes_raw, dict):
+            counts = ', '.join(
+                f'{len(cast(list[object], selectors))} {section}'
+                for section, selectors in cast(dict[str, Any], includes_raw).items()
+                if isinstance(selectors, list)
+            )
+            if counts:
+                print(f'      includes: {counts}')
 
 
 def write_global_config(
@@ -6071,6 +6707,7 @@ def collect_installation_plan(
     config_version: str | None,
     inheritance_chain: list[InheritanceChainEntry],
     args: argparse.Namespace,
+    selection: ComponentSelection | None = None,
 ) -> InstallationPlan:
     """Collect all installation artifacts into a structured plan.
 
@@ -6086,6 +6723,8 @@ def collect_installation_plan(
             (before inheritance resolution). None if root config has no version.
         inheritance_chain: Resolved inheritance chain entries.
         args: Parsed CLI arguments.
+        selection: Resolved component selection, or None when the config
+            defines no components.
 
     Returns:
         InstallationPlan containing all artifacts to be installed.
@@ -6184,6 +6823,7 @@ def collect_installation_plan(
         status_line=config.get('status-line'),
         unknown_keys=unknown_keys,
         sensitive_paths=sensitive_paths,
+        component_selection=selection,
     )
 
 
@@ -6266,6 +6906,21 @@ def display_installation_summary(
         type_parts = [f'{count} {name}' for name, count in sorted(type_counts.items())]
         _print(f'    ({", ".join(type_parts)})')
     _print(f'  * MCP servers: {len(plan.mcp_servers)}')
+
+    # Component selection
+    component_selection = plan.component_selection
+    if component_selection is not None and component_selection.is_active:
+        _print()
+        _print(f'{Colors.BOLD}Components:{Colors.NC}')
+        selected_set = set(component_selection.selected)
+        for name in component_selection.available:
+            mark = '[x]' if name in selected_set else '[ ]'
+            label = component_selection.labels.get(name, name)
+            suffix = f' ({name})' if label != name else ''
+            cause = component_selection.auto_included.get(name)
+            cause_str = f' {Colors.GREEN}[auto: {cause}]{Colors.NC}' if cause else ''
+            _print(f'  {mark} {label}{suffix}{cause_str}')
+        _print(f'  Replay: {component_selection.replay}')
 
     # Claude Code installation
     _print()
@@ -11195,6 +11850,12 @@ def resolve_args(args: argparse.Namespace) -> argparse.Namespace:
     args.no_admin = args.no_admin or os.environ.get('CLAUDE_CODE_TOOLBOX_NO_ADMIN') == '1'
     if not args.auth:
         args.auth = os.environ.get('CLAUDE_CODE_TOOLBOX_ENV_AUTH')
+    if args.select is None:
+        args.select = os.environ.get('CLAUDE_CODE_TOOLBOX_SELECT')
+    if args.with_ is None:
+        args.with_ = os.environ.get('CLAUDE_CODE_TOOLBOX_WITH')
+    if args.without is None:
+        args.without = os.environ.get('CLAUDE_CODE_TOOLBOX_WITHOUT')
     return args
 
 
@@ -11256,6 +11917,27 @@ def main() -> None:
         '--dry-run',
         action='store_true',
         help='Show installation plan and exit without installing',
+    )
+    parser.add_argument(
+        '--select',
+        type=str,
+        help='Install exactly these components (comma-separated; sentinels: all, none)',
+    )
+    parser.add_argument(
+        '--with',
+        dest='with_',
+        type=str,
+        help='Add components to the default selection (comma-separated)',
+    )
+    parser.add_argument(
+        '--without',
+        type=str,
+        help='Remove components from the selection (comma-separated; hard requires still win)',
+    )
+    parser.add_argument(
+        '--list-components',
+        action='store_true',
+        help='List the components defined by the configuration and exit',
     )
     args = parser.parse_args()
     resolve_args(args)
@@ -11320,6 +12002,36 @@ def main() -> None:
                 source_type=classify_config_source(config_source),
                 name=config.get('name', config_name),
             )]
+
+        # Resolve author-defined component selection at the single choke
+        # point: after inheritance resolution and before the admin check and
+        # remote file validation, so deselected items never trigger UAC
+        # elevation, network fetches, or auth prompts. Downstream consumers
+        # re-read config keys fresh, so one in-place filter pass suffices.
+        components_list: list[dict[str, Any]] = [
+            cast(dict[str, Any], c)
+            for c in config.get('components') or []
+            if isinstance(c, dict)
+        ]
+        component_errors = validate_components(config)
+        if component_errors:
+            for err in component_errors:
+                error(err)
+            sys.exit(1)
+        selector_errors = _validate_component_selector_args(
+            [str(c.get('name', '')).strip() for c in components_list],
+            args,
+        )
+        if selector_errors:
+            for err in selector_errors:
+                error(err)
+            sys.exit(1)
+        if args.list_components:
+            display_component_registry(components_list)
+            sys.exit(0)
+        selection = resolve_component_selection(components_list, args)
+        if selection.is_active:
+            apply_component_selection(config, selection)
 
         # Check if admin rights are needed for this configuration
         if platform.system() == 'Windows' and not args.no_admin and check_admin_needed(config, args) and not is_admin():

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -2399,9 +2399,12 @@ def validate_components(config: dict[str, Any]) -> list[str]:
         entry = cast(dict[str, Any], entry_raw)
         component_entries.append(entry)
 
-        name = str(entry.get('name') or '').strip()
+        name_raw = entry.get('name')
+        name = name_raw.strip() if isinstance(name_raw, str) else ''
         display = name or f'components[{index}]'
-        if not name:
+        if name_raw is not None and not isinstance(name_raw, str):
+            errors.append(f'components[{index}]: name must be a string')
+        elif not name:
             errors.append(f'components[{index}] requires a name')
         elif name in RESERVED_COMPONENT_NAMES:
             errors.append(
@@ -2458,7 +2461,12 @@ def validate_components(config: dict[str, Any]) -> list[str]:
                 continue
             available = _component_section_identities(config, section)
             for selector in cast(list[object], selectors):
-                selector_str = str(selector).strip()
+                if not isinstance(selector, str):
+                    errors.append(
+                        f"Component '{display}': includes.{section} selectors must be strings",
+                    )
+                    continue
+                selector_str = selector.strip()
                 if not selector_str:
                     errors.append(
                         f"Component '{display}': includes.{section} contains an empty selector",
@@ -2478,11 +2486,35 @@ def validate_components(config: dict[str, Any]) -> list[str]:
             if not isinstance(edges_raw, list):
                 errors.append(f"Component '{display}': {edge_key} must be a list of component names")
                 continue
-            errors.extend(
-                f"Component '{display}': {verb} unknown component '{str(ref).strip()}'"
-                for ref in cast(list[object], edges_raw)
-                if str(ref).strip() not in seen_names
-            )
+            for ref in cast(list[object], edges_raw):
+                if not isinstance(ref, str):
+                    errors.append(f"Component '{display}': {edge_key} entries must be strings")
+                elif ref.strip() not in seen_names:
+                    errors.append(f"Component '{display}': {verb} unknown component '{ref.strip()}'")
+
+    # Distinct files-to-download entries deploying to the same final path
+    # make component selectors ambiguous (one selector would claim both),
+    # silently defeating deselection. Only relevant when components exist;
+    # without them the inheritance merge layer handles duplicates itself.
+    if component_entries:
+        ftd_raw = config.get('files-to-download')
+        if isinstance(ftd_raw, list):
+            identity_owners: dict[str, int] = {}
+            for item_index, item in enumerate(cast(list[object], ftd_raw)):
+                if not isinstance(item, dict):
+                    continue
+                identity = _files_download_identity(cast(dict[str, Any], item))
+                if identity is None:
+                    continue
+                identity = identity.strip()
+                if identity in identity_owners:
+                    errors.append(
+                        f'files-to-download entries {identity_owners[identity]} and '
+                        f"{item_index} share the final path '{identity}', making component "
+                        f'selectors ambiguous. Give them distinct destinations.',
+                    )
+                else:
+                    identity_owners[identity] = item_index
 
     if not errors:
         _warn_hook_claim_asymmetry(config, component_entries)
@@ -2551,40 +2583,46 @@ def _validate_component_selector_args(
     return errors
 
 
-def _bundle_closure(seed: set[str], bundles_map: dict[str, list[str]]) -> set[str]:
+def _bundle_closure(seed: list[str], bundles_map: dict[str, list[str]]) -> set[str]:
     """Expand a selection along soft bundle edges to a fixpoint.
 
-    Cycles are tolerated via the visited set.
+    Breadth-first over the ordered seed so traversal is deterministic;
+    cycles are tolerated via the visited set.
 
     Args:
-        seed: Initially selected component names.
+        seed: Initially selected component names in registry order.
         bundles_map: Component name to its bundled component names.
 
     Returns:
         The seed expanded with every transitively bundled name.
     """
     result = set(seed)
-    stack = list(seed)
-    while stack:
-        current = stack.pop()
+    queue = list(seed)
+    index = 0
+    while index < len(queue):
+        current = queue[index]
+        index += 1
         for bundled in bundles_map.get(current, []):
             if bundled not in result:
                 result.add(bundled)
-                stack.append(bundled)
+                queue.append(bundled)
     return result
 
 
 def _requires_closure(
-    seed: set[str],
+    seed: list[str],
     requires_map: dict[str, list[str]],
 ) -> tuple[set[str], dict[str, str]]:
     """Expand a selection along hard requires edges, recording causes.
 
-    Cycles are tolerated via the visited set; each auto-included name
-    records the first requester that pulled it in.
+    Breadth-first over the ordered seed so that when several selected
+    components require the same target, the recorded cause is always the
+    earliest requester in registry order (a set-seeded traversal would make
+    the [auto: ...] summary text vary between identical runs). Cycles are
+    tolerated via the visited set.
 
     Args:
-        seed: Selected component names before the closure.
+        seed: Selected component names in registry order.
         requires_map: Component name to its required component names.
 
     Returns:
@@ -2592,14 +2630,16 @@ def _requires_closure(
     """
     result = set(seed)
     causes: dict[str, str] = {}
-    stack = list(seed)
-    while stack:
-        current = stack.pop()
+    queue = list(seed)
+    index = 0
+    while index < len(queue):
+        current = queue[index]
+        index += 1
         for required in requires_map.get(current, []):
             if required not in result:
                 result.add(required)
                 causes[required] = current
-                stack.append(required)
+                queue.append(required)
     return result, causes
 
 
@@ -2656,9 +2696,9 @@ def resolve_component_selection(
         base = {name for name, c in zip(names, components, strict=True) if c.get('default', True)}
 
     base |= set(with_tokens)
-    expanded = _bundle_closure(base, bundles_map)
+    expanded = _bundle_closure([name for name in names if name in base], bundles_map)
     trimmed = expanded - without_set
-    final, causes = _requires_closure(trimmed, requires_map)
+    final, causes = _requires_closure([name for name in names if name in trimmed], requires_map)
 
     for name in sorted(final & without_set):
         warning(
@@ -12300,6 +12340,7 @@ def main() -> None:
             config_version=config_version,
             inheritance_chain=inheritance_chain,
             args=args,
+            selection=selection,
         )
         plan.auto_injected_items = auto_injected_items
 

--- a/tests/scripts/models/test_environment_config.py
+++ b/tests/scripts/models/test_environment_config.py
@@ -2555,3 +2555,36 @@ class TestComponentsGraphValidation:
         message = str(exc_info.value)
         assert "requires unknown component 'nope'" in message
         assert 'matches no item in agents' in message
+
+    def test_duplicate_final_path_rejected_with_components(self):
+        """Entries sharing a final path are ambiguous once components exist."""
+        with pytest.raises(ValidationError, match='share the final path'):
+            EnvironmentConfig.model_validate(self._config(
+                **{'files-to-download': [
+                    {'source': 'files/f.txt', 'dest': '~/.claude/gdir/f.txt'},
+                    {'source': 'files/f.txt', 'dest': '~/.claude/gdir/'},
+                ]},
+                components=[
+                    {'name': 'core', 'includes': {'files-to-download': ['~/.claude/gdir/f.txt']}},
+                ],
+            ))
+
+    def test_whitespace_hook_id_matches_stripped_selector(self):
+        """Identities are stripped so padded ids match stripped selectors."""
+        config = EnvironmentConfig.model_validate(self._config(
+            hooks={
+                'files': ['hooks/h.py'],
+                'events': [
+                    {
+                        'event': 'PostToolUse',
+                        'type': 'command',
+                        'command': 'h.py',
+                        'id': ' post-edit ',
+                    },
+                ],
+            },
+            components=[
+                {'name': 'core', 'includes': {'hooks': ['post-edit']}},
+            ],
+        ))
+        assert config.components is not None

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -15443,6 +15443,46 @@ class TestValidateComponents:
         errors = setup_environment.validate_components(config)
         assert any("Duplicate hook event id 'dup'" in e for e in errors)
 
+    def test_non_string_name_rejected(self) -> None:
+        """A non-string component name is rejected, matching the model twin."""
+        config = _components_config()
+        config['components'][0]['name'] = 123
+        errors = setup_environment.validate_components(config)
+        assert any('name must be a string' in e for e in errors)
+
+    def test_non_string_edge_refs_rejected(self) -> None:
+        """Non-string requires/bundles entries are rejected."""
+        config = _components_config()
+        config['components'][0]['requires'] = [123]
+        config['components'][0]['bundles'] = [None]
+        errors = setup_environment.validate_components(config)
+        assert any('requires entries must be strings' in e for e in errors)
+        assert any('bundles entries must be strings' in e for e in errors)
+
+    def test_non_string_selector_rejected(self) -> None:
+        """Non-string selectors are rejected."""
+        config = _components_config()
+        config['components'][0]['includes'] = {'agents': [123]}
+        errors = setup_environment.validate_components(config)
+        assert any('selectors must be strings' in e for e in errors)
+
+    def test_duplicate_final_path_rejected(self) -> None:
+        """Entries sharing a final path are ambiguous once components exist."""
+        config = _components_config()
+        config['files-to-download'] = [
+            {'source': 'files/g.txt', 'dest': '~/.claude/gdir/g.txt'},
+            {'source': 'files/g.txt', 'dest': '~/.claude/gdir/'},
+        ]
+        config['components'][1]['includes']['files-to-download'] = ['~/.claude/gdir/g.txt']
+        errors = setup_environment.validate_components(config)
+        assert any('share the final path' in e for e in errors)
+
+    def test_whitespace_hook_id_matches_stripped_selector(self) -> None:
+        """Padded event ids match stripped selectors (both sides stripped)."""
+        config = _components_config()
+        config['hooks']['events'][0]['id'] = ' post-edit '
+        assert setup_environment.validate_components(config) == []
+
     def test_hook_claim_asymmetry_warns(self) -> None:
         """Claiming a hooks file without covering its events warns."""
         config = _components_config()
@@ -15643,6 +15683,19 @@ class TestResolveComponentSelection:
             'bundle-pack': 'bundle-pack',
         }
 
+    def test_requires_cause_attribution_is_deterministic(self) -> None:
+        """When several requesters pull the same target, the earliest in registry order is the cause."""
+        components: list[dict[str, Any]] = [
+            {'name': 'a', 'default': False, 'requires': ['c'], 'includes': {'agents': ['x']}},
+            {'name': 'b', 'default': False, 'requires': ['c'], 'includes': {'agents': ['y']}},
+            {'name': 'c', 'default': False, 'includes': {'agents': ['z']}},
+        ]
+        for _ in range(20):
+            selection = setup_environment.resolve_component_selection(
+                components, _component_args(select='a,b'),
+            )
+            assert selection.auto_included == {'c': "required by 'a'"}
+
 
 class TestApplyComponentSelection:
     """Test apply_component_selection() in-place filtering."""
@@ -15800,6 +15853,41 @@ class TestComponentSelectionInPlan:
         buf = io.StringIO()
         setup_environment.display_installation_summary(plan, output=buf)
         assert 'Components:' not in buf.getvalue()
+
+
+class TestComponentSelectionMainWiring:
+    """Regression: main() threads the resolved selection into the plan summary."""
+
+    def test_dry_run_summary_renders_components_block(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A dry run of main() with components renders the Components block."""
+        config = _components_config()
+        monkeypatch.setattr(
+            setup_environment,
+            'load_config_from_source',
+            lambda *_a, **_k: (config, 'https://example.com/test.yaml'),
+        )
+        monkeypatch.setattr(
+            setup_environment,
+            'validate_all_config_files',
+            lambda *_a, **_k: (True, []),
+        )
+        monkeypatch.setattr(
+            sys,
+            'argv',
+            ['setup_environment.py', 'test', '--dry-run', '--skip-install', '--no-admin'],
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            setup_environment.main()
+        assert exc_info.value.code == 0
+        output = capsys.readouterr()
+        combined = output.out + output.err
+        assert 'Components:' in combined
+        assert '[x] Core (core)' in combined
+        assert 'Replay: --select core' in combined
 
 
 class TestDisplayComponentRegistry:

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -14975,6 +14975,9 @@ class TestResolveArgs:
         skip_install: bool = False,
         no_admin: bool = False,
         auth: str | None = None,
+        select: str | None = None,
+        with_: str | None = None,
+        without: str | None = None,
     ) -> argparse.Namespace:
         return argparse.Namespace(
             yes=yes,
@@ -14982,7 +14985,47 @@ class TestResolveArgs:
             skip_install=skip_install,
             no_admin=no_admin,
             auth=auth,
+            select=select,
+            with_=with_,
+            without=without,
+            list_components=False,
         )
+
+    def test_component_selectors_from_env_vars(self) -> None:
+        """CLAUDE_CODE_TOOLBOX_SELECT/_WITH/_WITHOUT provide fallbacks."""
+        env = {
+            'CLAUDE_CODE_TOOLBOX_SELECT': 'core,extra',
+            'CLAUDE_CODE_TOOLBOX_WITH': 'docs',
+            'CLAUDE_CODE_TOOLBOX_WITHOUT': 'mcp',
+        }
+        with patch.dict(os.environ, env):
+            args = self._make_args()
+            setup_environment.resolve_args(args)
+            assert args.select == 'core,extra'
+            assert args.with_ == 'docs'
+            assert args.without == 'mcp'
+
+    def test_component_selectors_cli_takes_precedence(self) -> None:
+        """CLI selector values win over their env var equivalents."""
+        env = {
+            'CLAUDE_CODE_TOOLBOX_SELECT': 'env-value',
+            'CLAUDE_CODE_TOOLBOX_WITH': 'env-value',
+            'CLAUDE_CODE_TOOLBOX_WITHOUT': 'env-value',
+        }
+        with patch.dict(os.environ, env):
+            args = self._make_args(select='cli-a', with_='cli-b', without='cli-c')
+            setup_environment.resolve_args(args)
+            assert args.select == 'cli-a'
+            assert args.with_ == 'cli-b'
+            assert args.without == 'cli-c'
+
+    def test_component_selectors_default_to_none(self) -> None:
+        """Without CLI values or env vars the selectors stay None."""
+        args = self._make_args()
+        setup_environment.resolve_args(args)
+        assert args.select is None
+        assert args.with_ is None
+        assert args.without is None
 
     def test_cli_flags_unchanged_when_no_env_vars(self) -> None:
         """CLI flags pass through without env vars."""
@@ -15162,3 +15205,644 @@ class TestElevationLaunchArgs:
             'SETUP_ENVIRONMENT.PY',
         )
         assert result == ['SETUP_ENVIRONMENT.PY']
+
+
+def _component_args(
+    select: str | None = None,
+    with_: str | None = None,
+    without: str | None = None,
+) -> argparse.Namespace:
+    """Build a Namespace carrying the component selector flags."""
+    return argparse.Namespace(
+        yes=False,
+        dry_run=False,
+        skip_install=False,
+        no_admin=False,
+        auth=None,
+        select=select,
+        with_=with_,
+        without=without,
+        list_components=False,
+    )
+
+
+def _components_config() -> dict[str, Any]:
+    """Build a config with items in every selectable section and 3 components.
+
+    Unclaimed (mandatory) items: agents/b.md, commands/c.md, skill sk,
+    server srv, the windows dependency, ~/.claude/f.txt, hooks/k.py and
+    its id-less event.
+
+    Returns:
+        Config dict with a components registry covering all sections.
+    """
+    return {
+        'name': 'Test',
+        'agents': ['agents/a.md', 'agents/b.md'],
+        'slash-commands': ['commands/c.md'],
+        'rules': ['rules/r.md'],
+        'skills': [{'name': 'sk', 'base': 'skills/sk', 'files': ['SKILL.md']}],
+        'mcp-servers': [
+            {'name': 'srv', 'scope': 'user', 'command': 'python -m x'},
+            {'name': 'srv2', 'scope': 'user', 'command': 'python -m y'},
+        ],
+        'dependencies': {'common': ['echo hi'], 'windows': ['winget install x']},
+        'files-to-download': [
+            {'source': 'files/f.txt', 'dest': '~/.claude/f.txt'},
+            {'source': 'files/g.txt', 'dest': '~/.claude/gdir/'},
+        ],
+        'hooks': {
+            'files': ['hooks/h.py', 'hooks/k.py'],
+            'events': [
+                {
+                    'event': 'PostToolUse',
+                    'matcher': 'Edit',
+                    'type': 'command',
+                    'command': 'h.py',
+                    'id': 'post-edit',
+                },
+                {'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'command', 'command': 'k.py'},
+            ],
+        },
+        'components': [
+            {
+                'name': 'core',
+                'label': 'Core',
+                'includes': {
+                    'agents': ['agents/a.md'],
+                    'hooks': ['post-edit', 'hooks/h.py'],
+                },
+            },
+            {
+                'name': 'extra',
+                'default': False,
+                'requires': ['core'],
+                'includes': {
+                    'mcp-servers': ['srv2'],
+                    'dependencies': ['echo hi'],
+                    'files-to-download': ['~/.claude/gdir/'],
+                },
+            },
+            {
+                'name': 'bundle-pack',
+                'default': False,
+                'bundles': ['extra'],
+                'includes': {'rules': ['rules/r.md']},
+            },
+        ],
+    }
+
+
+class TestValidateComponents:
+    """Test validate_components() runtime validation."""
+
+    def test_valid_config_no_errors(self) -> None:
+        """A fully valid components registry produces no errors."""
+        assert setup_environment.validate_components(_components_config()) == []
+
+    def test_absent_components_no_errors(self) -> None:
+        """A config without components validates trivially."""
+        assert setup_environment.validate_components({'name': 'Test'}) == []
+
+    def test_non_list_components_rejected(self) -> None:
+        """A non-list components value is a single error."""
+        errors = setup_environment.validate_components({'components': 'oops'})
+        assert errors == ["'components' must be a list of component entries"]
+
+    def test_non_dict_entry_rejected(self) -> None:
+        """A non-mapping component entry is rejected by index."""
+        errors = setup_environment.validate_components({'components': ['oops']})
+        assert any('components[0] must be a mapping' in e for e in errors)
+
+    def test_missing_name_rejected(self) -> None:
+        """A component without a name is rejected."""
+        config = _components_config()
+        config['components'][0].pop('name')
+        errors = setup_environment.validate_components(config)
+        assert any('requires a name' in e for e in errors)
+
+    def test_reserved_name_rejected(self) -> None:
+        """Reserved sentinel names are rejected."""
+        config = _components_config()
+        config['components'][0]['name'] = 'all'
+        errors = setup_environment.validate_components(config)
+        assert any('reserved' in e for e in errors)
+
+    def test_invalid_name_pattern_rejected(self) -> None:
+        """Names outside the allowed pattern are rejected."""
+        config = _components_config()
+        config['components'][0]['name'] = 'Core Stuff'
+        errors = setup_environment.validate_components(config)
+        assert any('invalid' in e for e in errors)
+
+    def test_duplicate_names_rejected(self) -> None:
+        """Duplicate component names are rejected."""
+        config = _components_config()
+        config['components'][1]['name'] = 'core'
+        config['components'][1].pop('requires')
+        errors = setup_environment.validate_components(config)
+        assert any('Duplicate component name' in e for e in errors)
+
+    def test_unknown_field_rejected(self) -> None:
+        """Unknown component fields are rejected."""
+        config = _components_config()
+        config['components'][0]['unexpected'] = True
+        errors = setup_environment.validate_components(config)
+        assert any('unknown field' in e for e in errors)
+
+    def test_field_type_errors(self) -> None:
+        """label/description/default type mismatches are rejected."""
+        config = _components_config()
+        config['components'][0]['label'] = 5
+        config['components'][0]['description'] = ['x']
+        config['components'][0]['default'] = 'yes'
+        errors = setup_environment.validate_components(config)
+        assert any('label must be a string' in e for e in errors)
+        assert any('description must be a string' in e for e in errors)
+        assert any('default must be a boolean' in e for e in errors)
+
+    def test_missing_includes_rejected(self) -> None:
+        """A component without includes is rejected."""
+        config = _components_config()
+        config['components'][0].pop('includes')
+        errors = setup_environment.validate_components(config)
+        assert any('includes must claim at least one item' in e for e in errors)
+
+    def test_unknown_includes_key_rejected_with_hint(self) -> None:
+        """Non-selectable includes keys are rejected with a difflib hint."""
+        config = _components_config()
+        config['components'][0]['includes'] = {'slash-comands': ['commands/c.md']}
+        errors = setup_environment.validate_components(config)
+        assert any("includes key 'slash-comands' is not selectable" in e for e in errors)
+        assert any("did you mean 'slash-commands'" in e for e in errors)
+
+    def test_empty_selector_list_rejected(self) -> None:
+        """An empty selector list is rejected."""
+        config = _components_config()
+        config['components'][0]['includes'] = {'agents': []}
+        errors = setup_environment.validate_components(config)
+        assert any('must list at least one selector' in e for e in errors)
+
+    def test_empty_selector_string_rejected(self) -> None:
+        """An empty selector string is rejected."""
+        config = _components_config()
+        config['components'][0]['includes'] = {'agents': ['  ']}
+        errors = setup_environment.validate_components(config)
+        assert any('contains an empty selector' in e for e in errors)
+
+    def test_selector_matching_no_item_rejected(self) -> None:
+        """Selectors that match no item are rejected per section."""
+        config = _components_config()
+        config['components'][0]['includes'] = {
+            'agents': ['agents/missing.md'],
+            'skills': ['nope'],
+            'hooks': ['ghost'],
+        }
+        errors = setup_environment.validate_components(config)
+        assert any("'agents/missing.md' matches no item in agents" in e for e in errors)
+        assert any("'nope' matches no item in skills" in e for e in errors)
+        assert any("'ghost' matches no item in hooks" in e for e in errors)
+
+    def test_directory_dest_selector_by_identity_accepted(self) -> None:
+        """A directory dest is claimable by its normalized final file path."""
+        config = _components_config()
+        config['components'][1]['includes']['files-to-download'] = ['~/.claude/gdir/g.txt']
+        assert setup_environment.validate_components(config) == []
+
+    def test_selector_whitespace_tolerated(self) -> None:
+        """Selectors and section values are compared whitespace-stripped."""
+        config = _components_config()
+        config['components'][1]['includes']['dependencies'] = [' echo hi ']
+        assert setup_environment.validate_components(config) == []
+
+    def test_dangling_requires_rejected(self) -> None:
+        """requires naming an unknown component is rejected."""
+        config = _components_config()
+        config['components'][0]['requires'] = ['ghost']
+        errors = setup_environment.validate_components(config)
+        assert any("requires unknown component 'ghost'" in e for e in errors)
+
+    def test_dangling_bundles_rejected(self) -> None:
+        """bundles naming an unknown component is rejected."""
+        config = _components_config()
+        config['components'][0]['bundles'] = ['ghost']
+        errors = setup_environment.validate_components(config)
+        assert any("bundles unknown component 'ghost'" in e for e in errors)
+
+    def test_duplicate_hook_ids_rejected_without_components(self) -> None:
+        """Duplicate hook event ids are rejected even without components."""
+        config: dict[str, Any] = {
+            'hooks': {
+                'files': ['h.py'],
+                'events': [
+                    {'event': 'PostToolUse', 'type': 'command', 'command': 'h.py', 'id': 'dup'},
+                    {'event': 'PreToolUse', 'type': 'command', 'command': 'h.py', 'id': 'dup'},
+                ],
+            },
+        }
+        errors = setup_environment.validate_components(config)
+        assert any("Duplicate hook event id 'dup'" in e for e in errors)
+
+    def test_hook_claim_asymmetry_warns(self) -> None:
+        """Claiming a hooks file without covering its events warns."""
+        config = _components_config()
+        config['components'][0]['includes'] = {'hooks': ['hooks/h.py']}
+        with patch.object(setup_environment, 'warning') as mock_warning:
+            errors = setup_environment.validate_components(config)
+        assert errors == []
+        assert mock_warning.called
+        assert 'hooks/h.py' in mock_warning.call_args[0][0]
+
+    def test_no_asymmetry_warning_when_covered(self) -> None:
+        """Claiming a file and its events together does not warn."""
+        with patch.object(setup_environment, 'warning') as mock_warning:
+            errors = setup_environment.validate_components(_components_config())
+        assert errors == []
+        assert not mock_warning.called
+
+
+class TestParseComponentCsv:
+    """Test _parse_component_csv() absent/empty distinction."""
+
+    def test_none_stays_none(self) -> None:
+        """Absent input returns None."""
+        assert setup_environment._parse_component_csv(None) is None
+
+    def test_simple_split(self) -> None:
+        """Comma-separated names split into tokens."""
+        assert setup_environment._parse_component_csv('a,b') == ['a', 'b']
+
+    def test_whitespace_stripped(self) -> None:
+        """Tokens are whitespace-stripped."""
+        assert setup_environment._parse_component_csv(' a , b ') == ['a', 'b']
+
+    def test_empty_string_is_empty_list(self) -> None:
+        """An empty string parses to an empty list, not None."""
+        assert setup_environment._parse_component_csv('') == []
+
+    def test_only_commas_is_empty_list(self) -> None:
+        """Separators without tokens parse to an empty list."""
+        assert setup_environment._parse_component_csv(',,') == []
+
+
+class TestValidateComponentSelectorArgs:
+    """Test _validate_component_selector_args() against the registry."""
+
+    _NAMES = ['core', 'extra', 'bundle-pack']
+
+    def test_valid_selectors_pass(self) -> None:
+        """Known names in every flag produce no errors."""
+        args = _component_args(select='core', with_='extra', without='bundle-pack')
+        assert setup_environment._validate_component_selector_args(self._NAMES, args) == []
+
+    def test_sentinels_valid_in_select(self) -> None:
+        """The all/none sentinels are accepted in --select alone."""
+        for sentinel in ('all', 'none'):
+            args = _component_args(select=sentinel)
+            assert setup_environment._validate_component_selector_args(self._NAMES, args) == []
+
+    def test_unknown_name_rejected_with_hint(self) -> None:
+        """Unknown component names are rejected with a difflib hint."""
+        args = _component_args(select='cor')
+        errors = setup_environment._validate_component_selector_args(self._NAMES, args)
+        assert any("unknown component 'cor'" in e for e in errors)
+        assert any("did you mean 'core'" in e for e in errors)
+
+    def test_sentinel_rejected_in_with_and_without(self) -> None:
+        """Sentinels are only valid in --select."""
+        args = _component_args(with_='all', without='none')
+        errors = setup_environment._validate_component_selector_args(self._NAMES, args)
+        assert any("--with does not accept the sentinel 'all'" in e for e in errors)
+        assert any("--without does not accept the sentinel 'none'" in e for e in errors)
+
+    def test_sentinel_combined_with_names_rejected(self) -> None:
+        """--select sentinels cannot be combined with other names."""
+        args = _component_args(select='all,core')
+        errors = setup_environment._validate_component_selector_args(self._NAMES, args)
+        assert any('cannot be combined' in e for e in errors)
+
+    def test_empty_select_rejected(self) -> None:
+        """An empty --select value is rejected."""
+        args = _component_args(select='')
+        errors = setup_environment._validate_component_selector_args(self._NAMES, args)
+        assert any('--select requires at least one component name' in e for e in errors)
+
+
+class TestResolveComponentSelection:
+    """Test resolve_component_selection() algorithm."""
+
+    @staticmethod
+    def _components() -> list[dict[str, Any]]:
+        return list(_components_config()['components'])
+
+    def test_empty_components_inactive(self) -> None:
+        """No components produces an inactive selection."""
+        selection = setup_environment.resolve_component_selection([], _component_args())
+        assert selection.is_active is False
+        assert selection.available == []
+        assert selection.selected == []
+
+    def test_defaults_selected(self) -> None:
+        """Author defaults seed the selection when no selectors are given."""
+        selection = setup_environment.resolve_component_selection(
+            self._components(), _component_args(),
+        )
+        assert selection.is_active is True
+        assert selection.available == ['core', 'extra', 'bundle-pack']
+        assert selection.selected == ['core']
+        assert selection.skipped == ['extra', 'bundle-pack']
+        assert selection.replay == '--select core'
+
+    def test_select_replaces_defaults_and_requires_pulls(self) -> None:
+        """--select replaces the default set; requires auto-includes."""
+        selection = setup_environment.resolve_component_selection(
+            self._components(), _component_args(select='extra'),
+        )
+        assert selection.selected == ['core', 'extra']
+        assert selection.auto_included == {'core': "required by 'extra'"}
+        assert selection.replay == '--select core,extra'
+
+    def test_select_all(self) -> None:
+        """--select all selects every component."""
+        selection = setup_environment.resolve_component_selection(
+            self._components(), _component_args(select='all'),
+        )
+        assert selection.selected == ['core', 'extra', 'bundle-pack']
+
+    def test_select_none(self) -> None:
+        """--select none selects no component."""
+        selection = setup_environment.resolve_component_selection(
+            self._components(), _component_args(select='none'),
+        )
+        assert selection.selected == []
+        assert selection.replay == '--select none'
+
+    def test_with_adds_and_bundles_expand(self) -> None:
+        """--with adds to the defaults; bundle edges softly expand."""
+        selection = setup_environment.resolve_component_selection(
+            self._components(), _component_args(with_='bundle-pack'),
+        )
+        assert selection.selected == ['core', 'extra', 'bundle-pack']
+
+    def test_without_beats_defaults(self) -> None:
+        """--without removes a defaulted component."""
+        selection = setup_environment.resolve_component_selection(
+            self._components(), _component_args(without='core'),
+        )
+        assert selection.selected == []
+        assert selection.replay == '--select none'
+
+    def test_without_beats_bundles(self) -> None:
+        """--without removes a bundled component."""
+        selection = setup_environment.resolve_component_selection(
+            self._components(), _component_args(with_='bundle-pack', without='extra'),
+        )
+        assert selection.selected == ['core', 'bundle-pack']
+
+    def test_hard_requires_overrides_without_with_warning(self) -> None:
+        """The requires closure wins over --without and warns."""
+        with patch.object(setup_environment, 'warning') as mock_warning:
+            selection = setup_environment.resolve_component_selection(
+                self._components(), _component_args(select='extra', without='core'),
+            )
+        assert selection.selected == ['core', 'extra']
+        assert 'core' in selection.auto_included
+        assert mock_warning.called
+        assert "--without 'core' overridden" in mock_warning.call_args[0][0]
+
+    def test_bundle_cycle_tolerated(self) -> None:
+        """Mutually bundled components resolve without infinite loops."""
+        components: list[dict[str, Any]] = [
+            {'name': 'a', 'default': False, 'bundles': ['b'], 'includes': {'agents': ['x']}},
+            {'name': 'b', 'default': False, 'bundles': ['a'], 'includes': {'agents': ['y']}},
+        ]
+        selection = setup_environment.resolve_component_selection(
+            components, _component_args(with_='a'),
+        )
+        assert selection.selected == ['a', 'b']
+
+    def test_requires_cycle_tolerated(self) -> None:
+        """Mutually requiring components resolve without infinite loops."""
+        components: list[dict[str, Any]] = [
+            {'name': 'a', 'default': False, 'requires': ['b'], 'includes': {'agents': ['x']}},
+            {'name': 'b', 'default': False, 'requires': ['a'], 'includes': {'agents': ['y']}},
+        ]
+        selection = setup_environment.resolve_component_selection(
+            components, _component_args(select='a'),
+        )
+        assert selection.selected == ['a', 'b']
+
+    def test_labels_fall_back_to_name(self) -> None:
+        """Missing labels fall back to the component name."""
+        selection = setup_environment.resolve_component_selection(
+            self._components(), _component_args(),
+        )
+        assert selection.labels == {
+            'core': 'Core',
+            'extra': 'extra',
+            'bundle-pack': 'bundle-pack',
+        }
+
+
+class TestApplyComponentSelection:
+    """Test apply_component_selection() in-place filtering."""
+
+    @staticmethod
+    def _apply(config: dict[str, Any], selected: list[str]) -> dict[str, Any]:
+        selection = setup_environment.ComponentSelection(
+            is_active=True,
+            available=['core', 'extra', 'bundle-pack'],
+            selected=selected,
+        )
+        setup_environment.apply_component_selection(config, selection)
+        return config
+
+    def test_default_selection_drops_unselected_claims(self) -> None:
+        """Only items claimed exclusively by unselected components drop."""
+        config = self._apply(_components_config(), ['core'])
+        assert config['agents'] == ['agents/a.md', 'agents/b.md']
+        assert config['slash-commands'] == ['commands/c.md']
+        assert config['rules'] == []
+        assert [s['name'] for s in config['mcp-servers']] == ['srv']
+        assert config['dependencies'] == {'common': [], 'windows': ['winget install x']}
+        assert [f['dest'] for f in config['files-to-download']] == ['~/.claude/f.txt']
+        assert config['hooks']['files'] == ['hooks/h.py', 'hooks/k.py']
+        assert [e.get('id') for e in config['hooks']['events']] == ['post-edit', None]
+
+    def test_all_selected_drops_nothing(self) -> None:
+        """Selecting every component keeps the config intact."""
+        expected = _components_config()
+        config = self._apply(_components_config(), ['core', 'extra', 'bundle-pack'])
+        assert config == expected
+
+    def test_none_selected_drops_all_claimed(self) -> None:
+        """An empty selection drops every claimed item, keeping mandatory ones."""
+        config = self._apply(_components_config(), [])
+        assert config['agents'] == ['agents/b.md']
+        assert config['rules'] == []
+        assert [s['name'] for s in config['mcp-servers']] == ['srv']
+        assert config['dependencies']['common'] == []
+        assert config['hooks']['files'] == ['hooks/k.py']
+        assert [e.get('id') for e in config['hooks']['events']] == [None]
+
+    def test_multi_claim_survives_if_any_claimer_selected(self) -> None:
+        """An item claimed by several components survives when one is selected."""
+        config = _components_config()
+        config['components'][2]['includes']['agents'] = ['agents/a.md']
+        selection = setup_environment.ComponentSelection(
+            is_active=True,
+            available=['core', 'extra', 'bundle-pack'],
+            selected=['bundle-pack'],
+        )
+        setup_environment.apply_component_selection(config, selection)
+        assert 'agents/a.md' in config['agents']
+
+    def test_directory_dest_claim_by_identity(self) -> None:
+        """A selector using the normalized identity claims the directory dest."""
+        config = _components_config()
+        config['components'][1]['includes']['files-to-download'] = ['~/.claude/gdir/g.txt']
+        config = self._apply(config, [])
+        assert [f['dest'] for f in config['files-to-download']] == ['~/.claude/f.txt']
+
+    def test_selector_whitespace_tolerated(self) -> None:
+        """Selectors and item identities are compared whitespace-stripped."""
+        config = _components_config()
+        config['components'][1]['includes']['dependencies'] = [' echo hi ']
+        config = self._apply(config, [])
+        assert config['dependencies']['common'] == []
+
+    def test_inactive_selection_is_noop(self) -> None:
+        """An inactive selection leaves the config untouched."""
+        expected = _components_config()
+        config = _components_config()
+        setup_environment.apply_component_selection(
+            config, setup_environment.ComponentSelection(),
+        )
+        assert config == expected
+
+    def test_shape_preserved_section_keys_survive(self) -> None:
+        """Filtering empties lists but never deletes section keys."""
+        config = self._apply(_components_config(), [])
+        assert 'rules' in config
+        assert config['rules'] == []
+        assert 'events' in config['hooks']
+
+
+class TestComponentSelectionInPlan:
+    """Test component selection threading into the installation plan."""
+
+    def test_collect_plan_threads_selection(self) -> None:
+        """collect_installation_plan stores the selection on the plan."""
+        config = _components_config()
+        selection = setup_environment.resolve_component_selection(
+            config['components'], _component_args(),
+        )
+        plan = setup_environment.collect_installation_plan(
+            config=config,
+            config_source='test',
+            config_name='test',
+            config_version=None,
+            inheritance_chain=[],
+            args=_component_args(),
+            selection=selection,
+        )
+        assert plan.component_selection is selection
+
+    def test_collect_plan_selection_defaults_to_none(self) -> None:
+        """Without the selection kwarg the plan carries None."""
+        plan = setup_environment.collect_installation_plan(
+            config={'name': 'Test'},
+            config_source='test',
+            config_name='test',
+            config_version=None,
+            inheritance_chain=[],
+            args=_component_args(),
+        )
+        assert plan.component_selection is None
+
+    def test_summary_renders_components_block(self) -> None:
+        """The summary renders selection marks, causes, and the replay line."""
+        import io
+        selection = setup_environment.ComponentSelection(
+            is_active=True,
+            available=['core', 'extra', 'bundle-pack'],
+            labels={'core': 'Core', 'extra': 'extra', 'bundle-pack': 'bundle-pack'},
+            selected=['core', 'extra'],
+            auto_included={'core': "required by 'extra'"},
+            replay='--select core,extra',
+        )
+        plan = setup_environment.InstallationPlan(
+            config_name='test-env',
+            config_source='test',
+            config_source_type='repo',
+            config_version=None,
+            component_selection=selection,
+        )
+        buf = io.StringIO()
+        setup_environment.display_installation_summary(plan, output=buf)
+        output = buf.getvalue()
+        assert 'Components:' in output
+        assert '[x] Core (core)' in output
+        assert '[x] extra' in output
+        assert '[ ] bundle-pack' in output
+        assert "[auto: required by 'extra']" in output
+        assert 'Replay: --select core,extra' in output
+
+    def test_summary_omits_components_block_when_inactive(self) -> None:
+        """No components block renders for component-free configs."""
+        import io
+        plan = setup_environment.InstallationPlan(
+            config_name='test-env',
+            config_source='test',
+            config_source_type='repo',
+            config_version=None,
+        )
+        buf = io.StringIO()
+        setup_environment.display_installation_summary(plan, output=buf)
+        assert 'Components:' not in buf.getvalue()
+
+
+class TestDisplayComponentRegistry:
+    """Test display_component_registry() output for --list-components."""
+
+    def test_registry_lists_components(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Every component renders with markers, edges, and counts."""
+        components = _components_config()['components']
+        setup_environment.display_component_registry(components)
+        output = capsys.readouterr().out
+        assert 'core -- Core [default]' in output
+        assert 'extra' in output
+        assert 'requires: core' in output
+        assert 'bundles: extra' in output
+        assert 'includes: 1 agents, 2 hooks' in output
+
+    def test_empty_registry_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """An empty registry prints the no-components message."""
+        setup_environment.display_component_registry([])
+        output = capsys.readouterr().out
+        assert 'defines no components' in output
+
+
+class TestHookIdNotInGeneratedJson:
+    """Regression: hooks.events[].id never reaches the generated hooks JSON."""
+
+    def test_id_stripped_from_hooks_json(self, tmp_path: Path) -> None:
+        """The whitelist builder drops the id field for every hook type."""
+        hooks = {
+            'files': ['h.py'],
+            'events': [
+                {'event': 'PostToolUse', 'matcher': 'Edit', 'type': 'command',
+                 'command': 'h.py', 'id': 'cmd-id'},
+                {'event': 'PostToolUse', 'matcher': 'Write', 'type': 'http',
+                 'url': 'http://localhost:8080/x', 'id': 'http-id'},
+                {'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'prompt',
+                 'prompt': 'Check', 'id': 'prompt-id'},
+                {'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'agent',
+                 'prompt': 'Verify', 'id': 'agent-id'},
+            ],
+        }
+        result = setup_environment._build_hooks_json(hooks, tmp_path)
+        serialized = json.dumps(result)
+        assert '"id"' not in serialized
+        assert 'cmd-id' not in serialized
+        assert 'http-id' not in serialized

--- a/tests/test_setup_environment_validation.py
+++ b/tests/test_setup_environment_validation.py
@@ -1205,6 +1205,10 @@ class TestMainFlowWithValidation:
             yes=True,
             dry_run=False,
             no_admin=False,
+            select=None,
+            with_=None,
+            without=None,
+            list_components=False,
         )
         mock_load.return_value = (
             {
@@ -1274,6 +1278,10 @@ class TestMainFlowWithValidation:
             yes=True,
             dry_run=False,
             no_admin=False,
+            select=None,
+            with_=None,
+            without=None,
+            list_components=False,
         )
         mock_load.return_value = (
             {


### PR DESCRIPTION
## What

Second of three PRs implementing author-controlled component selection (follows #409).

- `validate_components()`: runtime twin of the Pydantic components validation (entry shape, name format and reserved sentinels, `includes` allowlist with difflib hints, selector resolution against the config's actual items, `requires`/`bundles` references, duplicate names, duplicate hook event ids), plus a soft hook-claim asymmetry warning when a claimed hooks file is referenced by events its claimers do not cover.
- `resolve_component_selection()`: author defaults → `--select` (with `all`/`none` sentinels) → `--with` → soft bundle closure → `--without` → hard requires closure (cycles tolerated, causes recorded, wins over `--without` with a warning). Returns a `ComponentSelection` with a copy-pasteable `--select` replay.
- `apply_component_selection()`: filters the resolved config in place per section merge identity; unclaimed items are mandatory and always survive; section keys are never deleted.
- Wired at the single choke point in `main()` — after inheritance resolution, before the Windows admin check and remote file validation — so deselected items never trigger UAC elevation, network fetches, or auth prompts. `--list-components` prints the registry and exits 0.
- New CLI flags `--select`/`--with`/`--without`/`--list-components` with `CLAUDE_CODE_TOOLBOX_SELECT`/`_WITH`/`_WITHOUT` env fallbacks in `resolve_args()`.
- Installation summary gains a Components block (`[x]`/`[ ]` rows, green auto-include causes, replay line) between Resources and the Claude Code lines.
- Regression test: `hooks.events[].id` never reaches the generated hooks JSON (whitelist builder).

## Verification

- Full suite: 2781 passed, 47 platform-skipped; `uv run pre-commit run --all-files` clean.
- 63 dedicated component tests across validation, CSV parsing, selector validation, resolution (incl. bundle/requires cycles and `--without` vs hard requires), in-place filtering, plan threading, summary rendering, registry display, and the id-leak regression.

The interactive questionary picker, golden E2E coverage, and docs follow in the final PR; without a `components:` key in the YAML everything here is inert.