### PR TITLE
Resolve confirmed findings of the 7.1.0 release-gate round 1

### DIFF
--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -1226,6 +1226,8 @@ Selection resolves before the Windows admin-elevation check and before remote fi
 
 CI model validation of a config that declares `inherit` skips the cross-reference checks (selector resolution, `requires`/`bundles` references, and the duplicate final-path check): the full item and component sets exist only after inheritance resolution, so those checks run at setup time against the resolved configuration instead. Within-file invariants (duplicate component names, duplicate hook event ids) stay enforced on every file.
 
+An inherited registry survives composition like any other undeclared key: a key the composing config does not declare SURVIVES from its parent, and `merge-keys` only chooses merge-versus-replace for keys the child declares. When a composition removes items a parent's registry claims (for example by replacing `hooks` or emptying `skills`), the composing config must override the registry itself -- declare `components: []` to drop selectability entirely, or declare a replacement registry claiming only surviving items.
+
 Deselection also uninstalls. A re-run that deselects a component removes what an earlier run installed for it: deselected MCP servers are removed via `claude mcp remove` for every non-profile scope (`user`, `local`, `project`; the profile `mcp.json` is rebuilt from the filtered configuration each run), toolbox-written hook entries of deselected events are stripped from the shared `settings.json`, and deselected skill directories, agent/command/rule files, hook files, and downloaded files are deleted from their install locations. The removal plan derives entirely from the current configuration (every claimed item is named there), so no on-disk state is required; removals appear in the installation summary as `[REMOVE]` rows and are previewed without acting under `--dry-run`. Dependencies are never uninstalled: arbitrary install commands cannot be reversed.
 
 ## Advanced Topics
@@ -1782,6 +1784,7 @@ Here is a conceptual overview of what the setup script does when you run it with
 20. **Create launcher** -- Creates the launcher script for the command. (Only if `command-names` is specified.)
 21. **Register commands** -- Creates global command wrappers. (Only if `command-names` is specified.)
 22. **Link projects directory** -- Links the isolated profile's `projects/` directory to the base `~/.claude/projects/`. (Only if `command-names` is specified and `link-projects-dir: true`.)
+23. **Remove deselected components** -- Uninstalls previously installed artifacts of deselected components: MCP servers, skill directories, agent/command/rule/hook/downloaded files, and shared-settings hook entries. Runs in BOTH modes (as Step 23 with `command-names`, as Step 22 without) and only when the selection deselects at least one claimed item.
 
 Step 17 is skipped if no hooks, hook files, or status-line file are configured. In non-isolated mode, Step 18 is a no-op if the profile delta is empty -- no `status-line` or `hooks` declared at YAML root level. Steps 19-22 are skipped if `command-names` is not specified. Step 22 additionally requires `link-projects-dir: true`.
 

--- a/scripts/models/environment_config.py
+++ b/scripts/models/environment_config.py
@@ -1897,12 +1897,21 @@ class EnvironmentConfig(BaseModel):
         Note: Prompt hooks (type='prompt') do not use command or config files,
         so they are excluded from file consistency validation.
 
+        A config that declares ``inherit`` is exempt: its hooks.events can
+        legitimately reference a command file a parent's hooks.files
+        contributes, and a parent's hooks.files entry is legitimately
+        unused by itself because children reference it, so the
+        cross-references are decidable only on the resolved composition.
+
         Returns:
             The validated EnvironmentConfig instance.
 
         Raises:
             ValueError: If hooks files consistency rules are violated.
         """
+        if self.inherit:
+            return self
+
         # Skip validation if hooks is not configured
         if self.hooks is None:
             # If status_line is configured but hooks is None, that's an error

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -3066,17 +3066,33 @@ def execute_deselection_cleanup(
                 continue
             _remove_file(target_dir / name, description)
 
+    def _download_target(entry: dict[str, Any]) -> Path | None:
+        identity = _files_download_identity(entry)
+        if not identity:
+            return None
+        target = Path(normalize_tilde_path(identity.strip()))
+        # process_file_downloads() also treats an EXISTING directory as a
+        # directory-form dest even without a trailing separator
+        if target.is_dir():
+            target = target / _source_filename(str(entry.get('source', '')))
+        return target
+
+    surviving_targets = {
+        resolved for resolved in (
+            _download_target(cast(dict[str, Any], item))
+            for item in cast(list[object], surviving_config.get('files-to-download') or [])
+            if isinstance(item, dict)
+        ) if resolved is not None
+    }
     for entry in deselected['files-to-download']:
         if isinstance(entry, dict):
-            entry_dict = cast(dict[str, Any], entry)
-            identity = _files_download_identity(entry_dict)
-            if identity:
-                target = Path(normalize_tilde_path(identity.strip()))
-                # process_file_downloads() also treats an EXISTING directory
-                # as a directory-form dest even without a trailing separator
-                if target.is_dir():
-                    target = target / _source_filename(str(entry_dict.get('source', '')))
-                _remove_file(target, 'file')
+            target = _download_target(cast(dict[str, Any], entry))
+            if target is None:
+                continue
+            if target in surviving_targets:
+                info(f"Keeping file '{target.name}': a selected entry deploys to the same path")
+                continue
+            _remove_file(target, 'file')
 
     for skill in deselected['skills']:
         if isinstance(skill, dict):
@@ -3118,8 +3134,11 @@ def execute_deselection_cleanup(
                 success(f'Removed deselected MCP server: {name} (scope: {scope})')
             else:
                 stderr = (result.stderr or '').strip()
-                # 'not found' is the healthy first-run case: nothing was installed
-                if 'not found' not in stderr.lower():
+                # A missing server is the healthy first-run case. The claude
+                # CLI reports it as 'No user-scoped MCP server found with
+                # name: <name>' (or the project/local variants), so the
+                # shared marker is 'found with name'
+                if 'found with name' not in stderr.lower():
                     warning(
                         f"Cannot remove MCP server '{name}' (scope: {scope}): "
                         f'exit code {result.returncode}'

--- a/tests/scripts/models/test_environment_config.py
+++ b/tests/scripts/models/test_environment_config.py
@@ -2482,6 +2482,22 @@ class TestComponentsGraphValidation:
         with pytest.raises(ValidationError, match='Duplicate component name'):
             EnvironmentConfig.model_validate(config)
 
+    def test_inherit_config_skips_hooks_files_consistency(self):
+        """A leaf may reference a hook file a parent's hooks.files contributes."""
+        config = self._config(inherit='parent.yaml')
+        config['hooks'] = {
+            'events': [
+                {'event': 'PostToolUse', 'matcher': 'Edit', 'type': 'command', 'command': 'parent-hook.py'},
+            ],
+        }
+        EnvironmentConfig.model_validate(config)
+
+    def test_inherit_config_allows_unused_hooks_files(self):
+        """A parent's hooks.files entry is legitimately unused by itself."""
+        config = self._config(inherit='parent.yaml')
+        config['hooks'] = {'files': ['hooks/shared-hook.py'], 'events': []}
+        EnvironmentConfig.model_validate(config)
+
     def test_inherit_config_still_rejects_duplicate_hook_ids(self):
         """Duplicate hook event ids stay rejected for inherit-declaring configs."""
         config = self._config(inherit='parent.yaml')

