### PR TITLE
Keep the terminal-input flush best-effort on non-standard streams

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -8030,21 +8030,24 @@ def _flush_pending_terminal_input() -> None:
 
             while msvcrt.kbhit():
                 msvcrt.getwch()
-        except (ImportError, OSError):
+        except (ImportError, OSError, AttributeError, TypeError):
             pass
         return
     try:
         import termios
     except ImportError:
         return
-    # termios.error subclasses Exception directly, not OSError
+    # termios.error subclasses Exception directly, not OSError; a
+    # non-standard stdin object (a test double, a wrapped stream) can
+    # raise TypeError or AttributeError from fileno(), and best-effort
+    # means none of these may escape
     try:
         if sys.stdin.isatty():
             termios.tcflush(sys.stdin.fileno(), termios.TCIFLUSH)
         else:
             with open('/dev/tty') as tty:
                 termios.tcflush(tty.fileno(), termios.TCIFLUSH)
-    except (OSError, ValueError, termios.error):
+    except (OSError, ValueError, AttributeError, TypeError, termios.error):
         pass
 
 

--- a/tests/e2e/test_confirmation_tty.py
+++ b/tests/e2e/test_confirmation_tty.py
@@ -270,14 +270,15 @@ class TestConfirmInstallationThroughPty:
     def test_all_garbage_line_reprompts_then_accepts(self) -> None:
         """A pure-garbage line re-prompts; a y at the re-prompt proceeds.
 
-        The y is sent only after the warning renders, because the
-        re-prompt flushes type-ahead by design.
+        The y is sent only after the SECOND consent prompt renders: the
+        re-prompt flushes type-ahead before rendering, so synchronizing on
+        the warning alone races the flush and can discard the answer.
         """
         result, output = _run_pty_probe(
             CONFIRM_INSTALLATION_PROBE,
             b'\x1b[24;80R\n',
             prompt_marker=b'Proceed with installation?',
-            followup=(b'Unrecognized answer', b'y\n'),
+            followup=(b'Proceed with installation?', b'y\n'),
         )
         assert result == 'RESULT=True'
         assert 'Unrecognized answer' in output

--- a/tests/e2e/test_launcher_scripts.py
+++ b/tests/e2e/test_launcher_scripts.py
@@ -384,6 +384,11 @@ class TestGeneratedScriptSyntax:
         )
         assert completed.returncode == 0, f'bash -n rejected launch.sh:\n{completed.stderr}'
 
+    @pytest.mark.skipif(
+        sys.platform != 'win32',
+        reason='start.ps1 is generated only on Windows; on POSIX the returned '
+               'tuple carries shell launchers',
+    )
     def test_start_ps1_parses_without_errors(
         self,
         e2e_isolated_home: dict[str, Path],


### PR DESCRIPTION
Fixes the three defects behind the POSIX CI failures that were wrongly merged past in the interactive-input series (and re-releases them properly):

1. `_flush_pending_terminal_input()` violated its own never-raise contract: a stdin object whose `fileno()` returns a non-integer raised `TypeError` through the flush. Both platform branches now also swallow `TypeError`/`AttributeError`, keeping consent prompts alive on any stream shape.
2. `test_start_ps1_parses_without_errors` ran on POSIX, where `create_launcher_script()` never generates `start.ps1` and the returned tuple carries shell launchers -- the PowerShell parser was handed `launch.sh`. The test is Windows-only now.
3. `test_all_garbage_line_reprompts_then_accepts` synchronized its second answer on the warning text, racing the re-prompt's own type-ahead flush, which could discard the answer. It now waits for the second consent prompt to render.