### PR TITLE
Forward component selection env vars through Windows UAC elevation

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -589,6 +589,9 @@ def request_admin_elevation(script_args: list[str] | None = None) -> None:
             'CLAUDE_CODE_TOOLBOX_SKIP_INSTALL',
             'CLAUDE_CODE_TOOLBOX_NO_ADMIN',
             'CLAUDE_CODE_TOOLBOX_ENV_AUTH',
+            'CLAUDE_CODE_TOOLBOX_SELECT',
+            'CLAUDE_CODE_TOOLBOX_WITH',
+            'CLAUDE_CODE_TOOLBOX_WITHOUT',
         ]
 
         for var_name in critical_env_vars:

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -15165,6 +15165,9 @@ class TestRequestAdminElevationEnvVars:
             'CLAUDE_CODE_TOOLBOX_SKIP_INSTALL',
             'CLAUDE_CODE_TOOLBOX_NO_ADMIN',
             'CLAUDE_CODE_TOOLBOX_ENV_AUTH',
+            'CLAUDE_CODE_TOOLBOX_SELECT',
+            'CLAUDE_CODE_TOOLBOX_WITH',
+            'CLAUDE_CODE_TOOLBOX_WITHOUT',
         }
         assert set(critical_vars) == expected_vars
 


### PR DESCRIPTION
## What

Found by the final whole-feature verification of the component-selection feature (regression-safety dimension, upheld by both adversarial skeptics).

`request_admin_elevation()` forwards workflow-control environment variables to the elevated Windows relaunch via `--env-VAR=value` arguments, but its `critical_env_vars` allowlist was never extended with `CLAUDE_CODE_TOOLBOX_SELECT`/`_WITH`/`_WITHOUT`. A Windows user expressing component selection only through those env vars (the documented mechanism for piped invocations, where CLI flags cannot be passed) would have the selection silently dropped after UAC elevation: the elevated process falls back to the author's default component set, installing components the user excluded or omitting ones they requested. CLI-flag selection was unaffected (flags survive via `sys.argv` forwarding).

The pre-existing regression guard (`TestRequestAdminElevationEnvVars`) exists precisely to catch this class of gap but asserts against a hardcoded expected set that was never updated, so it passed vacuously. Both the allowlist and the test's expected set now carry the three variables.

## Verification

Full suite: 2818 passed, 47 platform-skipped; pre-commit clean.