### PR TITLE
Route every consent gate through one re-prompting y/N loop

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -6346,17 +6346,13 @@ def prompt_for_credentials(url: str, *, tokens_checked: list[str]) -> dict[str, 
         info(f'  1. Setting environment variable: {tokens_checked[0]}')
         info(f'  2. Passing it on the command line: --env {tokens_checked[0]}=token_here')
 
-        # Ask if they want to enter it now. The read goes through the
-        # shared hardened reader: queued terminal reports are flushed and
-        # escape sequences sanitized, so a clean typed y is never
-        # misread as a decline (the /dev/tty fallback inside is
+        # Ask if they want to enter it now. The shared consent gate
+        # flushes queued terminal reports, sanitizes escape sequences,
+        # and re-prompts on an unrecognized answer, so a clean typed y is
+        # never misread as a decline (the /dev/tty fallback inside is
         # unreachable here because this branch requires a tty stdin).
         try:
-            _flush_pending_terminal_input()
-            response = _read_user_input(
-                'Would you like to enter the token now? (y/N): ',
-            ).lower()
-            if response == 'y':
+            if _ask_yes_no('Would you like to enter the token now? (y/N): '):
                 import getpass
 
                 input_token = getpass.getpass(f'Enter {repo_type.title()} token (will not echo): ')
@@ -8140,6 +8136,32 @@ def _get_user_confirmation(prompt: str) -> str:
         return ''
 
 
+def _ask_yes_no(prompt: str) -> bool:
+    """Ask a y/N consent question with unrecognized-answer re-prompting.
+
+    Up to three attempts: y/yes accepts, a deliberate Enter or n/no
+    declines, and any other answer -- including the contaminated-input
+    marker for an all-garbage line -- warns and re-prompts instead of
+    silently counting as a denial. Every consent gate goes through this
+    single loop so a mangled line is handled identically everywhere.
+
+    Args:
+        prompt: The prompt string to display.
+
+    Returns:
+        True only on explicit consent.
+    """
+    for _ in range(3):
+        response = _get_user_confirmation(prompt)
+        answer = response.lower()
+        if answer in ('y', 'yes'):
+            return True
+        if answer in ('', 'n', 'no'):
+            return False
+        warning(f'Unrecognized answer {response!r}; type y to proceed or n to cancel.')
+    return False
+
+
 def confirm_installation(
     plan: InstallationPlan,
     auto_confirm: bool = False,
@@ -8202,20 +8224,10 @@ def confirm_installation(
         info('  CLAUDE_CODE_TOOLBOX_ENV_AUTH=<val>   Authentication (header:value)')
         return False
 
-    # Interactive confirmation. An unrecognized answer re-prompts instead
-    # of silently cancelling, so a mangled line never reads as a denial;
-    # Enter and n/no cancel immediately.
+    # Interactive confirmation
     print()
-    for _ in range(3):
-        response = _get_user_confirmation(
-            f'{Colors.YELLOW}Proceed with installation? [y/N]: {Colors.NC}',
-        )
-        answer = response.lower()
-        if answer in ('y', 'yes'):
-            return True
-        if answer in ('', 'n', 'no'):
-            break
-        warning(f'Unrecognized answer {response!r}; type y to proceed or n to cancel.')
+    if _ask_yes_no(f'{Colors.YELLOW}Proceed with installation? [y/N]: {Colors.NC}'):
+        return True
 
     info('Installation cancelled by user.')
     return False

--- a/tests/e2e/test_confirmation_tty.py
+++ b/tests/e2e/test_confirmation_tty.py
@@ -93,8 +93,9 @@ def _run_pty_probe(
     *,
     pre_queued: bytes = b'',
     prompt_marker: bytes = b'PROMPT_READY',
+    followup: tuple[bytes, bytes] | None = None,
     delay: float = 0.0,
-) -> str:
+) -> tuple[str, str]:
     """Run a probe in a child whose controlling terminal is a fresh pty.
 
     The child's stdin is redirected to /dev/null before exec, so the
@@ -106,11 +107,17 @@ def _run_pty_probe(
         payload: Bytes written to the pty after the prompt renders.
         pre_queued: Bytes queued into the pty before the prompt renders.
         prompt_marker: Output substring that signals the prompt rendered.
+        followup: Optional second exchange (marker, payload): the payload
+            is written only after the marker appears in output produced
+            AFTER the first payload was sent, because consent re-prompts
+            flush type-ahead.
         delay: Seconds the child sleeps before prompting, giving pre_queued
             bytes time to land in the terminal input queue.
 
     Returns:
-        The RESULT=... line printed by the child.
+        Tuple of the RESULT=... line printed by the child and the child's
+        full decoded output (for asserting which prompts and warnings
+        rendered).
 
     Raises:
         AssertionError: When the probe times out or produces no RESULT line.
@@ -126,6 +133,8 @@ def _run_pty_probe(
 
     buffer = b''
     sent = False
+    followup_sent = False
+    search_from = 0
     timed_out = True
     deadline = time.time() + 60
     try:
@@ -146,6 +155,13 @@ def _run_pty_probe(
             if not sent and prompt_marker in buffer:
                 os.write(master, payload)
                 sent = True
+                search_from = len(buffer)
+            if (
+                sent and not followup_sent and followup is not None
+                and followup[0] in buffer[search_from:]
+            ):
+                os.write(master, followup[1])
+                followup_sent = True
             if b'RESULT=' in buffer and b'\n' in buffer.split(b'RESULT=')[-1]:
                 timed_out = False
                 break
@@ -159,9 +175,10 @@ def _run_pty_probe(
     if timed_out:
         raise AssertionError(f'pty probe timed out; output so far: {buffer!r}')
 
-    for line in buffer.decode('utf-8', 'replace').splitlines():
+    output = buffer.decode('utf-8', 'replace')
+    for line in output.splitlines():
         if 'RESULT=' in line:
-            return line[line.index('RESULT='):]
+            return line[line.index('RESULT='):], output
     raise AssertionError(f'no RESULT line in pty output: {buffer!r}')
 
 
@@ -170,11 +187,13 @@ class TestDevTtyConfirmationRead:
 
     def test_clean_yes(self) -> None:
         """A plain typed y reads back as y."""
-        assert _run_pty_probe(CONFIRMATION_PROBE, b'y\n') == "RESULT='y'"
+        result, _ = _run_pty_probe(CONFIRMATION_PROBE, b'y\n')
+        assert result == "RESULT='y'"
 
     def test_clean_no(self) -> None:
         """A plain typed n reads back as n."""
-        assert _run_pty_probe(CONFIRMATION_PROBE, b'n\n') == "RESULT='n'"
+        result, _ = _run_pty_probe(CONFIRMATION_PROBE, b'n\n')
+        assert result == "RESULT='n'"
 
     def test_contaminated_line_sanitized(self) -> None:
         """A cursor-position report glued to the answer is stripped.
@@ -183,14 +202,20 @@ class TestDevTtyConfirmationRead:
         user sees a clean y, and the unsanitized read returned
         ESC[24;80Ry.
         """
-        assert _run_pty_probe(CONFIRMATION_PROBE, b'\x1b[24;80Ry\n') == "RESULT='y'"
+        result, _ = _run_pty_probe(CONFIRMATION_PROBE, b'\x1b[24;80Ry\n')
+        assert result == "RESULT='y'"
 
     def test_pre_queued_garbage_flushed(self) -> None:
-        """Bytes queued before the prompt renders never satisfy the read."""
-        result = _run_pty_probe(
+        """A garbage line queued before the prompt renders is discarded.
+
+        The queued report forms its own complete line so an unflushed read
+        would consume it as a standalone answer; the flush makes the read
+        start at the user's y with no detour through the marker handling.
+        """
+        result, _ = _run_pty_probe(
             CONFIRMATION_PROBE,
             b'y\n',
-            pre_queued=b'\x1b[24;80R',
+            pre_queued=b'\x1b[24;80R\n',
             delay=1.0,
         )
         assert result == "RESULT='y'"
@@ -205,24 +230,29 @@ class TestNumberedPickerThroughPty:
         The questionary tier can fail mid-render with its terminal query
         replies still queued; the numbered picker flushes them at entry, so
         the user's real toggle of item 2 plus Enter decides the outcome.
+        The queued report forms its own complete line, and the absence of
+        the invalid-input warning proves the flush discarded it rather than
+        the marker handling absorbing it.
         """
-        result = _run_pty_probe(
+        result, output = _run_pty_probe(
             NUMBERED_PICKER_PROBE,
             b'2\n\n',
-            pre_queued=b'\x1b[24;80R',
+            pre_queued=b'\x1b[24;80R\n',
             prompt_marker=b'Enter = confirm:',
             delay=1.0,
         )
         assert result == "RESULT=['alpha']"
+        assert 'Invalid input' not in output
 
     def test_contaminated_line_reprompts_not_confirms(self) -> None:
         """An all-garbage line mid-loop is invalid input, not Enter-confirm."""
-        result = _run_pty_probe(
+        result, output = _run_pty_probe(
             NUMBERED_PICKER_PROBE,
             b'\x1b[24;80R\n2\n\n',
             prompt_marker=b'Enter = confirm:',
         )
         assert result == "RESULT=['alpha']"
+        assert 'Invalid input' in output
 
 
 class TestConfirmInstallationThroughPty:
@@ -230,16 +260,31 @@ class TestConfirmInstallationThroughPty:
 
     def test_contaminated_yes_proceeds(self) -> None:
         """The full consent flow accepts a contaminated y."""
-        result = _run_pty_probe(
+        result, _ = _run_pty_probe(
             CONFIRM_INSTALLATION_PROBE,
             b'\x1b[24;80Ry\n',
             prompt_marker=b'Proceed with installation?',
         )
         assert result == 'RESULT=True'
 
+    def test_all_garbage_line_reprompts_then_accepts(self) -> None:
+        """A pure-garbage line re-prompts; a y at the re-prompt proceeds.
+
+        The y is sent only after the warning renders, because the
+        re-prompt flushes type-ahead by design.
+        """
+        result, output = _run_pty_probe(
+            CONFIRM_INSTALLATION_PROBE,
+            b'\x1b[24;80R\n',
+            prompt_marker=b'Proceed with installation?',
+            followup=(b'Unrecognized answer', b'y\n'),
+        )
+        assert result == 'RESULT=True'
+        assert 'Unrecognized answer' in output
+
     def test_enter_cancels(self) -> None:
         """The default deny still cancels through the real path."""
-        result = _run_pty_probe(
+        result, _ = _run_pty_probe(
             CONFIRM_INSTALLATION_PROBE,
             b'\n',
             prompt_marker=b'Proceed with installation?',

--- a/tests/test_interactive_input_sanitization.py
+++ b/tests/test_interactive_input_sanitization.py
@@ -210,3 +210,46 @@ class TestConfirmationReprompt:
         result, confirmation = self._confirm([''])
         assert result is False
         assert confirmation.call_count == 1
+
+
+class TestCredentialsGateReprompt:
+    """The credentials y/N gate handles a garbled line like the confirmation.
+
+    Before the shared _ask_yes_no gate, any answer other than a literal y
+    -- including the contaminated-input marker -- silently declined
+    authentication with no warning.
+    """
+
+    @staticmethod
+    def _prompt(responses: list[str]) -> tuple[dict[str, str], MagicMock]:
+        gate = MagicMock(side_effect=responses)
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = True
+        with patch.object(sys, 'stdin', fake_stdin), \
+             patch.object(setup_environment, '_get_user_confirmation', gate), \
+             patch('getpass.getpass', return_value='tok123'), \
+             patch.dict('os.environ', {}, clear=True):
+            headers = setup_environment.prompt_for_credentials(
+                'https://gitlab.com/repo', tokens_checked=['GITLAB_TOKEN'],
+            )
+        return headers, gate
+
+    def test_marker_reprompts_then_yes_reaches_token_entry(self) -> None:
+        """An all-garbage line re-prompts; the second y collects the token."""
+        marker = setup_environment._CONTAMINATED_INPUT_MARKER
+        headers, gate = self._prompt([marker, 'y'])
+        assert headers == {'PRIVATE-TOKEN': 'tok123'}
+        assert gate.call_count == 2
+
+    def test_persistent_garbage_declines(self) -> None:
+        """Three unrecognized answers decline authentication."""
+        marker = setup_environment._CONTAMINATED_INPUT_MARKER
+        headers, gate = self._prompt([marker, marker, marker])
+        assert headers == {}
+        assert gate.call_count == 3
+
+    def test_explicit_no_declines_on_first_read(self) -> None:
+        """An explicit n declines without re-prompting."""
+        headers, gate = self._prompt(['n'])
+        assert headers == {}
+        assert gate.call_count == 1


### PR DESCRIPTION
Release-gate round 3 over v7.2.0..main confirmed two release-blocking findings (dual-skeptic verified; the second was proven by re-running the test against deliberately un-fixed code):

1. **Credentials gate silent decline**: `prompt_for_credentials` checked only `response == 'y'`, so an all-garbage line (the contaminated-input marker) silently declined authentication with no warning -- while the sibling confirmation gate re-prompted. The new shared `_ask_yes_no()` loop now backs BOTH gates: y/yes accepts, Enter/n/no declines, anything else warns and re-prompts (3 attempts). One consent behavior everywhere.

2. **Non-discriminating flush tests**: the pty flush regression tests passed with or without the flush fix, because the pre-queued garbage had no trailing newline and glued onto the payload's first line -- sanitizing to the same answer either way. The garbage now forms its own complete line, and the probes assert the presence/absence of the re-prompt warnings in the full pty output (`Unrecognized answer` / `Invalid input`), which diverges between fixed and unfixed code. The probe gained a two-exchange mode (send the follow-up answer only after the warning renders) because consent re-prompts flush type-ahead by design -- itself a confirmation the flush works.

New coverage: credentials-gate marker re-prompt unit tests, confirm_installation garbage-then-accept through a real pty, discriminating flush assertions on both pty flush tests.

Full suite: 3013 passed / 56 platform-skipped; pty suite stable across repeated Linux runs (WSL); pre-commit clean.