### PR TITLE
Strip DCS, SOS, PM, and APC string sequences whole

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -7972,14 +7972,16 @@ def _dev_tty_available() -> bool:
 # Terminal escape sequences that can contaminate an interactive read: CSI
 # sequences (including cursor-position reports like ESC[24;80R that a
 # terminal queues in reply to queries from a full-screen prompt session),
-# OSC sequences, SS3 function keys, and charset designators. Any remaining
-# ESC byte is stripped ALONE: consuming the following character too would
+# OSC sequences, DCS/SOS/PM/APC string sequences (terminal capability and
+# graphics-protocol replies, body terminated by ST), SS3 function keys,
+# and charset designators. Any remaining ESC byte is stripped ALONE: consuming the following character too would
 # turn Alt+y (sent as ESC y by many terminals) into an empty answer and
 # silently decline a clear consent, while a stray residue character merely
 # triggers the re-prompt.
 _TERMINAL_SEQUENCE_PATTERN = re.compile(
     r'\x1b\[[0-9;?<=>]*[A-Za-z~]'
     r'|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)'
+    r'|\x1b[PX^_][^\x1b]*(?:\x1b\\)?'
     r'|\x1bO.'
     r'|\x1b[()*+][0-9A-Za-z]'
     r'|\x1b',

--- a/tests/test_interactive_input_sanitization.py
+++ b/tests/test_interactive_input_sanitization.py
@@ -45,6 +45,11 @@ class TestSanitizeInteractiveInput:
             # SS3 function keys (xterm F1) are stripped whole
             ('\x1bOPy\n', 'y'),
             ('\x1bOP\n', ''),
+            # DCS/APC/PM string sequences (capability and graphics replies)
+            # are stripped whole including their ST terminator
+            ('\x1bP1$r0m\x1b\\y\n', 'y'),
+            ('\x1b_Gi=1;OK\x1b\\y\n', 'y'),
+            ('\x1b^privacy\x1b\\\n', ''),
             ('\x1b\n', ''),
             ('', ''),
             ('\x1b[24;80R\n', ''),


### PR DESCRIPTION
Release-gate round 5 (final) over v7.2.0..main confirmed one advisory finding (dual-skeptic verified with live repros): DCS/APC/PM string sequences (`ESC P/_/^ ... ST` -- DECRPSS capability replies, kitty-graphics acknowledgments) were not stripped whole; only the leading bare ESC was removed, leaving residue like `P1$r0m\y` glued to the answer. Both skeptics verified the residue can never equal an accept/deny token, so the consent outcome was always a re-prompt -- never a wrong verdict -- making this a coverage-completeness and warning-readability fix: the pattern gains a `\x1b[PX^_][^\x1b]*(?:\x1b\\)?` alternative and the sanitizer corpus gains DCS/APC/PM cases. Full suite: 3016 passed / 56 platform-skipped; pty suite green on Linux (WSL); pre-commit clean.