### PR TITLE
Strip a bare ESC alone so Alt-modified consent answers survive

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -7970,13 +7970,17 @@ def _dev_tty_available() -> bool:
 # Terminal escape sequences that can contaminate an interactive read: CSI
 # sequences (including cursor-position reports like ESC[24;80R that a
 # terminal queues in reply to queries from a full-screen prompt session),
-# OSC sequences, charset designators, and any other two-character ESC
-# sequence.
+# OSC sequences, SS3 function keys, and charset designators. Any remaining
+# ESC byte is stripped ALONE: consuming the following character too would
+# turn Alt+y (sent as ESC y by many terminals) into an empty answer and
+# silently decline a clear consent, while a stray residue character merely
+# triggers the re-prompt.
 _TERMINAL_SEQUENCE_PATTERN = re.compile(
     r'\x1b\[[0-9;?<=>]*[A-Za-z~]'
     r'|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)'
+    r'|\x1bO.'
     r'|\x1b[()*+][0-9A-Za-z]'
-    r'|\x1b.',
+    r'|\x1b',
 )
 
 
@@ -7988,7 +7992,8 @@ def _sanitize_interactive_input(raw: str) -> str:
     cursor-position reply left by a full-screen prompt session prefixes the
     user's typed answer, so a visually clean ``y`` reads as
     ``ESC[24;80Ry``. Removes escape sequences and remaining C0 control
-    characters, then strips surrounding whitespace.
+    characters, then strips surrounding whitespace. An Alt-modified key
+    (sent as ESC plus the character) reduces to the bare character.
 
     Args:
         raw: The raw line as read from the interactive device.

--- a/tests/e2e/test_confirmation_tty.py
+++ b/tests/e2e/test_confirmation_tty.py
@@ -17,6 +17,7 @@ platform too, where the tests are skipped.
 
 from __future__ import annotations
 
+import contextlib
 import importlib
 import os
 import select
@@ -68,8 +69,11 @@ def _reap_child(pid: int) -> None:
         if done:
             return
         time.sleep(0.05)
-    os.kill(pid, _SIGKILL)
-    os.waitpid(pid, 0)
+    try:
+        os.kill(pid, _SIGKILL)
+        os.waitpid(pid, 0)
+    except (ProcessLookupError, ChildProcessError, OSError):
+        pass
 
 
 def _run_pty_probe(
@@ -135,7 +139,8 @@ def _run_pty_probe(
                 timed_out = False
                 break
         if timed_out:
-            os.kill(pid, _SIGKILL)
+            with contextlib.suppress(ProcessLookupError, OSError):
+                os.kill(pid, _SIGKILL)
     finally:
         _reap_child(pid)
         os.close(master)

--- a/tests/test_interactive_input_sanitization.py
+++ b/tests/test_interactive_input_sanitization.py
@@ -39,6 +39,13 @@ class TestSanitizeInteractiveInput:
             ('\x1b(By\n', 'y'),
             ('\x01\x02y\x7f\n', 'y'),
             ('\x1b[?2004hy\x1b[?2004l\n', 'y'),
+            # Alt+y arrives as a bare ESC plus the character; the ESC is
+            # stripped alone so the consent survives
+            ('\x1by\n', 'y'),
+            # SS3 function keys (xterm F1) are stripped whole
+            ('\x1bOPy\n', 'y'),
+            ('\x1bOP\n', ''),
+            ('\x1b\n', ''),
             ('', ''),
             ('\x1b[24;80R\n', ''),
         ],
@@ -104,6 +111,23 @@ class TestFlushPendingTerminalInput:
         with patch.object(sys, 'platform', 'linux'), \
              patch.dict(sys.modules, {'termios': None}), \
              patch.object(sys, 'stdin', fake_stdin):
+            _flush_pending_terminal_input()
+
+    def test_windows_branch_drains_console_buffer(self) -> None:
+        """The win32 branch drains msvcrt keystrokes until the buffer is empty."""
+        fake_msvcrt = SimpleNamespace(
+            kbhit=MagicMock(side_effect=[True, True, False]),
+            getwch=MagicMock(return_value='x'),
+        )
+        with patch.object(sys, 'platform', 'win32'), \
+             patch.dict(sys.modules, {'msvcrt': fake_msvcrt}):
+            _flush_pending_terminal_input()
+        assert fake_msvcrt.getwch.call_count == 2
+
+    def test_windows_missing_msvcrt_is_silent(self) -> None:
+        """An unavailable msvcrt module ends the flush without raising."""
+        with patch.object(sys, 'platform', 'win32'), \
+             patch.dict(sys.modules, {'msvcrt': None}):
             _flush_pending_terminal_input()
 
 


### PR DESCRIPTION
Release-gate round 1 over v7.2.0..main confirmed four findings (dual-skeptic verified, one with a 10k-case fuzz):

1. **Alt+y silent decline (minor)**: the `ESC-any` catch-all consumed the character following a lone ESC, so `ESC y` (Alt+y in many terminals, or a truncated query reply adjacent to the answer) sanitized to `''` -- which `confirm_installation` treats as immediate deny, bypassing the re-prompt safety net. The pattern now strips any remaining bare ESC byte ALONE: Alt+y reduces to `y`, and stray residue characters hit the re-prompt instead of a silent misread.
2. **SS3 partial strip (advisory)**: `ESC O P` (xterm F1-F4) lost only two of three bytes, gluing the function-key identifier onto the answer. A dedicated SS3 branch now strips the sequence whole.
3. **Windows msvcrt drain untested (advisory)**: the win32 flush branch gains mocked tests (drain loop termination + missing-module silence).
4. **pty helper kill race (minor)**: timeout-path `os.kill` calls are now guarded so a child exiting exactly at the deadline cannot replace the informative timeout failure with a `ProcessLookupError` traceback.

Full suite: 3007 passed / 53 platform-skipped (pty suite re-verified on Linux via WSL); pre-commit clean.