### PR TITLE
Close selection and upgrade gaps in hooks validation and reconciliation

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -2600,7 +2600,11 @@ def _hook_file_basename(path_or_url: str) -> str:
     return parts[-1] if parts else path_or_url
 
 
-def validate_hooks_files_consistency(config: dict[str, Any]) -> list[str]:
+def validate_hooks_files_consistency(
+    config: dict[str, Any],
+    *,
+    require_all_files_used: bool = True,
+) -> list[str]:
     """Validate hooks files, events, and status-line consistency at runtime.
 
     Runtime twin of the Pydantic validate_hooks_files_consistency model
@@ -2624,6 +2628,12 @@ def validate_hooks_files_consistency(config: dict[str, Any]) -> list[str]:
 
     Args:
         config: Fully resolved configuration dictionary.
+        require_all_files_used: When False, the unused-files check (rule 1)
+            is skipped. Used for the post-selection recheck in main(): a
+            deselected component may legitimately strand a hooks.files entry
+            its claims covered asymmetrically (the hook-claim asymmetry
+            warning covers authoring), while a dangling event or status-line
+            reference is always an error.
 
     Returns:
         List of error messages; empty when hooks references are consistent.
@@ -2763,7 +2773,7 @@ def validate_hooks_files_consistency(config: dict[str, Any]) -> list[str]:
                     used_files.add(config_basename)
 
     # Rule 1: Check that each file in hooks.files is used somewhere
-    if not structure_broken:
+    if require_all_files_used and not structure_broken:
         unused_files = available_files - used_files
         if unused_files:
             errors.append(
@@ -3112,6 +3122,36 @@ def has_deselected_items(deselected: dict[str, list[Any]]) -> bool:
     return any(items for items in deselected.values())
 
 
+def _hook_entries_equal(built: dict[str, Any], existing: object) -> bool:
+    """Compare a freshly built hook entry against an on-disk hook entry.
+
+    Every field is compared by equality except ``command``, which is
+    compared with double quotes stripped from both sides: the builder
+    quotes built file paths, while entries written before quoting existed
+    carry the same command unquoted, and both describe the same hook.
+
+    Args:
+        built: Hook entry dict produced by _build_hooks_json().
+        existing: Candidate entry from the on-disk settings JSON.
+
+    Returns:
+        True when the entries describe the same hook.
+    """
+    if not isinstance(existing, dict):
+        return False
+    built_rest = {k: v for k, v in built.items() if k != 'command'}
+    existing_rest = {k: v for k, v in cast(dict[str, Any], existing).items() if k != 'command'}
+    if built_rest != existing_rest:
+        return False
+    built_command = built.get('command')
+    existing_command = cast(dict[str, Any], existing).get('command')
+    if built_command == existing_command:
+        return True
+    if isinstance(built_command, str) and isinstance(existing_command, str):
+        return built_command.replace('"', '') == existing_command.replace('"', '')
+    return False
+
+
 def _strip_hooks_from_settings(
     settings_path: Path,
     deselected_events: list[dict[str, Any]],
@@ -3123,8 +3163,10 @@ def _strip_hooks_from_settings(
     entry, so hook events written by an earlier run survive deselection
     there. This builds the exact JSON the deselected events generate (via
     the same builder the writer uses) and removes matching entries from the
-    file: hook dicts are matched by equality inside same-matcher groups,
-    emptied groups and event keys are dropped.
+    file: hook dicts are matched inside same-matcher groups via
+    _hook_entries_equal() (quote-insensitive on the command, so entries
+    written before path quoting existed still match), emptied groups and
+    event keys are dropped.
 
     Args:
         settings_path: Path to the shared settings.json file.
@@ -3162,8 +3204,15 @@ def _strip_hooks_from_settings(
                 if not isinstance(group_hooks, list):
                     continue
                 for hook_entry in cast(list[Any], remove_group.get('hooks') or []):
-                    if hook_entry in group_hooks:
-                        group_hooks.remove(hook_entry)
+                    match = next(
+                        (
+                            candidate for candidate in cast(list[Any], group_hooks)
+                            if _hook_entries_equal(cast(dict[str, Any], hook_entry), candidate)
+                        ),
+                        None,
+                    )
+                    if match is not None:
+                        group_hooks.remove(match)
                         removed += 1
         hooks_json[event_name] = [
             g for g in cast(list[Any], existing_groups)
@@ -12950,6 +12999,24 @@ def main() -> None:
         deselected = collect_deselected_items(config, selection)
         if selection.is_active:
             apply_component_selection(config, selection)
+            # Post-selection recheck: deselection can strand an event or
+            # status-line reference whose file a deselected component
+            # claimed. Reference resolution must hold on the filtered
+            # config; unused files are legitimate deselection residue
+            # covered by the hook-claim asymmetry warning.
+            post_selection_errors = validate_hooks_files_consistency(
+                config, require_all_files_used=False,
+            )
+            if post_selection_errors:
+                for err in post_selection_errors:
+                    error(err)
+                error(
+                    'The selected components leave hook references dangling. '
+                    'Select the component that provides the referenced file, or '
+                    'update the components registry to claim the event and its '
+                    'file together.',
+                )
+                sys.exit(1)
 
         # Check if admin rights are needed for this configuration
         if platform.system() == 'Windows' and not args.no_admin and check_admin_needed(config, args) and not is_admin():

--- a/tests/e2e/test_hooks_consistency.py
+++ b/tests/e2e/test_hooks_consistency.py
@@ -10,6 +10,7 @@ resolve_config_inheritance(), and the fail-fast exit path of main().
 
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -90,6 +91,86 @@ class TestResolvedCompositionConsistency:
         }
         assert basenames == {'e2e_test_hook.py', 'e2e-hook-config.yaml'}
         assert len(resolved['hooks']['events']) == 2
+
+
+class TestPostSelectionRecheck:
+    """Deselection-induced dangling hook references fail at setup."""
+
+    @staticmethod
+    def _asymmetric_config() -> dict[str, Any]:
+        """Config where a component claims a hook file but not its id-less event."""
+        return {
+            'name': 'Asymmetric Claims',
+            'agents': ['agents/keep.md'],
+            'hooks': {
+                'files': ['hooks/my_hook.py'],
+                'events': [
+                    {'event': 'PostToolUse', 'matcher': 'Edit',
+                     'type': 'command', 'command': 'my_hook.py'},
+                ],
+            },
+            'components': [
+                {'name': 'core', 'includes': {'agents': ['agents/keep.md']}},
+                {'name': 'extra', 'default': False,
+                 'includes': {'hooks': ['hooks/my_hook.py']}},
+            ],
+        }
+
+    def test_main_exits_when_deselection_strands_a_reference(
+        self,
+        e2e_isolated_home: dict[str, Path],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Deselecting the file-claiming component stops setup at the recheck.
+
+        The pre-filter validation passes (the config is self-consistent),
+        but the default selection drops the claimed hooks.files entry while
+        the id-less event survives as mandatory, so the post-selection
+        recheck reports the dangling command reference.
+        """
+        del e2e_isolated_home
+        with patch('scripts.setup_environment.load_config_from_source',
+                   return_value=(self._asymmetric_config(), 'test.yaml')), \
+             patch('sys.argv', ['setup_environment.py', 'test', '--yes', '--skip-install']), \
+             pytest.raises(SystemExit) as exc_info:
+            setup_environment.main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert 'command "my_hook.py" not found in hooks.files' in captured.err
+        assert 'leave hook references dangling' in captured.err
+
+    def test_stranded_file_without_dangling_reference_is_tolerated(self) -> None:
+        """Deselecting an event-claiming component leaves an unused file, not an error."""
+        config: dict[str, Any] = {
+            'name': 'Event Claimed Only',
+            'hooks': {
+                'files': ['hooks/my_hook.py'],
+                'events': [
+                    {'event': 'PostToolUse', 'matcher': 'Edit', 'type': 'command',
+                     'command': 'my_hook.py', 'id': 'claimed-event'},
+                ],
+            },
+            'components': [
+                {'name': 'extra', 'default': False,
+                 'includes': {'hooks': ['claimed-event']}},
+            ],
+        }
+        assert setup_environment.validate_components(config) == []
+        components = [c for c in config['components'] if isinstance(c, dict)]
+        selection = setup_environment.resolve_component_selection(
+            components,
+            argparse.Namespace(
+                yes=True, dry_run=False, select=None, with_=None, without=None,
+            ),
+        )
+        setup_environment.apply_component_selection(config, selection)
+        assert config['hooks']['events'] == []
+        assert config['hooks']['files'] == ['hooks/my_hook.py']
+        errors = setup_environment.validate_hooks_files_consistency(
+            config, require_all_files_used=False,
+        )
+        assert errors == []
 
 
 class TestMainFailsFastOnBrokenHooks:

