### PR TITLE
Flush the numbered picker at entry and mark all-garbage lines

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -3550,6 +3550,12 @@ def _prompt_component_selection_numbered(
         Selected names in registry order, or None when input is unavailable
         (the caller keeps the non-interactive selection).
     """
+    # The questionary tier can fail MID-render (mintty's console error)
+    # after its terminal queries went out, so replies may be queued AFTER
+    # the pre-tier flush; discard them before the first read, where an
+    # empty line means confirm
+    _flush_pending_terminal_input()
+
     selected = set(seed)
     while True:
         print()
@@ -8044,6 +8050,32 @@ def _flush_pending_terminal_input() -> None:
         pass
 
 
+# Returned by _read_user_input() for a line whose content was ENTIRELY
+# terminal-report garbage: an empty string must keep meaning a deliberate
+# Enter (the deny default in confirmations, confirm in the picker), so a
+# fully-sanitized-away line surfaces as this answer and lands in each
+# flow's unrecognized-input handling instead. Plain ASCII so the
+# re-prompt warning renders on any console encoding; a user literally
+# typing it gets the identical unrecognized-answer treatment.
+_CONTAMINATED_INPUT_MARKER = '<terminal-noise>'
+
+
+def _finalize_interactive_line(raw: str) -> str:
+    """Sanitize a raw interactive line, marking all-garbage content.
+
+    Args:
+        raw: The raw line as read from the interactive device.
+
+    Returns:
+        The sanitized answer; _CONTAMINATED_INPUT_MARKER when the line had
+        content but every character of it was terminal-report garbage.
+    """
+    cleaned = _sanitize_interactive_input(raw)
+    if not cleaned and raw.strip():
+        return _CONTAMINATED_INPUT_MARKER
+    return cleaned
+
+
 def _read_user_input(prompt: str) -> str:
     """Read one line of user input with /dev/tty fallback for piped stdin.
 
@@ -8053,7 +8085,9 @@ def _read_user_input(prompt: str) -> str:
     KeyboardInterrupt deliberately propagates to the caller so
     interactive flows can distinguish cancellation from an empty answer.
     The returned line is sanitized: terminal escape sequences and control
-    characters never reach the caller.
+    characters never reach the caller, and a line consisting entirely of
+    such garbage returns _CONTAMINATED_INPUT_MARKER rather than
+    masquerading as a deliberate empty answer.
 
     Args:
         prompt: The prompt string to display.
@@ -8065,7 +8099,7 @@ def _read_user_input(prompt: str) -> str:
     # Try stdin first if it's a TTY
     if sys.stdin.isatty():
         try:
-            return _sanitize_interactive_input(input(prompt))
+            return _finalize_interactive_line(input(prompt))
         except EOFError:
             return ''
 
@@ -8076,7 +8110,7 @@ def _read_user_input(prompt: str) -> str:
                 # Write prompt to stderr (stdout may be piped)
                 sys.stderr.write(prompt)
                 sys.stderr.flush()
-                return _sanitize_interactive_input(tty.readline())
+                return _finalize_interactive_line(tty.readline())
         except (OSError, EOFError):
             pass
 

--- a/tests/e2e/test_confirmation_tty.py
+++ b/tests/e2e/test_confirmation_tty.py
@@ -57,6 +57,17 @@ result = setup_environment.confirm_installation(None)
 print('RESULT=' + repr(result))
 '''
 
+NUMBERED_PICKER_PROBE = '''
+import sys, time
+sys.path.insert(0, {repo!r})
+from scripts.setup_environment import _prompt_component_selection_numbered
+time.sleep({delay})
+result = _prompt_component_selection_numbered(
+    ['alpha', 'beta'], {{'alpha': 'Alpha', 'beta': 'Beta'}}, ['alpha', 'beta'],
+)
+print('RESULT=' + repr(result))
+'''
+
 
 def _reap_child(pid: int) -> None:
     """Wait for the probe child, force-killing it if it lingers."""
@@ -183,6 +194,35 @@ class TestDevTtyConfirmationRead:
             delay=1.0,
         )
         assert result == "RESULT='y'"
+
+
+class TestNumberedPickerThroughPty:
+    """The Tier 2 numbered picker through a real pty with piped stdin."""
+
+    def test_pre_queued_garbage_never_confirms_the_seed(self) -> None:
+        """Garbage queued before the picker renders cannot press Enter for the user.
+
+        The questionary tier can fail mid-render with its terminal query
+        replies still queued; the numbered picker flushes them at entry, so
+        the user's real toggle of item 2 plus Enter decides the outcome.
+        """
+        result = _run_pty_probe(
+            NUMBERED_PICKER_PROBE,
+            b'2\n\n',
+            pre_queued=b'\x1b[24;80R',
+            prompt_marker=b'Enter = confirm:',
+            delay=1.0,
+        )
+        assert result == "RESULT=['alpha']"
+
+    def test_contaminated_line_reprompts_not_confirms(self) -> None:
+        """An all-garbage line mid-loop is invalid input, not Enter-confirm."""
+        result = _run_pty_probe(
+            NUMBERED_PICKER_PROBE,
+            b'\x1b[24;80R\n2\n\n',
+            prompt_marker=b'Enter = confirm:',
+        )
+        assert result == "RESULT=['alpha']"
 
 
 class TestConfirmInstallationThroughPty:

--- a/tests/test_interactive_input_sanitization.py
+++ b/tests/test_interactive_input_sanitization.py
@@ -142,6 +142,28 @@ class TestReadUserInputSanitized:
              patch('builtins.input', return_value='\x1b[24;80Ry'):
             assert _read_user_input('prompt: ') == 'y'
 
+    def test_all_garbage_line_returns_marker_not_empty(self) -> None:
+        """A line that was pure terminal garbage never reads as a deliberate Enter.
+
+        An empty answer means deny in confirmations and confirm in the
+        picker, so a fully-sanitized-away line must surface as the
+        contaminated-input marker and hit the unrecognized-answer handling
+        instead.
+        """
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = True
+        with patch.object(sys, 'stdin', fake_stdin), \
+             patch('builtins.input', return_value='\x1b[24;80R'):
+            assert _read_user_input('prompt: ') == setup_environment._CONTAMINATED_INPUT_MARKER
+
+    def test_genuine_enter_still_reads_empty(self) -> None:
+        """A deliberate Enter (whitespace-only line) stays an empty answer."""
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = True
+        with patch.object(sys, 'stdin', fake_stdin), \
+             patch('builtins.input', return_value=''):
+            assert _read_user_input('prompt: ') == ''
+
 
 class TestConfirmationReprompt:
     """Unrecognized answers re-prompt instead of silently cancelling."""
@@ -161,6 +183,13 @@ class TestConfirmationReprompt:
     def test_garbage_then_yes_proceeds(self) -> None:
         """A mangled first answer re-prompts; the second y proceeds."""
         result, confirmation = self._confirm(['[24;80Rq', 'y'])
+        assert result is True
+        assert confirmation.call_count == 2
+
+    def test_contaminated_marker_reprompts_instead_of_cancelling(self) -> None:
+        """An all-garbage line re-prompts; it never counts as the deny default."""
+        marker = setup_environment._CONTAMINATED_INPUT_MARKER
+        result, confirmation = self._confirm([marker, 'y'])
         assert result is True
         assert confirmation.call_count == 2
 


### PR DESCRIPTION
Release-gate round 2 over v7.2.0..main confirmed one release-blocking finding (dual-skeptic verified): the questionary tier can fail MID-render (the real mintty trigger) with its terminal query replies still queued -- after the single pre-tier flush -- and the numbered fallback picker treated a sanitized-to-empty line as "Enter = confirm", silently accepting the untouched seed before the user toggled anything.

Two-part fix:

1. **Tier-2 entry flush**: `_prompt_component_selection_numbered` discards queued terminal input at entry, covering the Tier1-failure handoff (in-loop iterations stay flush-free so legitimate type-ahead between toggle prompts survives).
2. **Contaminated-input marker (class-level fix)**: `_read_user_input` now returns an ASCII `<terminal-noise>` marker for a line whose content was ENTIRELY terminal garbage, so it can never masquerade as a deliberate Enter anywhere: the confirmation re-prompts instead of treating it as the deny default, and the picker reports invalid input instead of confirming. A genuine Enter still reads as empty. This also neutralizes the round-2-rejected-but-real shapes like `ESC O y` sanitizing to empty. The marker is plain ASCII so the re-prompt warning renders on any console encoding (U+FFFD crashed a cp1251 console during development).

Real-pty coverage: the numbered picker driven through an actual pty with pre-queued garbage (flushed at entry, user's toggle decides) and with an all-garbage mid-loop line (invalid-input re-prompt, not confirm).

Full suite: 3010 passed / 55 platform-skipped (pty suite verified on Linux via WSL); pre-commit clean.