--- a/tests/test_deselection_reconciliation.py
+++ b/tests/test_deselection_reconciliation.py
@@ -226,6 +226,56 @@ class TestExecuteDeselectionCleanup:
         assert not (dest_dir / 'report.txt').exists()
         assert dest_dir.is_dir()
 
+    def test_surviving_download_target_is_never_deleted(self, tmp_path: Path) -> None:
+        """A deselected entry resolving to a surviving entry's final path is skipped."""
+        dirs = self._dirs(tmp_path)
+        drop = tmp_path / 'dropzone'
+        drop.mkdir()
+        deployed = drop / 'config.txt'
+        deployed.write_text('kept')
+        deselected: dict[str, list[Any]] = {
+            'agents': [], 'slash-commands': [], 'rules': [], 'skills': [],
+            'mcp-servers': [],
+            'files-to-download': [{'source': 'a/config.txt', 'dest': str(deployed)}],
+            'hooks-files': [], 'hooks-events': [],
+        }
+        surviving = {
+            'files-to-download': [{'source': 'b/config.txt', 'dest': str(drop) + '/'}],
+        }
+        with patch.object(setup_environment, 'normalize_tilde_path', side_effect=lambda p, **_: p):
+            setup_environment.execute_deselection_cleanup(
+                deselected, surviving,
+                agents_dir=dirs['agents'], commands_dir=dirs['commands'],
+                rules_dir=dirs['rules'], skills_dir=dirs['skills'],
+                hooks_dir=dirs['hookfiles'], is_isolated=True,
+            )
+        assert deployed.read_text() == 'kept'
+
+    def test_missing_server_stderr_wording_does_not_warn(self, tmp_path: Path) -> None:
+        """The real claude CLI missing-server wording is tolerated silently."""
+        dirs = self._dirs(tmp_path)
+        deselected: dict[str, list[Any]] = {
+            'agents': [], 'slash-commands': [], 'rules': [], 'skills': [],
+            'mcp-servers': [{'name': 'srv', 'scope': 'user'}],
+            'files-to-download': [], 'hooks-files': [], 'hooks-events': [],
+        }
+        stderr = 'No user-scoped MCP server found with name: srv\n'
+        with (
+            patch.object(setup_environment, 'find_command', return_value='claude'),
+            patch.object(
+                setup_environment, 'run_command',
+                return_value=subprocess.CompletedProcess([], 1, '', stderr),
+            ),
+            patch.object(setup_environment, 'warning') as mock_warning,
+        ):
+            setup_environment.execute_deselection_cleanup(
+                deselected, {},
+                agents_dir=dirs['agents'], commands_dir=dirs['commands'],
+                rules_dir=dirs['rules'], skills_dir=dirs['skills'],
+                hooks_dir=dirs['hookfiles'], is_isolated=True,
+            )
+        assert not mock_warning.called
+
     def test_failed_mcp_remove_warns(self, tmp_path: Path) -> None:
         """A non-zero claude mcp remove exit surfaces as a warning."""
         dirs = self._dirs(tmp_path)


### PR DESCRIPTION
## What

Fixes all four confirmed findings of release-gate review round 1 (wf_11021091, 2 skeptics per finding, 0 refuted):

- **files-to-download surviving-target guard** (material): removal targets resolving to a surviving entry's final path (including the is-dir runtime append) are skipped with a notice — a deselected explicit-dest entry could previously delete the file a selected directory-form entry deploys
- **`claude mcp remove` missing-server tolerance** (material): matches the CLI's actual wording (`No user-scoped MCP server found with name: …` and scope variants); the previous `'not found'` substring never matched, so every ordinary first run warned spuriously
- **`validate_hooks_files_consistency` inherit exemption** (material): same undecidability as the components graph — a leaf's events legitimately reference parent-contributed hook files; the validator now skips inherit-declaring configs
- **Guide staleness** (minor): the numbered step overview lists the removal step (isolated Step 23 / non-isolated Step 22) with its gating; the components section documents the inherited-registry composition trap and its remedy

## Verification

2882 passed / 47 platform-skipped (+4 new tests: surviving-download guard, real CLI wording tolerance, both hooks-consistency inherit exemptions); pre-commit clean.