--- a/tests/test_deselection_reconciliation.py
+++ b/tests/test_deselection_reconciliation.py
@@ -453,3 +453,84 @@ class TestStripHooksFromSettings:
         settings_path = tmp_path / 'settings.json'
         settings_path.write_text('{}')
         assert setup_environment._strip_hooks_from_settings(settings_path, [], hooks_dir) == 0
+
+    def test_pre_quoting_entries_still_match(self, tmp_path: Path) -> None:
+        """Entries written before path quoting existed are still stripped.
+
+        Earlier toolbox versions wrote hook commands with unquoted built
+        paths; the current builder quotes them. The reconciliation matches
+        the command quote-insensitively so upgraded installs still strip
+        deselected hooks instead of orphaning an entry whose file the
+        cleanup deletes.
+        """
+        hooks_dir = tmp_path / 'hookfiles'
+        hooks_dir.mkdir()
+        deselected_events = [
+            {'event': 'PostToolUse', 'matcher': 'Edit', 'type': 'command',
+             'command': 'linter.py', 'id': 'lint'},
+        ]
+        script = (hooks_dir / 'linter.py').as_posix()
+        legacy_entry = {
+            'type': 'command',
+            'command': f'uv run --no-project --python 3.12 {script}',
+        }
+        settings_path = tmp_path / 'settings.json'
+        settings_path.write_text(json.dumps({
+            'hooks': {'PostToolUse': [{'matcher': 'Edit', 'hooks': [legacy_entry]}]},
+        }))
+
+        removed = setup_environment._strip_hooks_from_settings(
+            settings_path, deselected_events, hooks_dir,
+        )
+
+        assert removed == 1
+        final = json.loads(settings_path.read_text())
+        assert final['hooks'] == {}
+
+    def test_genuinely_different_command_is_kept(self, tmp_path: Path) -> None:
+        """A command differing beyond quoting never matches."""
+        hooks_dir = tmp_path / 'hookfiles'
+        hooks_dir.mkdir()
+        deselected_events = [
+            {'event': 'PostToolUse', 'matcher': 'Edit', 'type': 'command',
+             'command': 'linter.py', 'id': 'lint'},
+        ]
+        other_script = (hooks_dir / 'other.py').as_posix()
+        settings_path = tmp_path / 'settings.json'
+        settings_path.write_text(json.dumps({
+            'hooks': {'PostToolUse': [{'matcher': 'Edit', 'hooks': [
+                {'type': 'command', 'command': f'uv run --no-project --python 3.12 {other_script}'},
+            ]}]},
+        }))
+
+        removed = setup_environment._strip_hooks_from_settings(
+            settings_path, deselected_events, hooks_dir,
+        )
+
+        assert removed == 0
+        final = json.loads(settings_path.read_text())
+        assert len(final['hooks']['PostToolUse'][0]['hooks']) == 1
+
+    def test_non_command_field_difference_is_kept(self, tmp_path: Path) -> None:
+        """Quote-insensitive matching still requires every other field to be equal."""
+        hooks_dir = tmp_path / 'hookfiles'
+        hooks_dir.mkdir()
+        deselected_events = [
+            {'event': 'PostToolUse', 'matcher': 'Edit', 'type': 'command',
+             'command': 'linter.py', 'id': 'lint'},
+        ]
+        script = (hooks_dir / 'linter.py').as_posix()
+        settings_path = tmp_path / 'settings.json'
+        settings_path.write_text(json.dumps({
+            'hooks': {'PostToolUse': [{'matcher': 'Edit', 'hooks': [
+                {'type': 'command',
+                 'command': f'uv run --no-project --python 3.12 {script}',
+                 'async': True},
+            ]}]},
+        }))
+
+        removed = setup_environment._strip_hooks_from_settings(
+            settings_path, deselected_events, hooks_dir,
+        )
+
+        assert removed == 0

--- a/tests/test_hooks_consistency_validation.py
+++ b/tests/test_hooks_consistency_validation.py
@@ -282,6 +282,26 @@ class TestValidateHooksFilesConsistency:
         errors = validate_hooks_files_consistency(config)
         assert 'hooks.files[0] must be a string path or URL' in errors
 
+    def test_require_all_files_used_false_skips_unused_rule(self) -> None:
+        """The post-selection mode tolerates stranded files but not dangling refs."""
+        stranded = {
+            'hooks': {
+                'files': ['hooks/a.py', 'hooks/stranded.py'],
+                'events': [{'event': 'PostToolUse', 'command': 'a.py'}],
+            },
+        }
+        assert validate_hooks_files_consistency(stranded, require_all_files_used=False) == []
+        assert validate_hooks_files_consistency(stranded) != []
+
+        dangling = {
+            'hooks': {
+                'files': [],
+                'events': [{'event': 'PostToolUse', 'command': 'dropped.py'}],
+            },
+        }
+        errors = validate_hooks_files_consistency(dangling, require_all_files_used=False)
+        assert any('dropped.py' in e for e in errors)
+
 
 class TestBuildHooksJsonFileReferenceClassification:
     """hooks.files-aware file-reference classification in _build_hooks_json."""


### PR DESCRIPTION
Release-gate round 2 over v7.1.0..main confirmed two release-blocking findings, both verified with live repros by two independent skeptics:

1. **Post-selection validation gap**: `validate_hooks_files_consistency` ran only pre-filter. A component claiming a hook FILE but not its id-less EVENT left, after deselection, a filtered config whose surviving event references a dropped file -- validated clean, broken at hook build time. `main()` now re-validates the filtered config right after `apply_component_selection` with `require_all_files_used=False`: a dangling event/status-line reference is a hard error with actionable guidance, while a stranded unused file remains legitimate deselection residue (covered by the existing hook-claim asymmetry warning).

2. **Upgrade-path reconciliation miss**: `_strip_hooks_from_settings` matched on-disk entries by exact dict equality, so settings.json entries written by pre-quoting versions (unquoted command paths) never matched the newly quoted builds -- deselection deleted the hook file while orphaning its settings entry. The new `_hook_entries_equal` compares the command quote-insensitively and every other field exactly.

Coverage: new unit tests for the relaxed mode and quote-insensitive matching (including negative cases: genuinely different commands and non-command field differences never match), plus E2E for the post-selection recheck (main() exit-1 with the dangling reference listed, and the tolerated stranded-file direction).

Full suite: 2964 passed / 47 platform-skipped; pre-commit clean.