### PR TITLE
Extend hooks to the full Claude Code hook configuration contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,22 +316,23 @@ Retry logic for GitHub API rate limiting: 10 attempts with linear additive backo
 
 ### Hooks Configuration Structure
 
-Hooks support four types matching the official Claude Code hooks specification:
+Hooks support five types matching the official Claude Code hooks specification:
 
-| Type      | Required Field | Description                                        |
-|-----------|----------------|----------------------------------------------------|
-| `command` | `command`      | Executes a shell command or script (default)       |
-| `http`    | `url`          | Sends an HTTP POST request                         |
-| `prompt`  | `prompt`       | Single-turn LLM evaluation (no tool access)        |
-| `agent`   | `prompt`       | Spawns a subagent with tool access for evaluation  |
+| Type       | Required Fields  | Description                                        |
+|------------|------------------|----------------------------------------------------|
+| `command`  | `command`        | Executes a shell command or script (default)       |
+| `http`     | `url`            | Sends an HTTP POST request                         |
+| `prompt`   | `prompt`         | Single-turn LLM evaluation (no tool access)        |
+| `agent`    | `prompt`         | Spawns a subagent with tool access for evaluation  |
+| `mcp_tool` | `server`, `tool` | Calls a tool on an already-configured MCP server   |
 
-Common fields available on all types: `if`, `status-message`, `once`, `timeout`.
+Common fields available on all types: `if`, `status-message`, `once`, `timeout` (must be positive; non-positive values fail model validation and are warn-skipped at runtime).
 
-Only `command` hooks reference files from `hooks.files`. Other types are pure pass-through. `_apply_common_hook_fields()` applies shared fields to all types.
+Only `command` hooks reference files from `hooks.files`. Other types are pure pass-through. `_apply_common_hook_fields()` applies shared fields to all types. Event names are checked against `HOOK_EVENT_NAMES` (31 names Claude Code 2.1.238 recognizes; byte-identical frozensets in `setup_environment.py` and `environment_config.py`, parity enforced by `tests/scripts/models/test_hook_event_names_parity.py`): an unknown name warns but still installs, so configs written for newer Claude Code releases keep working. `_build_hooks_json()` also warns about (and ignores) YAML keys a hook type does not support; the `HookEvent` model rejects them outright (`extra='forbid'`).
 
 **Consistency validation:** the model's `validate_hooks_files_consistency` (skipped under `inherit`) and its runtime twin of the same name in `setup_environment.py` (running on the resolved config at the `main()` choke point) enforce the same rules: every `hooks.files` entry is referenced by a command hook or `status-line`, every command hook's `command`/`config` and the `status-line` `file`/`config` exist in `hooks.files` (`command` and `status-line.file` are exact basename matches; `config` references match after query-strip plus basename extraction), and `status-line` without `hooks` is an error.
 
-**Command construction:** the shared `_build_file_command()` builds hook and `statusLine` command strings identically (Python via `uv run`, JavaScript via `node`, anything else executes directly) with built paths double-quoted so spaced hooks directories survive shell word-splitting. In `_build_hooks_json()`, a command is a file reference when it matches a `hooks.files` basename (even with spaces) or contains no spaces; anything else passes through as-is.
+**Command construction:** the shared `_build_file_command()` builds hook and `statusLine` command strings identically (launcher selection via `_hook_launcher_args()`: Python via `uv run`, JavaScript via `node`, anything else executes directly) with built paths double-quoted so spaced hooks directories survive shell word-splitting. In `_build_hooks_json()`, a command is a file reference when it matches a `hooks.files` basename (even with spaces) or contains no spaces; anything else passes through as-is. When a command hook declares `args`, `_build_file_exec_command()` produces the exec form instead: the launcher executable becomes `command` and the launcher arguments, resolved script path, config path, and user `args` become the unquoted `args` list (no shell is involved; `shell` is warned about and dropped). The exec-form fold applies ONLY to commands listed in `hooks.files`; any unlisted command -- bare name or absolute path, with or without spaces -- stays verbatim as the executable (the shell form's no-space heuristic never reroutes it into the hooks directory).
 
 ```yaml
 hooks:
@@ -346,9 +347,10 @@ hooks:
 ```
 
 Type-specific fields (setting a field on the wrong type produces a validation error):
-- **command**: `command` (required), `config`, `async`, `shell`
-- **http**: `url` (required), `headers`, `allowed-env-vars`
-- **prompt/agent**: `prompt` (required), `model`
+- **command**: `command` (required), `config`, `args` (exec form; conflicts with `shell`), `async`, `async-rewake` (emitted as `asyncRewake`), `shell`
+- **http**: `url` (required; must be an http/https URL), `headers`, `allowed-env-vars`
+- **prompt/agent**: `prompt` (required), `model`; prompt only: `continue-on-block` (emitted as `continueOnBlock`)
+- **mcp_tool**: `server` (required), `tool` (required), `input`
 
 ### Two-Layer Naming Convention (Sub-Keys)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Define your complete Claude Code environment in a single YAML file -- custom age
 - **Rules** -- user-scope rule files for coding standards, security policies, and project conventions
 - **Skills** -- multi-file skill packages for complex agent capabilities
 - **System prompts** -- replace or append to the default Claude Code prompt
-- **Hooks** -- four hook types: command (shell scripts), HTTP (webhooks), prompt (LLM evaluation), and agent (subagent with tools)
+- **Hooks** -- five hook types: command (shell scripts, shell or exec form), HTTP (webhooks), prompt (LLM evaluation), agent (subagent with tools), and MCP tool (a tool on a configured MCP server)
 - **User and global settings** -- `user-settings` is raw `settings.json` content (camelCase keys) and `global-config` is raw `~/.claude.json` content, covering model selection, permissions, effort levels, thinking mode, environment variables, and every other Claude Code setting
 - **Status line** -- custom status bar scripts for real-time session information
 - **Configuration inheritance** -- extend and override parent configurations with selective per-key merge

--- a/docs/environment-configuration-guide.md
+++ b/docs/environment-configuration-guide.md
@@ -912,7 +912,7 @@ status-line:
 
 ### Hooks
 
-Event-driven hooks that run automatically during Claude Code sessions. Four hook types are supported: `command`, `http`, `prompt`, and `agent`.
+Event-driven hooks that run automatically during Claude Code sessions. Five hook types are supported: `command`, `http`, `prompt`, `agent`, and `mcp_tool`.
 
 - **Type:** `Hooks | None`
 - **Default:** `None`
@@ -923,38 +923,41 @@ Event-driven hooks that run automatically during Claude Code sessions. Four hook
 
 #### Hook Types
 
-| Type      | Description                                            | Required Field |
-|-----------|--------------------------------------------------------|----------------|
-| `command` | Executes a shell command or script (default)           | `command`      |
-| `http`    | Sends an HTTP POST request to a URL                    | `url`          |
-| `prompt`  | Single-turn LLM evaluation with no tool access         | `prompt`       |
-| `agent`   | Spawns a subagent with tool access for evaluation      | `prompt`       |
+| Type       | Description                                            | Required Fields  |
+|------------|--------------------------------------------------------|------------------|
+| `command`  | Executes a shell command or script (default)           | `command`        |
+| `http`     | Sends an HTTP POST request to a URL                    | `url`            |
+| `prompt`   | Single-turn LLM evaluation with no tool access         | `prompt`         |
+| `agent`    | Spawns a subagent with tool access for evaluation      | `prompt`         |
+| `mcp_tool` | Calls a tool on an already-configured MCP server       | `server`, `tool` |
 
 #### Common Fields (All Hook Types)
 
-These fields apply to all four hook types:
+These fields apply to all five hook types:
 
 | Field            | YAML Key         | Type   | Required | Description                                                                                                                                                          |
 |------------------|------------------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `event`          | `event`          | `str`  | Yes      | Event name (for example, `PreToolUse`, `PostToolUse`, `Notification`)                                                                                                |
+| `event`          | `event`          | `str`  | Yes      | Event name (for example, `PreToolUse`, `PostToolUse`, `Notification`); see [Recognized Event Names](#recognized-event-names)                                         |
 | `matcher`        | `matcher`        | `str`  | No       | Regex pattern for matching (default: `""`)                                                                                                                           |
-| `type`           | `type`           | `str`  | No       | Hook type: `command`, `http`, `prompt`, or `agent` (default: `command`)                                                                                              |
+| `type`           | `type`           | `str`  | No       | Hook type: `command`, `http`, `prompt`, `agent`, or `mcp_tool` (default: `command`)                                                                                  |
 | `if`             | `if`             | `str`  | No       | Permission rule syntax filter (for example, `"Bash(git *)"`, `"Edit(*.ts)"`)                                                                                         |
 | `status-message` | `status-message` | `str`  | No       | Custom spinner message displayed while the hook runs                                                                                                                 |
 | `once`           | `once`           | `bool` | No       | If true, runs only once per session then is removed (skills only)                                                                                                    |
-| `timeout`        | `timeout`        | `int`  | No       | Timeout in seconds (defaults vary by type: 600 for command, 30 for prompt, 60 for agent)                                                                             |
+| `timeout`        | `timeout`        | `int`  | No       | Timeout in seconds; must be positive (defaults vary by type: 600 for command, 30 for prompt, 60 for agent)                                                           |
 | `id`             | `id`             | `str`  | No       | Stable identifier used solely as a [`components`](#components) selector for this event; unique across events when present, never written to the generated hooks JSON |
 
 #### Type-Specific Fields
 
 ##### Command Hook Fields
 
-| Field     | YAML Key  | Type   | Required | Description                                                                                 |
-|-----------|-----------|--------|----------|---------------------------------------------------------------------------------------------|
-| `command` | `command` | `str`  | Yes      | Script filename (must exist in `hooks.files`)                                               |
-| `config`  | `config`  | `str`  | No       | Config file reference (must exist in `hooks.files`). Toolbox-specific: appended as argument |
-| `async`   | `async`   | `bool` | No       | If true, runs the command in the background without blocking                                |
-| `shell`   | `shell`   | `str`  | No       | Shell to use: `"bash"` (default) or `"powershell"`                                          |
+| Field          | YAML Key       | Type        | Required | Description                                                                                 |
+|----------------|----------------|-------------|----------|---------------------------------------------------------------------------------------------|
+| `command`      | `command`      | `str`       | Yes      | Script filename (must exist in `hooks.files`)                                               |
+| `config`       | `config`       | `str`       | No       | Config file reference (must exist in `hooks.files`). Toolbox-specific: appended as argument |
+| `args`         | `args`         | `list[str]` | No       | Argument list switching the command to exec form (see [Command Hooks](#command-hooks))      |
+| `async`        | `async`        | `bool`      | No       | If true, runs the command in the background without blocking                                |
+| `async-rewake` | `async-rewake` | `bool`      | No       | If true, runs in the background and wakes the model on exit code 2; implies `async`         |
+| `shell`        | `shell`        | `str`       | No       | Shell to use: `"bash"` (default) or `"powershell"`; cannot be combined with `args`          |
 
 ##### HTTP Hook Fields
 
@@ -966,38 +969,63 @@ These fields apply to all four hook types:
 
 ##### Prompt and Agent Hook Fields
 
-| Field    | YAML Key | Type  | Required | Description                                       |
-|----------|----------|-------|----------|---------------------------------------------------|
-| `prompt` | `prompt` | `str` | Yes      | Prompt text for LLM evaluation                    |
-| `model`  | `model`  | `str` | No       | Model to use for the evaluation                   |
+| Field               | YAML Key            | Type   | Required | Description                                                                                     |
+|---------------------|---------------------|--------|----------|-------------------------------------------------------------------------------------------------|
+| `prompt`            | `prompt`            | `str`  | Yes      | Prompt text for LLM evaluation                                                                  |
+| `model`             | `model`             | `str`  | No       | Model to use for the evaluation                                                                 |
+| `continue-on-block` | `continue-on-block` | `bool` | No       | Prompt hooks only: a deny feeds its reason back to the agent and the turn continues (see below) |
+
+##### MCP Tool Hook Fields
+
+| Field    | YAML Key | Type   | Required | Description                                                                                    |
+|----------|----------|--------|----------|------------------------------------------------------------------------------------------------|
+| `server` | `server` | `str`  | Yes      | Name of an already-configured MCP server to invoke                                             |
+| `tool`   | `tool`   | `str`  | Yes      | Name of the tool on that server to call                                                        |
+| `input`  | `input`  | `dict` | No       | Arguments passed to the tool; string values support `${path}` interpolation from the hook JSON |
 
 #### Field Matrix
 
 Complete required/forbidden field matrix across all hook types:
 
-| Field              | `command` | `http`    | `prompt`  | `agent`   |
-|--------------------|-----------|-----------|-----------|-----------|
-| `command`          | REQUIRED  | FORBIDDEN | FORBIDDEN | FORBIDDEN |
-| `config`           | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN |
-| `async`            | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN |
-| `shell`            | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN |
-| `url`              | FORBIDDEN | REQUIRED  | FORBIDDEN | FORBIDDEN |
-| `headers`          | FORBIDDEN | Optional  | FORBIDDEN | FORBIDDEN |
-| `allowed-env-vars` | FORBIDDEN | Optional  | FORBIDDEN | FORBIDDEN |
-| `prompt`           | FORBIDDEN | FORBIDDEN | REQUIRED  | REQUIRED  |
-| `model`            | FORBIDDEN | FORBIDDEN | Optional  | Optional  |
-| `if`               | Optional  | Optional  | Optional  | Optional  |
-| `status-message`   | Optional  | Optional  | Optional  | Optional  |
-| `once`             | Optional  | Optional  | Optional  | Optional  |
-| `timeout`          | Optional  | Optional  | Optional  | Optional  |
+| Field               | `command` | `http`    | `prompt`  | `agent`   | `mcp_tool` |
+|---------------------|-----------|-----------|-----------|-----------|------------|
+| `command`           | REQUIRED  | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN  |
+| `config`            | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN  |
+| `args`              | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN  |
+| `async`             | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN  |
+| `async-rewake`      | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN  |
+| `shell`             | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN  |
+| `url`               | FORBIDDEN | REQUIRED  | FORBIDDEN | FORBIDDEN | FORBIDDEN  |
+| `headers`           | FORBIDDEN | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN  |
+| `allowed-env-vars`  | FORBIDDEN | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN  |
+| `prompt`            | FORBIDDEN | FORBIDDEN | REQUIRED  | REQUIRED  | FORBIDDEN  |
+| `model`             | FORBIDDEN | FORBIDDEN | Optional  | Optional  | FORBIDDEN  |
+| `continue-on-block` | FORBIDDEN | FORBIDDEN | Optional  | FORBIDDEN | FORBIDDEN  |
+| `server`            | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN | REQUIRED   |
+| `tool`              | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN | REQUIRED   |
+| `input`             | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN | Optional   |
+| `if`                | Optional  | Optional  | Optional  | Optional  | Optional   |
+| `status-message`    | Optional  | Optional  | Optional  | Optional  | Optional   |
+| `once`              | Optional  | Optional  | Optional  | Optional  | Optional   |
+| `timeout`           | Optional  | Optional  | Optional  | Optional  | Optional   |
 
-Setting a field marked FORBIDDEN on a hook type produces a validation error.
+Setting a field marked FORBIDDEN on a hook type produces a validation error. Two combinations are additionally rejected on command hooks: `shell` together with `args` (exec form spawns the executable without a shell), and a non-positive `timeout` on any hook type.
+
+#### Recognized Event Names
+
+Claude Code 2.1.238 recognizes exactly these hook event names and rejects any other name at configuration load time:
+
+`ConfigChange`, `CwdChanged`, `DirectoryAdded`, `Elicitation`, `ElicitationResult`, `FileChanged`, `InstructionsLoaded`, `MessageDisplay`, `Notification`, `PermissionDenied`, `PermissionRequest`, `PostCompact`, `PostToolBatch`, `PostToolUse`, `PostToolUseFailure`, `PreCompact`, `PreToolUse`, `SessionEnd`, `SessionStart`, `Setup`, `Stop`, `StopFailure`, `SubagentStart`, `SubagentStop`, `TaskCompleted`, `TaskCreated`, `TeammateIdle`, `UserPromptExpansion`, `UserPromptSubmit`, `WorktreeCreate`, `WorktreeRemove`
+
+The toolbox warns about an event name outside this set but still writes it, so a configuration written for a newer Claude Code release keeps installing; a typo surfaces as the warning at setup time and as a load-time rejection by Claude Code.
 
 #### Command Hooks
 
 Execute a script file when the event fires. The `command` field must reference a filename listed in `hooks.files`. The toolbox processes command paths by prepending the appropriate runtime (`uv run` for `.py`, `node` for `.js`/`.mjs`/`.cjs`). Built file paths are double-quoted in the generated command, so hooks directories containing spaces (for example a Windows home like `C:/Users/John Smith`) work in every shell.
 
 The `config` field is a toolbox-specific extension: when set, the config file path is appended as an argument to the command. This field is not part of the official Claude Code hooks specification.
+
+Setting `args` switches the hook to exec form: Claude Code resolves `command` as an executable and spawns it directly with the argument list, without any shell. The toolbox folds the launcher into that shape -- for a Python script it emits `command: "uv"` with `run --no-project --python 3.12`, the resolved script path, the config path (when set), and your `args` entries as the argument list; for a JavaScript script it emits `command: "node"` the same way. No element is quoted, because there is no shell to word-split, so spaced hooks directories are safe in exec form too. `shell` cannot be combined with `args`.
 
 ```yaml
 hooks:
@@ -1010,10 +1038,16 @@ hooks:
       type: "command"
       command: "linter.py"
       config: "linter-config.yaml"
+    - event: "PostToolUse"
+      matcher: "Write"
+      type: "command"
+      command: "linter.py"
+      args: ["--fix", "--level", "2"]
     - event: "Notification"
       type: "command"
       command: "linter.py"
       async: true
+      async-rewake: true
       shell: "bash"
       status-message: "Running notification handler..."
 ```
@@ -1042,6 +1076,8 @@ hooks:
 
 Send a prompt to the LLM for single-turn evaluation when the event fires. No tool access is available.
 
+By default, a denying evaluation (`ok: false`) ends the turn. With `continue-on-block: true`, the deny still blocks the matched action, but its reason is fed back to the agent and the turn continues, so a steering hook can redirect the agent within the same turn. Claude Code supports this setting although its public hooks reference does not document it (verified against Claude Code 2.1.238); it applies to prompt hooks only.
+
 ```yaml
 hooks:
   events:
@@ -1050,6 +1086,7 @@ hooks:
       type: "prompt"
       prompt: "Check if this bash command is safe to execute"
       model: "sonnet"
+      continue-on-block: true
       timeout: 30
 ```
 
@@ -1070,9 +1107,26 @@ hooks:
       once: true
 ```
 
+#### MCP Tool Hooks
+
+Call a tool on an already-configured MCP server when the event fires. The server must be connected in the session the hook runs in (for example, one declared under [`mcp-servers`](#mcp-servers)); the toolbox passes `server`, `tool`, and `input` through to the generated configuration as-is. String values inside `input` support `${path}` interpolation from the hook input JSON.
+
+```yaml
+hooks:
+  events:
+    - event: "PostToolUse"
+      matcher: "Edit"
+      type: "mcp_tool"
+      server: "linter"
+      tool: "lint_file"
+      input:
+        file_path: "${tool_input.file_path}"
+      timeout: 20
+```
+
 #### File Consistency Rules
 
-Hook file references are validated for **command hooks only**. HTTP, prompt, and agent hooks do not use file references and are excluded from file consistency validation.
+Hook file references are validated for **command hooks only**. HTTP, prompt, agent, and MCP tool hooks do not use file references and are excluded from file consistency validation.
 
 The rules are enforced in two layers. The Pydantic model validates configurations that do not declare `inherit`; for a config that declares `inherit`, cross-references are decidable only on the resolved composition, so the model skips them. The setup script then validates every fully resolved configuration at runtime -- before the admin check, remote file validation, and any installation work -- listing all violations and exiting with code 1. When component selection filters the configuration, the setup re-validates the filtered result: a dangling event or `status-line` reference is still an error, while a file stranded by a deselected component is tolerated (see [Component Selection](#components)). A composition whose hook events or status-line reference a missing hook file therefore fails at setup time, not at hook execution.
 

--- a/scripts/models/environment_config.py
+++ b/scripts/models/environment_config.py
@@ -4,6 +4,7 @@ Defines the schema for Claude Code environment YAML files.
 """
 
 import re
+import warnings
 from pathlib import PurePath
 from typing import Any
 from typing import Literal
@@ -112,6 +113,47 @@ GLOBAL_CONFIG_SETTINGS_ONLY_KEYS: frozenset[str] = frozenset({
 
 # Environment variable names: letters, digits, underscores; no leading digit
 ENV_VAR_NAME_PATTERN: re.Pattern[str] = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+# Hook event names recognized by Claude Code 2.1.238; Claude Code rejects any
+# other name at configuration load time. The HookEvent model warns (rather
+# than errors) on names outside this set so a configuration written for a
+# newer Claude Code release keeps installing. Inline copy of
+# HOOK_EVENT_NAMES in setup_environment.py (standalone script policy
+# prevents cross-import); parity enforced by
+# tests/scripts/models/test_hook_event_names_parity.py.
+HOOK_EVENT_NAMES: frozenset[str] = frozenset({
+    'ConfigChange',
+    'CwdChanged',
+    'DirectoryAdded',
+    'Elicitation',
+    'ElicitationResult',
+    'FileChanged',
+    'InstructionsLoaded',
+    'MessageDisplay',
+    'Notification',
+    'PermissionDenied',
+    'PermissionRequest',
+    'PostCompact',
+    'PostToolBatch',
+    'PostToolUse',
+    'PostToolUseFailure',
+    'PreCompact',
+    'PreToolUse',
+    'SessionEnd',
+    'SessionStart',
+    'Setup',
+    'Stop',
+    'StopFailure',
+    'SubagentStart',
+    'SubagentStop',
+    'TaskCompleted',
+    'TaskCreated',
+    'TeammateIdle',
+    'UserPromptExpansion',
+    'UserPromptSubmit',
+    'WorktreeCreate',
+    'WorktreeRemove',
+})
 
 # Sections whose items may be claimed by entries in the top-level
 # `components:` registry. Any other key inside a component's `includes`
@@ -631,20 +673,21 @@ class MCPServerStdio(BaseModel):
 class HookEvent(BaseModel):
     """Hook event configuration.
 
-    Supports four hook types matching the official Claude Code hooks specification:
+    Supports five hook types matching the official Claude Code hooks specification:
     - command: Executes a shell command (requires 'command' field)
     - http: Sends HTTP POST request (requires 'url' field)
     - prompt: Uses single-turn LLM evaluation (requires 'prompt' field)
     - agent: Spawns a subagent with tool access (requires 'prompt' field)
+    - mcp_tool: Calls a tool on a configured MCP server (requires 'server' and 'tool' fields)
     """
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, extra='forbid')
 
     event: str = Field(..., description='Event name (e.g., PreToolUse, PostToolUse, Notification)')
     matcher: str | None = Field('', description='Regex pattern for matching')
-    type: Literal['command', 'http', 'prompt', 'agent'] = Field(
+    type: Literal['command', 'http', 'prompt', 'agent', 'mcp_tool'] = Field(
         'command',
-        description='Hook type: command, http, prompt, or agent',
+        description='Hook type: command, http, prompt, agent, or mcp_tool',
     )
 
     # Common fields (all hook types)
@@ -664,7 +707,9 @@ class HookEvent(BaseModel):
     )
     timeout: int | None = Field(
         None,
-        description='Timeout in seconds (default varies by type: 600 for command, 30 for prompt, 60 for agent)',
+        gt=0,
+        description='Timeout in seconds; must be positive '
+        '(default varies by type: 600 for command, 30 for prompt, 60 for agent)',
     )
     id: str | None = Field(
         None,
@@ -681,10 +726,21 @@ class HookEvent(BaseModel):
         None,
         description='Optional config file reference to pass as argument to hook command',
     )
+    args: list[str] | None = Field(
+        None,
+        description='Argument list switching the command to exec form: the executable is spawned '
+        'directly with these arguments appended, without any shell parsing',
+    )
     async_execution: bool | None = Field(
         None,
         alias='async',
         description='If true, runs command in background without blocking',
+    )
+    async_rewake: bool | None = Field(
+        None,
+        alias='async-rewake',
+        description='If true, runs the command in the background and wakes the model when it exits '
+        'with code 2 (blocking error); implies async',
     )
     shell: Literal['bash', 'powershell'] | None = Field(
         None,
@@ -715,23 +771,81 @@ class HookEvent(BaseModel):
         None,
         description='Model to use for prompt or agent hook evaluation',
     )
+    continue_on_block: bool | None = Field(
+        None,
+        alias='continue-on-block',
+        description='If true, a denying prompt-hook evaluation (ok: false) feeds its reason back to '
+        'the agent and the turn continues instead of ending; prompt hooks only',
+    )
+
+    # MCP tool hook fields
+    server: str | None = Field(
+        None,
+        description='Name of an already-configured MCP server to invoke (required for mcp_tool hooks)',
+    )
+    tool: str | None = Field(
+        None,
+        description='Name of the tool on the MCP server to call (required for mcp_tool hooks)',
+    )
+    input: dict[str, Any] | None = Field(
+        None,
+        description='Arguments passed to the MCP tool; string values support ${path} interpolation '
+        'from the hook input JSON (e.g., "${tool_input.file_path}")',
+    )
+
+    @field_validator('event')
+    @classmethod
+    def warn_on_unknown_event_name(cls, v: str) -> str:
+        """Warn when the event name is not one Claude Code recognizes.
+
+        Claude Code validates hook event names against a fixed set and rejects
+        unknown names at configuration load time. A warning (not an error)
+        keeps configurations written for a newer Claude Code release
+        installable while still surfacing typos.
+
+        Args:
+            v: The event name to check.
+
+        Returns:
+            The event name unchanged.
+        """
+        if v and v not in HOOK_EVENT_NAMES:
+            warnings.warn(
+                f"Unknown hook event name '{v}'. Claude Code 2.1.238 recognizes: "
+                f'{", ".join(sorted(HOOK_EVENT_NAMES))}. An unrecognized name is written to the '
+                'generated configuration as-is, and Claude Code rejects it at load time.',
+                UserWarning,
+                stacklevel=2,
+            )
+        return v
 
     @model_validator(mode='after')
     def validate_hook_type_fields(self) -> 'HookEvent':
         """Validate that fields match the hook type per official Claude Code spec.
 
         Field Matrix:
-        | Field            | command   | http       | prompt    | agent     |
-        |------------------|-----------|------------|-----------|-----------|
-        | command          | REQUIRED  | FORBIDDEN  | FORBIDDEN | FORBIDDEN |
-        | config           | Optional  | FORBIDDEN  | FORBIDDEN | FORBIDDEN |
-        | async            | Optional  | FORBIDDEN  | FORBIDDEN | FORBIDDEN |
-        | shell            | Optional  | FORBIDDEN  | FORBIDDEN | FORBIDDEN |
-        | url              | FORBIDDEN | REQUIRED   | FORBIDDEN | FORBIDDEN |
-        | headers          | FORBIDDEN | Optional   | FORBIDDEN | FORBIDDEN |
-        | allowed-env-vars | FORBIDDEN | Optional   | FORBIDDEN | FORBIDDEN |
-        | prompt           | FORBIDDEN | FORBIDDEN  | REQUIRED  | REQUIRED  |
-        | model            | FORBIDDEN | FORBIDDEN  | Optional  | Optional  |
+        | Field             | command   | http      | prompt    | agent     | mcp_tool  |
+        |-------------------|-----------|-----------|-----------|-----------|-----------|
+        | command           | REQUIRED  | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN |
+        | config            | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN |
+        | args              | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN |
+        | async             | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN |
+        | async-rewake      | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN |
+        | shell             | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN |
+        | url               | FORBIDDEN | REQUIRED  | FORBIDDEN | FORBIDDEN | FORBIDDEN |
+        | headers           | FORBIDDEN | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN |
+        | allowed-env-vars  | FORBIDDEN | Optional  | FORBIDDEN | FORBIDDEN | FORBIDDEN |
+        | prompt            | FORBIDDEN | FORBIDDEN | REQUIRED  | REQUIRED  | FORBIDDEN |
+        | model             | FORBIDDEN | FORBIDDEN | Optional  | Optional  | FORBIDDEN |
+        | continue-on-block | FORBIDDEN | FORBIDDEN | Optional  | FORBIDDEN | FORBIDDEN |
+        | server            | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN | REQUIRED  |
+        | tool              | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN | REQUIRED  |
+        | input             | FORBIDDEN | FORBIDDEN | FORBIDDEN | FORBIDDEN | Optional  |
+
+        On command hooks, 'shell' is additionally forbidden together with
+        'args', because 'args' switches the command to exec form, which
+        spawns the executable directly without any shell. On http hooks,
+        'url' must be a valid http:// or https:// URL.
 
         Returns:
             The validated HookEvent instance.
@@ -739,106 +853,78 @@ class HookEvent(BaseModel):
         Raises:
             ValueError: If field requirements are not met for the hook type.
         """
-        # Fields exclusive to each type group (typed as object for type checker compatibility)
-        _command_only_fields: dict[str, object] = {
-            'command': self.command,
-            'config': self.config,
-            'async': self.async_execution,
-            'shell': self.shell,
-        }
-        _http_only_fields: dict[str, object] = {
-            'url': self.url,
-            'headers': self.headers,
-            'allowed-env-vars': self.allowed_env_vars,
-        }
-        _prompt_agent_fields: dict[str, object] = {
-            'prompt': self.prompt,
-            'model': self.model,
-        }
+        # (YAML field name, value, hook types that may set it, guidance appended to the error)
+        _field_rules: tuple[tuple[str, object, tuple[str, ...], str], ...] = (
+            ('command', self.command, ('command',), "Use type 'command' for script-based hooks."),
+            ('config', self.config, ('command',), "Use type 'command' for script-based hooks."),
+            ('args', self.args, ('command',), "Use type 'command' for script-based hooks."),
+            ('async', self.async_execution, ('command',), "Use type 'command' for script-based hooks."),
+            ('async-rewake', self.async_rewake, ('command',), "Use type 'command' for script-based hooks."),
+            ('shell', self.shell, ('command',), "Use type 'command' for script-based hooks."),
+            ('url', self.url, ('http',), "Use type 'http' for HTTP webhook hooks."),
+            ('headers', self.headers, ('http',), "Use type 'http' for HTTP webhook hooks."),
+            ('allowed-env-vars', self.allowed_env_vars, ('http',), "Use type 'http' for HTTP webhook hooks."),
+            ('prompt', self.prompt, ('prompt', 'agent'), "Use type 'prompt' or 'agent' for LLM-based hooks."),
+            ('model', self.model, ('prompt', 'agent'), "Use type 'prompt' or 'agent' for LLM-based hooks."),
+            (
+                'continue-on-block',
+                self.continue_on_block,
+                ('prompt',),
+                "Claude Code supports 'continue-on-block' on prompt hooks only.",
+            ),
+            ('server', self.server, ('mcp_tool',), "Use type 'mcp_tool' for MCP tool hooks."),
+            ('tool', self.tool, ('mcp_tool',), "Use type 'mcp_tool' for MCP tool hooks."),
+            ('input', self.input, ('mcp_tool',), "Use type 'mcp_tool' for MCP tool hooks."),
+        )
+        for field_name, value, allowed_types, guidance in _field_rules:
+            if value is not None and self.type not in allowed_types:
+                raise ValueError(
+                    f"Hook type '{self.type}' cannot have '{field_name}' field. {guidance}",
+                )
 
         if self.type == 'command':
             if not self.command:
                 raise ValueError(
                     "Hook type 'command' requires 'command' field. "
-                    "Either provide a command or change type to 'http', 'prompt', or 'agent'.",
+                    "Either provide a command or change type to 'http', 'prompt', 'agent', or 'mcp_tool'.",
                 )
-            for field_name, value in _http_only_fields.items():
-                if value is not None:
-                    raise ValueError(
-                        f"Hook type 'command' cannot have '{field_name}' field. "
-                        f"Use type 'http' for HTTP webhook hooks.",
-                    )
-            if self.prompt is not None:
+            if self.args is not None and self.shell is not None:
                 raise ValueError(
-                    "Hook type 'command' cannot have 'prompt' field. "
-                    "Use type 'prompt' or 'agent' for LLM-based hooks.",
-                )
-            if self.model is not None:
-                raise ValueError(
-                    "Hook type 'command' cannot have 'model' field. "
-                    "Use type 'prompt' or 'agent' for LLM-based hooks.",
+                    "Hook type 'command' cannot combine 'shell' with 'args'. "
+                    "'args' switches the command to exec form, which spawns the executable "
+                    'directly without any shell.',
                 )
 
         elif self.type == 'http':
             if not self.url:
                 raise ValueError(
                     "Hook type 'http' requires 'url' field. "
-                    "Provide the URL to send the HTTP POST request to.",
+                    'Provide the URL to send the HTTP POST request to.',
                 )
-            for field_name, value in _command_only_fields.items():
-                if value is not None:
-                    raise ValueError(
-                        f"Hook type 'http' cannot have '{field_name}' field. "
-                        f"Use type 'command' for script-based hooks.",
-                    )
-            if self.prompt is not None:
+            parsed_url = urlparse(self.url)
+            if parsed_url.scheme not in ('http', 'https') or not parsed_url.netloc:
                 raise ValueError(
-                    "Hook type 'http' cannot have 'prompt' field. "
-                    "Use type 'prompt' or 'agent' for LLM-based hooks.",
-                )
-            if self.model is not None:
-                raise ValueError(
-                    "Hook type 'http' cannot have 'model' field. "
-                    "Use type 'prompt' or 'agent' for LLM-based hooks.",
+                    f"Hook type 'http' requires 'url' to be a valid http:// or https:// URL, got '{self.url}'.",
                 )
 
-        elif self.type == 'prompt':
+        elif self.type in ('prompt', 'agent'):
             if not self.prompt:
                 raise ValueError(
-                    "Hook type 'prompt' requires 'prompt' field. "
-                    "Either provide a prompt or change type to 'command'.",
+                    f"Hook type '{self.type}' requires 'prompt' field. "
+                    'Provide the prompt for the LLM evaluation.',
                 )
-            for field_name, value in _command_only_fields.items():
-                if value is not None:
-                    raise ValueError(
-                        f"Hook type 'prompt' cannot have '{field_name}' field. "
-                        f"Use type 'command' for script-based hooks.",
-                    )
-            for field_name, value in _http_only_fields.items():
-                if value is not None:
-                    raise ValueError(
-                        f"Hook type 'prompt' cannot have '{field_name}' field. "
-                        f"Use type 'http' for HTTP webhook hooks.",
-                    )
 
-        elif self.type == 'agent':
-            if not self.prompt:
+        elif self.type == 'mcp_tool':
+            if not self.server:
                 raise ValueError(
-                    "Hook type 'agent' requires 'prompt' field. "
-                    "Provide the prompt for the subagent evaluation.",
+                    "Hook type 'mcp_tool' requires 'server' field. "
+                    'Provide the name of an already-configured MCP server.',
                 )
-            for field_name, value in _command_only_fields.items():
-                if value is not None:
-                    raise ValueError(
-                        f"Hook type 'agent' cannot have '{field_name}' field. "
-                        f"Use type 'command' for script-based hooks.",
-                    )
-            for field_name, value in _http_only_fields.items():
-                if value is not None:
-                    raise ValueError(
-                        f"Hook type 'agent' cannot have '{field_name}' field. "
-                        f"Use type 'http' for HTTP webhook hooks.",
-                    )
+            if not self.tool:
+                raise ValueError(
+                    "Hook type 'mcp_tool' requires 'tool' field. "
+                    'Provide the name of the tool to call on the MCP server.',
+                )
 
         return self
 
@@ -1936,7 +2022,7 @@ class EnvironmentConfig(BaseModel):
         # Only command hooks use file references; http/prompt/agent hooks are excluded
         for event in self.hooks.events:
             # Skip non-command hooks - only command hooks reference files
-            if event.type in ('prompt', 'http', 'agent'):
+            if event.type in ('prompt', 'http', 'agent', 'mcp_tool'):
                 continue
 
             # For command hooks, validate command and config files

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -159,6 +159,47 @@ RESERVED_COMPONENT_NAMES: frozenset[str] = frozenset({'all', 'none'})
 # must start with a letter or digit
 COMPONENT_NAME_PATTERN: re.Pattern[str] = re.compile(r'^[a-z0-9][a-z0-9._-]*$')
 
+# Hook event names recognized by Claude Code 2.1.238; Claude Code rejects any
+# other name at configuration load time. _build_hooks_json() warns (rather
+# than errors) on names outside this set so a configuration written for a
+# newer Claude Code release keeps installing. Inline copy of
+# HOOK_EVENT_NAMES in scripts/models/environment_config.py (standalone
+# script policy prevents cross-import); parity enforced by
+# tests/scripts/models/test_hook_event_names_parity.py.
+HOOK_EVENT_NAMES: frozenset[str] = frozenset({
+    'ConfigChange',
+    'CwdChanged',
+    'DirectoryAdded',
+    'Elicitation',
+    'ElicitationResult',
+    'FileChanged',
+    'InstructionsLoaded',
+    'MessageDisplay',
+    'Notification',
+    'PermissionDenied',
+    'PermissionRequest',
+    'PostCompact',
+    'PostToolBatch',
+    'PostToolUse',
+    'PostToolUseFailure',
+    'PreCompact',
+    'PreToolUse',
+    'SessionEnd',
+    'SessionStart',
+    'Setup',
+    'Stop',
+    'StopFailure',
+    'SubagentStart',
+    'SubagentStop',
+    'TaskCompleted',
+    'TaskCreated',
+    'TeammateIdle',
+    'UserPromptExpansion',
+    'UserPromptSubmit',
+    'WorktreeCreate',
+    'WorktreeRemove',
+})
+
 # Path prefixes indicating sensitive filesystem destinations
 SENSITIVE_PATH_PREFIXES: tuple[str, ...] = (
     '~/.ssh/',
@@ -2621,8 +2662,8 @@ def validate_hooks_files_consistency(
     2. Each command hook's command and config exists in hooks.files
     3. The status-line file and config (if configured) exist in hooks.files
 
-    Prompt, http, and agent hooks do not reference files and are excluded.
-    Structural errors (non-mapping hooks or events, non-string entries)
+    Prompt, http, agent, and mcp_tool hooks do not reference files and are
+    excluded. Structural errors (non-mapping hooks or events, non-string entries)
     suppress the unused-files check because its verdict is only meaningful on
     a well-formed configuration. Never raises.
 
@@ -2697,7 +2738,7 @@ def validate_hooks_files_consistency(
             structure_broken = True
             continue
         event = cast(dict[str, Any], event_raw)
-        if event.get('type') in ('prompt', 'http', 'agent'):
+        if event.get('type') in ('prompt', 'http', 'agent', 'mcp_tool'):
             continue
 
         # For command hooks, validate command and config files
@@ -11340,6 +11381,28 @@ def download_hook_files(
     return process_resources(hook_files, hooks_dir, 'hook files', config_source, base_url, auth_param, auth_cache)
 
 
+def _hook_launcher_args(file_name: str) -> list[str]:
+    """Return the launcher argument list for a hooks-directory file.
+
+    Picks the launcher by file type (case-insensitive): Python files run via
+    uv, JavaScript files via node, and anything else executes directly (an
+    empty launcher list).
+
+    Args:
+        file_name: Bare file name of the hook script.
+
+    Returns:
+        Launcher executable and its arguments; empty when the file executes
+        directly.
+    """
+    lowered_name = file_name.lower()
+    if lowered_name.endswith(('.py', '.pyw')):
+        return ['uv', 'run', '--no-project', '--python', '3.12']
+    if lowered_name.endswith(('.js', '.mjs', '.cjs')):
+        return ['node']
+    return []
+
+
 def _build_file_command(
     file_reference: str,
     config_reference: str | None,
@@ -11349,9 +11412,8 @@ def _build_file_command(
 
     Shared by _build_hooks_json() (command hooks) and
     _build_profile_settings() (statusLine): strips query parameters, resolves
-    the basename under hooks_dir, picks the launcher by file type
-    (case-insensitive: Python via uv, JavaScript via node, anything else
-    executes directly), and appends the config file path when given. Built
+    the basename under hooks_dir, picks the launcher by file type via
+    _hook_launcher_args(), and appends the config file path when given. Built
     paths are double-quoted so a hooks directory containing spaces (for
     example a Windows home like C:/Users/John Smith) survives shell
     word-splitting in bash, PowerShell, and cmd alike.
@@ -11368,13 +11430,8 @@ def _build_file_command(
     """
     clean_reference = file_reference.split('?')[0] if '?' in file_reference else file_reference
     file_name = Path(clean_reference).name
-    lowered_name = file_name.lower()
-    if lowered_name.endswith(('.py', '.pyw')):
-        launcher_prefix = 'uv run --no-project --python 3.12 '
-    elif lowered_name.endswith(('.js', '.mjs', '.cjs')):
-        launcher_prefix = 'node '
-    else:
-        launcher_prefix = ''
+    launcher_args = _hook_launcher_args(file_name)
+    launcher_prefix = f'{" ".join(launcher_args)} ' if launcher_args else ''
 
     file_path_str = (hooks_dir / file_name).as_posix()
     command = f'{launcher_prefix}"{file_path_str}"'
@@ -11387,6 +11444,52 @@ def _build_file_command(
         command = f'{command} "{config_path_str}"'
 
     return command
+
+
+def _build_file_exec_command(
+    file_reference: str,
+    config_reference: str | None,
+    hooks_dir: Path,
+) -> tuple[str, list[str]]:
+    """Build the exec-form executable and argument list for a file reference.
+
+    Exec-form counterpart of _build_file_command(), used by
+    _build_hooks_json() for command hooks that declare 'args': Claude Code
+    spawns the executable directly with the argument list, without any
+    shell, so no element is quoted (a spaced path survives as a single
+    argument-list element). The launcher executable becomes the command,
+    while the remaining launcher arguments, the resolved script path, and
+    the config file path (when given) become the leading arguments.
+
+    Args:
+        file_reference: Script file reference from the YAML configuration
+            (a hooks.files basename, optionally with query parameters).
+        config_reference: Optional config file reference appended as an
+            argument.
+        hooks_dir: Absolute directory path where downloaded hook files reside.
+
+    Returns:
+        Tuple of the executable to spawn and its leading argument list.
+    """
+    clean_reference = file_reference.split('?')[0] if '?' in file_reference else file_reference
+    file_name = Path(clean_reference).name
+    file_path_str = (hooks_dir / file_name).as_posix()
+
+    launcher_args = _hook_launcher_args(file_name)
+    if launcher_args:
+        executable = launcher_args[0]
+        exec_args = [*launcher_args[1:], file_path_str]
+    else:
+        executable = file_path_str
+        exec_args = []
+
+    if config_reference:
+        clean_config = (
+            config_reference.split('?')[0] if '?' in config_reference else config_reference
+        )
+        exec_args.append((hooks_dir / Path(clean_config).name).as_posix())
+
+    return executable, exec_args
 
 
 def _apply_common_hook_fields(
@@ -11413,6 +11516,22 @@ def _apply_common_hook_fields(
         hook_config['timeout'] = hook['timeout']
 
 
+# YAML keys accepted on a hooks.events[] entry, per hook type. Used by
+# _build_hooks_json() to warn about (and ignore) keys that have no meaning
+# for the entry's type; the generated JSON is built from an explicit
+# whitelist, so an unlisted key never reaches the output.
+_HOOK_COMMON_YAML_KEYS: frozenset[str] = frozenset({
+    'event', 'matcher', 'type', 'if', 'status-message', 'once', 'timeout', 'id',
+})
+_HOOK_TYPE_ALLOWED_YAML_KEYS: dict[str, frozenset[str]] = {
+    'command': _HOOK_COMMON_YAML_KEYS | {'command', 'config', 'args', 'async', 'async-rewake', 'shell'},
+    'http': _HOOK_COMMON_YAML_KEYS | {'url', 'headers', 'allowed-env-vars'},
+    'prompt': _HOOK_COMMON_YAML_KEYS | {'prompt', 'model', 'continue-on-block'},
+    'agent': _HOOK_COMMON_YAML_KEYS | {'prompt', 'model'},
+    'mcp_tool': _HOOK_COMMON_YAML_KEYS | {'server', 'tool', 'input'},
+}
+
+
 def _build_hooks_json(
     hooks: dict[str, Any],
     hooks_dir: Path,
@@ -11420,8 +11539,8 @@ def _build_hooks_json(
     """Build hooks JSON structure from YAML configuration.
 
     Converts YAML hook event definitions into Claude Code's JSON hooks format.
-    Generates absolute POSIX paths for hook file references. Supports all four
-    hook types: command, http, prompt, agent.
+    Generates absolute POSIX paths for hook file references. Supports all five
+    hook types: command, http, prompt, agent, mcp_tool.
 
     Used by create_profile_config() (per-environment config.json, atomic
     overwrite in isolated mode) and indirectly by
@@ -11464,15 +11583,53 @@ def _build_hooks_json(
             warning('Invalid hook configuration: missing event, skipping')
             continue
 
+        if event not in HOOK_EVENT_NAMES:
+            warning(
+                f'Unknown hook event name: {event} (not recognized by Claude Code 2.1.238, '
+                'which rejects unknown event names at configuration load time)',
+            )
+
+        allowed_keys = _HOOK_TYPE_ALLOWED_YAML_KEYS.get(hook_type)
+        if allowed_keys is None:
+            warning(f'Unknown hook type: {hook_type}, skipping')
+            continue
+
+        unknown_keys = sorted(set(hook) - allowed_keys)
+        if unknown_keys:
+            warning(
+                f"Hook event {event}: ignoring key(s) not supported for hook type '{hook_type}': "
+                f'{", ".join(unknown_keys)}',
+            )
+
         # Validate required fields per hook type
         if hook_type == 'command' and not command:
             warning('Invalid command hook: missing command, skipping')
             continue
-        if hook_type == 'http' and not hook.get('url'):
-            warning('Invalid http hook: missing url, skipping')
-            continue
+        if hook_type == 'http':
+            url = hook.get('url')
+            if not url:
+                warning('Invalid http hook: missing url, skipping')
+                continue
+            if not isinstance(url, str) or not url.startswith(('http://', 'https://')):
+                warning(f'Invalid http hook: url must be an http:// or https:// URL, got {url}, skipping')
+                continue
         if hook_type in ('prompt', 'agent') and not hook.get('prompt'):
             warning(f'Invalid {hook_type} hook: missing prompt, skipping')
+            continue
+        if hook_type == 'mcp_tool':
+            if not hook.get('server'):
+                warning('Invalid mcp_tool hook: missing server, skipping')
+                continue
+            if not hook.get('tool'):
+                warning('Invalid mcp_tool hook: missing tool, skipping')
+                continue
+
+        # Claude Code requires a positive timeout on every hook type
+        timeout = hook.get('timeout')
+        if timeout is not None and (
+            isinstance(timeout, bool) or not isinstance(timeout, int | float) or timeout <= 0
+        ):
+            warning(f'Invalid {hook_type} hook: timeout must be a positive number, got {timeout}, skipping')
             continue
 
         # Add to result
@@ -11516,19 +11673,45 @@ def _build_hooks_json(
             # 'echo "test"', are direct commands used as-is
             is_file_reference = clean_command in listed_basenames or ' ' not in clean_command
 
-            # An unlisted command with spaces is a direct command used as-is
-            full_command = _build_file_command(command, config, hooks_dir) if is_file_reference else command
+            args = hook.get('args')
+            if args is not None:
+                # Exec form: Claude Code spawns the executable directly with
+                # the argument list and no shell, so the launcher and the
+                # resolved script path move into the argument list unquoted.
+                # Only a basename listed in hooks.files is folded this way;
+                # any other command IS the executable (a bare name resolves
+                # via PATH, an absolute path is spawned as-is), so the shell
+                # form's no-space heuristic must not reroute it into hooks_dir
+                extra_args = [str(a) for a in args] if isinstance(args, list) else [str(args)]
+                if clean_command in listed_basenames:
+                    executable, exec_args = _build_file_exec_command(command, config, hooks_dir)
+                else:
+                    executable, exec_args = command, []
+                hook_config = {
+                    'type': hook_type,
+                    'command': executable,
+                    'args': exec_args + extra_args,
+                }
+                if hook.get('shell') is not None:
+                    warning(
+                        f"Hook event {event}: 'shell' is ignored when 'args' is set "
+                        '(exec form spawns the executable without a shell)',
+                    )
+            else:
+                # An unlisted command with spaces is a direct command used as-is
+                full_command = _build_file_command(command, config, hooks_dir) if is_file_reference else command
+                hook_config = {
+                    'type': hook_type,
+                    'command': full_command,
+                }
+                if hook.get('shell') is not None:
+                    hook_config['shell'] = hook['shell']
 
-            # Add hook configuration for command hook
-            hook_config = {
-                'type': hook_type,
-                'command': full_command,
-            }
-            # Pass through command-specific optional fields
+            # Background-execution fields apply to both forms
             if hook.get('async') is not None:
                 hook_config['async'] = hook['async']
-            if hook.get('shell') is not None:
-                hook_config['shell'] = hook['shell']
+            if hook.get('async-rewake') is not None:
+                hook_config['asyncRewake'] = hook['async-rewake']
 
         elif hook_type == 'http':
             # HTTP hooks: pure pass-through, no file-path processing
@@ -11542,13 +11725,15 @@ def _build_hooks_json(
                 hook_config['allowedEnvVars'] = hook['allowed-env-vars']
 
         elif hook_type == 'prompt':
-            # Prompt hooks: pass-through for prompt and model
+            # Prompt hooks: pass-through for prompt, model, continue-on-block
             hook_config = {
                 'type': hook_type,
                 'prompt': hook.get('prompt', ''),
             }
             if hook.get('model') is not None:
                 hook_config['model'] = hook['model']
+            if hook.get('continue-on-block') is not None:
+                hook_config['continueOnBlock'] = hook['continue-on-block']
 
         elif hook_type == 'agent':
             # Agent hooks: same structure as prompt but type is 'agent'
@@ -11559,8 +11744,18 @@ def _build_hooks_json(
             if hook.get('model') is not None:
                 hook_config['model'] = hook['model']
 
+        elif hook_type == 'mcp_tool':
+            # MCP tool hooks: call a tool on an already-configured MCP server
+            hook_config = {
+                'type': hook_type,
+                'server': hook.get('server', ''),
+                'tool': hook.get('tool', ''),
+            }
+            if hook.get('input') is not None:
+                hook_config['input'] = hook['input']
+
         else:
-            warning(f'Unknown hook type: {hook_type}, skipping')
+            # Unreachable: hook_type membership is validated above
             continue
 
         # Apply common fields to ALL hook types

--- a/tests/e2e/golden_config.yaml
+++ b/tests/e2e/golden_config.yaml
@@ -114,11 +114,13 @@ hooks:
       matcher: "Grep"
       type: "command"
       command: "e2e_test_hook_cjs.cjs"
-    # Prompt hook example
+    # Prompt hook example (continue-on-block feeds a deny reason back to the
+    # agent and lets the turn continue)
     - event: "PreToolUse"
       matcher: "Bash"
       type: "prompt"
       prompt: "Consider security implications before executing bash commands"
+      continue-on-block: true
       timeout: 30
     # HTTP hook example
     - event: "PostToolUse"
@@ -141,15 +143,37 @@ hooks:
       timeout: 60
       if: "Bash(rm *)"
       once: true
-    # Command hook with async and shell (id makes it claimable by components)
+    # Command hook with async, async-rewake, and shell (id makes it claimable
+    # by components)
     - event: "Notification"
       matcher: ""
       type: "command"
       command: "e2e_test_hook.py"
       async: true
+      async-rewake: true
       shell: "bash"
       status-message: "Running notification handler..."
       id: "e2e-notify"
+    # Command hook in exec form (args spawns the launcher directly, no shell;
+    # id makes it claimable by components alongside its script file)
+    - event: "PreToolUse"
+      matcher: "Task"
+      type: "command"
+      command: "e2e_test_hook.py"
+      args:
+        - "--strict"
+        - "--level"
+        - "2"
+      id: "e2e-exec"
+    # MCP tool hook example (calls a tool on an already-configured MCP server)
+    - event: "PostToolUse"
+      matcher: "Edit"
+      type: "mcp_tool"
+      server: "e2e-http-server"
+      tool: "lint_file"
+      input:
+        file_path: "${tool_input.file_path}"
+      timeout: 20
 
 # MCP Servers - all transport types
 mcp-servers:
@@ -292,6 +316,7 @@ components:
       hooks:
         - "e2e-post-edit"
         - "e2e-notify"
+        - "e2e-exec"
         - "hooks/e2e_test_hook.py"
         - "configs/e2e-hook-config.yaml"
   - name: "mcp-http"

--- a/tests/e2e/validators.py
+++ b/tests/e2e/validators.py
@@ -510,7 +510,7 @@ def _validate_hooks_structure(actual: dict[str, Any], config: dict[str, Any]) ->
         ]
     }
 
-    Supports all 4 hook types: command, http, prompt, agent.
+    Supports all 5 hook types: command, http, prompt, agent, mcp_tool.
     Also validates common fields (if, status-message, once, timeout) pass-through.
 
     Args:
@@ -563,25 +563,60 @@ def _validate_hooks_structure(actual: dict[str, Any], config: dict[str, Any]) ->
                             command_file = event_config.get('command', '')
                             command_file_lower = command_file.lower()
 
-                            # Check Python prefix
-                            if (
-                                command_file_lower.endswith(('.py', '.pyw'))
-                                and 'uv run' not in command
-                            ):
-                                errors.append(
-                                    f"Python hook '{command_file}' missing 'uv run' prefix "
-                                    f'in command: {command}',
-                                )
+                            if event_config.get('args') is not None:
+                                # Exec form: the launcher is the executable and
+                                # the script path plus user args live in 'args'
+                                actual_args = hook.get('args')
+                                if not isinstance(actual_args, list):
+                                    errors.append(
+                                        f"Exec-form hook '{event_name}' missing 'args' list",
+                                    )
+                                else:
+                                    if command_file_lower.endswith(('.py', '.pyw')) and command != 'uv':
+                                        errors.append(
+                                            f"Exec-form Python hook '{command_file}' must spawn 'uv', "
+                                            f'got: {command}',
+                                        )
+                                    elif (
+                                        command_file_lower.endswith(('.js', '.mjs', '.cjs'))
+                                        and command != 'node'
+                                    ):
+                                        errors.append(
+                                            f"Exec-form JavaScript hook '{command_file}' must spawn 'node', "
+                                            f'got: {command}',
+                                        )
+                                    expected_tail = [str(a) for a in event_config['args']]
+                                    if expected_tail and actual_args[-len(expected_tail):] != expected_tail:
+                                        errors.append(
+                                            f"Exec-form hook '{event_name}' args tail mismatch: "
+                                            f'expected {expected_tail!r}, got {actual_args!r}',
+                                        )
+                            else:
+                                # Check Python prefix
+                                if (
+                                    command_file_lower.endswith(('.py', '.pyw'))
+                                    and 'uv run' not in command
+                                ):
+                                    errors.append(
+                                        f"Python hook '{command_file}' missing 'uv run' prefix "
+                                        f'in command: {command}',
+                                    )
 
-                            # Check JavaScript prefix
-                            elif (
-                                command_file_lower.endswith(('.js', '.mjs', '.cjs'))
-                                and not command.startswith('node ')
-                            ):
-                                errors.append(
-                                    f"JavaScript hook '{command_file}' missing 'node' prefix "
-                                    f'in command: {command}',
-                                )
+                                # Check JavaScript prefix
+                                elif (
+                                    command_file_lower.endswith(('.js', '.mjs', '.cjs'))
+                                    and not command.startswith('node ')
+                                ):
+                                    errors.append(
+                                        f"JavaScript hook '{command_file}' missing 'node' prefix "
+                                        f'in command: {command}',
+                                    )
+
+                                if event_config.get('shell') is not None and hook.get('shell') != event_config['shell']:
+                                    errors.append(
+                                        f"Hook '{event_name}' shell field mismatch: "
+                                        f"expected {event_config['shell']!r}, got {hook.get('shell')!r}",
+                                    )
 
                             # Validate command-specific optional fields pass-through
                             if event_config.get('async') is not None and hook.get('async') != event_config['async']:
@@ -589,10 +624,11 @@ def _validate_hooks_structure(actual: dict[str, Any], config: dict[str, Any]) ->
                                     f"Hook '{event_name}' async field mismatch: "
                                     f"expected {event_config['async']!r}, got {hook.get('async')!r}",
                                 )
-                            if event_config.get('shell') is not None and hook.get('shell') != event_config['shell']:
+                            expected_rewake = event_config.get('async-rewake')
+                            if expected_rewake is not None and hook.get('asyncRewake') != expected_rewake:
                                 errors.append(
-                                    f"Hook '{event_name}' shell field mismatch: "
-                                    f"expected {event_config['shell']!r}, got {hook.get('shell')!r}",
+                                    f"Hook '{event_name}' asyncRewake field mismatch: "
+                                    f"expected {expected_rewake!r}, got {hook.get('asyncRewake')!r}",
                                 )
 
                         elif hook_type == 'http':
@@ -620,6 +656,30 @@ def _validate_hooks_structure(actual: dict[str, Any], config: dict[str, Any]) ->
                                 errors.append(
                                     f"{hook_type.capitalize()} hook '{event_name}' model mismatch: "
                                     f"expected {expected_model!r}, got {hook.get('model')!r}",
+                                )
+                            expected_cob = event_config.get('continue-on-block')
+                            if expected_cob is not None and hook.get('continueOnBlock') != expected_cob:
+                                errors.append(
+                                    f"Prompt hook '{event_name}' continueOnBlock mismatch: "
+                                    f"expected {expected_cob!r}, got {hook.get('continueOnBlock')!r}",
+                                )
+
+                        elif hook_type == 'mcp_tool':
+                            if hook.get('server') != event_config.get('server'):
+                                errors.append(
+                                    f"MCP tool hook '{event_name}' server mismatch: "
+                                    f"expected {event_config.get('server')!r}, got {hook.get('server')!r}",
+                                )
+                            if hook.get('tool') != event_config.get('tool'):
+                                errors.append(
+                                    f"MCP tool hook '{event_name}' tool mismatch: "
+                                    f"expected {event_config.get('tool')!r}, got {hook.get('tool')!r}",
+                                )
+                            expected_input = event_config.get('input')
+                            if expected_input is not None and hook.get('input') != expected_input:
+                                errors.append(
+                                    f"MCP tool hook '{event_name}' input mismatch: "
+                                    f"expected {expected_input!r}, got {hook.get('input')!r}",
                                 )
 
                         # Validate common fields pass-through for all types

--- a/tests/scripts/models/test_environment_config.py
+++ b/tests/scripts/models/test_environment_config.py
@@ -430,7 +430,7 @@ class TestHookEventValidation:
 
 
 class TestHookEventAllTypes:
-    """Test HookEvent model for all 4 hook types with aliases and field matrix."""
+    """Test HookEvent model for all 5 hook types with aliases and field matrix."""
 
     # --- HTTP hook valid cases ---
     def test_http_hook_with_url(self) -> None:
@@ -557,10 +557,11 @@ class TestHookEventAllTypes:
         common = {'if': 'Bash(*)', 'status-message': 'Working...', 'once': True, 'timeout': 30}
 
         for hook_data in [
-            {'event': 'E', 'type': 'command', 'command': 'c.py', **common},
-            {'event': 'E', 'type': 'http', 'url': 'http://x.com', **common},
-            {'event': 'E', 'type': 'prompt', 'prompt': 'p', **common},
-            {'event': 'E', 'type': 'agent', 'prompt': 'a', **common},
+            {'event': 'PostToolUse', 'type': 'command', 'command': 'c.py', **common},
+            {'event': 'PostToolUse', 'type': 'http', 'url': 'http://x.com', **common},
+            {'event': 'PostToolUse', 'type': 'prompt', 'prompt': 'p', **common},
+            {'event': 'PostToolUse', 'type': 'agent', 'prompt': 'a', **common},
+            {'event': 'PostToolUse', 'type': 'mcp_tool', 'server': 's', 'tool': 't', **common},
         ]:
             event = HookEvent.model_validate(hook_data)
             assert event.if_condition == 'Bash(*)'
@@ -785,6 +786,370 @@ class TestHookEventAllTypes:
         })
         assert config.hooks is not None
         assert len(config.hooks.events) == 1
+
+    def test_validate_hooks_files_consistency_skips_mcp_tool(self) -> None:
+        """MCP tool hooks are skipped during file consistency validation."""
+        from scripts.models.environment_config import EnvironmentConfig
+        config = EnvironmentConfig.model_validate({
+            'name': 'test',
+            'hooks': {
+                'files': [],
+                'events': [
+                    {'event': 'PostToolUse', 'type': 'mcp_tool', 'server': 'linter', 'tool': 'lint_file'},
+                ],
+            },
+        })
+        assert config.hooks is not None
+        assert len(config.hooks.events) == 1
+
+
+class TestHookEventContinueOnBlock:
+    """Test the continue-on-block field (prompt hooks only)."""
+
+    def test_prompt_hook_with_continue_on_block(self) -> None:
+        """Prompt hook accepts continue-on-block."""
+        event = HookEvent.model_validate({
+            'event': 'PreToolUse',
+            'matcher': 'Search|Grep',
+            'type': 'prompt',
+            'prompt': 'Route search calls to the right tool',
+            'continue-on-block': True,
+        })
+        assert event.continue_on_block is True
+
+    def test_prompt_hook_with_continue_on_block_false(self) -> None:
+        """Prompt hook accepts an explicit continue-on-block: false."""
+        event = HookEvent.model_validate({
+            'event': 'PreToolUse',
+            'type': 'prompt',
+            'prompt': 'test',
+            'continue-on-block': False,
+        })
+        assert event.continue_on_block is False
+
+    def test_continue_on_block_defaults_to_none(self) -> None:
+        """Omitted continue-on-block stays None."""
+        event = HookEvent.model_validate({
+            'event': 'PreToolUse',
+            'type': 'prompt',
+            'prompt': 'test',
+        })
+        assert event.continue_on_block is None
+
+    def test_agent_hook_with_continue_on_block_raises(self) -> None:
+        """Agent hook rejects continue-on-block (prompt hooks only)."""
+        with pytest.raises(ValidationError) as exc_info:
+            HookEvent.model_validate({
+                'event': 'PreToolUse',
+                'type': 'agent',
+                'prompt': 'test',
+                'continue-on-block': True,
+            })
+        assert "cannot have 'continue-on-block' field" in str(exc_info.value)
+        assert 'prompt hooks only' in str(exc_info.value)
+
+    def test_command_hook_with_continue_on_block_raises(self) -> None:
+        """Command hook rejects continue-on-block."""
+        with pytest.raises(ValidationError) as exc_info:
+            HookEvent.model_validate({
+                'event': 'PreToolUse',
+                'type': 'command',
+                'command': 'test.py',
+                'continue-on-block': True,
+            })
+        assert "cannot have 'continue-on-block' field" in str(exc_info.value)
+
+    def test_http_hook_with_continue_on_block_raises(self) -> None:
+        """HTTP hook rejects continue-on-block."""
+        with pytest.raises(ValidationError) as exc_info:
+            HookEvent.model_validate({
+                'event': 'PostToolUse',
+                'type': 'http',
+                'url': 'http://localhost:8080/hook',
+                'continue-on-block': True,
+            })
+        assert "cannot have 'continue-on-block' field" in str(exc_info.value)
+
+
+class TestHookEventArgsField:
+    """Test the args field (command hooks only, exec form)."""
+
+    def test_command_hook_with_args(self) -> None:
+        """Command hook accepts an args list."""
+        event = HookEvent.model_validate({
+            'event': 'PostToolUse',
+            'matcher': 'Edit',
+            'type': 'command',
+            'command': 'linter.py',
+            'args': ['--fix', '--strict'],
+        })
+        assert event.args == ['--fix', '--strict']
+
+    def test_command_hook_with_empty_args(self) -> None:
+        """Command hook accepts an empty args list."""
+        event = HookEvent.model_validate({
+            'event': 'PostToolUse',
+            'type': 'command',
+            'command': 'linter.py',
+            'args': [],
+        })
+        assert event.args == []
+
+    def test_command_hook_args_with_shell_raises(self) -> None:
+        """Combining args with shell raises (exec form has no shell)."""
+        with pytest.raises(ValidationError) as exc_info:
+            HookEvent.model_validate({
+                'event': 'PostToolUse',
+                'type': 'command',
+                'command': 'linter.py',
+                'args': ['--fix'],
+                'shell': 'bash',
+            })
+        assert "cannot combine 'shell' with 'args'" in str(exc_info.value)
+
+    def test_prompt_hook_with_args_raises(self) -> None:
+        """Prompt hook rejects args."""
+        with pytest.raises(ValidationError) as exc_info:
+            HookEvent.model_validate({
+                'event': 'PreToolUse',
+                'type': 'prompt',
+                'prompt': 'test',
+                'args': ['--fix'],
+            })
+        assert "cannot have 'args' field" in str(exc_info.value)
+
+    def test_http_hook_with_args_raises(self) -> None:
+        """HTTP hook rejects args."""
+        with pytest.raises(ValidationError) as exc_info:
+            HookEvent.model_validate({
+                'event': 'PostToolUse',
+                'type': 'http',
+                'url': 'http://localhost:8080/hook',
+                'args': ['--fix'],
+            })
+        assert "cannot have 'args' field" in str(exc_info.value)
+
+
+class TestHookEventAsyncRewake:
+    """Test the async-rewake field (command hooks only)."""
+
+    def test_command_hook_with_async_rewake(self) -> None:
+        """Command hook accepts async-rewake."""
+        event = HookEvent.model_validate({
+            'event': 'Stop',
+            'type': 'command',
+            'command': 'verify.py',
+            'async-rewake': True,
+        })
+        assert event.async_rewake is True
+
+    def test_command_hook_with_async_and_async_rewake(self) -> None:
+        """Command hook accepts async and async-rewake together."""
+        event = HookEvent.model_validate({
+            'event': 'Stop',
+            'type': 'command',
+            'command': 'verify.py',
+            'async': True,
+            'async-rewake': True,
+        })
+        assert event.async_execution is True
+        assert event.async_rewake is True
+
+    def test_prompt_hook_with_async_rewake_raises(self) -> None:
+        """Prompt hook rejects async-rewake."""
+        with pytest.raises(ValidationError) as exc_info:
+            HookEvent.model_validate({
+                'event': 'PreToolUse',
+                'type': 'prompt',
+                'prompt': 'test',
+                'async-rewake': True,
+            })
+        assert "cannot have 'async-rewake' field" in str(exc_info.value)
+
+
+class TestHookEventMcpTool:
+    """Test the mcp_tool hook type."""
+
+    def test_mcp_tool_hook_valid(self) -> None:
+        """MCP tool hook with server and tool is valid."""
+        event = HookEvent.model_validate({
+            'event': 'PostToolUse',
+            'matcher': 'Write',
+            'type': 'mcp_tool',
+            'server': 'linter',
+            'tool': 'lint_file',
+        })
+        assert event.type == 'mcp_tool'
+        assert event.server == 'linter'
+        assert event.tool == 'lint_file'
+        assert event.input is None
+
+    def test_mcp_tool_hook_with_input(self) -> None:
+        """MCP tool hook accepts an input mapping."""
+        event = HookEvent.model_validate({
+            'event': 'PostToolUse',
+            'type': 'mcp_tool',
+            'server': 'linter',
+            'tool': 'lint_file',
+            'input': {'file_path': '${tool_input.file_path}', 'strict': True},
+        })
+        assert event.input == {'file_path': '${tool_input.file_path}', 'strict': True}
+
+    def test_mcp_tool_hook_with_common_fields(self) -> None:
+        """MCP tool hook accepts the common fields."""
+        event = HookEvent.model_validate({
+            'event': 'PreToolUse',
+            'type': 'mcp_tool',
+            'server': 'guard',
+            'tool': 'check_call',
+            'if': 'Bash(git *)',
+            'status-message': 'Checking...',
+            'once': True,
+            'timeout': 20,
+        })
+        assert event.if_condition == 'Bash(git *)'
+        assert event.status_message == 'Checking...'
+        assert event.once is True
+        assert event.timeout == 20
+
+    def test_mcp_tool_hook_without_server_raises(self) -> None:
+        """MCP tool hook without server raises ValueError."""
+        with pytest.raises(ValidationError) as exc_info:
+            HookEvent.model_validate({
+                'event': 'PostToolUse',
+                'type': 'mcp_tool',
+                'tool': 'lint_file',
+            })
+        assert "requires 'server' field" in str(exc_info.value)
+
+    def test_mcp_tool_hook_without_tool_raises(self) -> None:
+        """MCP tool hook without tool raises ValueError."""
+        with pytest.raises(ValidationError) as exc_info:
+            HookEvent.model_validate({
+                'event': 'PostToolUse',
+                'type': 'mcp_tool',
+                'server': 'linter',
+            })
+        assert "requires 'tool' field" in str(exc_info.value)
+
+    def test_mcp_tool_hook_with_command_raises(self) -> None:
+        """MCP tool hook rejects command-hook fields."""
+        with pytest.raises(ValidationError) as exc_info:
+            HookEvent.model_validate({
+                'event': 'PostToolUse',
+                'type': 'mcp_tool',
+                'server': 'linter',
+                'tool': 'lint_file',
+                'command': 'test.py',
+            })
+        assert "cannot have 'command' field" in str(exc_info.value)
+
+    def test_mcp_tool_hook_with_prompt_raises(self) -> None:
+        """MCP tool hook rejects prompt-hook fields."""
+        with pytest.raises(ValidationError) as exc_info:
+            HookEvent.model_validate({
+                'event': 'PostToolUse',
+                'type': 'mcp_tool',
+                'server': 'linter',
+                'tool': 'lint_file',
+                'prompt': 'test',
+            })
+        assert "cannot have 'prompt' field" in str(exc_info.value)
+
+    def test_command_hook_with_server_raises(self) -> None:
+        """Command hook rejects mcp_tool-hook fields."""
+        with pytest.raises(ValidationError) as exc_info:
+            HookEvent.model_validate({
+                'event': 'PostToolUse',
+                'type': 'command',
+                'command': 'test.py',
+                'server': 'linter',
+            })
+        assert "cannot have 'server' field" in str(exc_info.value)
+
+    def test_prompt_hook_with_input_raises(self) -> None:
+        """Prompt hook rejects the input field."""
+        with pytest.raises(ValidationError) as exc_info:
+            HookEvent.model_validate({
+                'event': 'PreToolUse',
+                'type': 'prompt',
+                'prompt': 'test',
+                'input': {'a': 1},
+            })
+        assert "cannot have 'input' field" in str(exc_info.value)
+
+
+class TestHookEventValueConstraints:
+    """Test value-level constraints on hook event fields."""
+
+    def test_zero_timeout_raises(self) -> None:
+        """Zero timeout is rejected (Claude Code requires a positive timeout)."""
+        with pytest.raises(ValidationError):
+            HookEvent.model_validate({
+                'event': 'PreToolUse',
+                'type': 'prompt',
+                'prompt': 'test',
+                'timeout': 0,
+            })
+
+    def test_negative_timeout_raises(self) -> None:
+        """Negative timeout is rejected."""
+        with pytest.raises(ValidationError):
+            HookEvent.model_validate({
+                'event': 'PreToolUse',
+                'type': 'prompt',
+                'prompt': 'test',
+                'timeout': -5,
+            })
+
+    def test_http_url_without_scheme_raises(self) -> None:
+        """An http hook url without an http(s) scheme is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            HookEvent.model_validate({
+                'event': 'PostToolUse',
+                'type': 'http',
+                'url': 'localhost:8080/hook',
+            })
+        assert 'valid http:// or https:// URL' in str(exc_info.value)
+
+    def test_http_url_https_accepted(self) -> None:
+        """An https url is accepted."""
+        event = HookEvent.model_validate({
+            'event': 'PostToolUse',
+            'type': 'http',
+            'url': 'https://hooks.example.com/post-tool-use',
+        })
+        assert event.url == 'https://hooks.example.com/post-tool-use'
+
+    def test_unknown_event_name_warns(self) -> None:
+        """An event name Claude Code does not recognize produces a warning."""
+        with pytest.warns(UserWarning, match='Unknown hook event name'):
+            HookEvent.model_validate({
+                'event': 'TotallyMadeUpEvent',
+                'type': 'prompt',
+                'prompt': 'test',
+            })
+
+    def test_known_event_name_no_warning(self) -> None:
+        """A recognized event name produces no warning."""
+        import warnings as warnings_module
+        with warnings_module.catch_warnings():
+            warnings_module.simplefilter('error')
+            HookEvent.model_validate({
+                'event': 'PostToolUse',
+                'type': 'prompt',
+                'prompt': 'test',
+            })
+
+    def test_unknown_yaml_key_raises(self) -> None:
+        """An undeclared YAML key on a hook event is rejected, not silently dropped."""
+        with pytest.raises(ValidationError):
+            HookEvent.model_validate({
+                'event': 'PreToolUse',
+                'type': 'prompt',
+                'prompt': 'test',
+                'continueOnBlock': True,
+            })
 
 
 class TestPromptHooksWithEnvironmentConfig:

--- a/tests/scripts/models/test_hook_event_names_parity.py
+++ b/tests/scripts/models/test_hook_event_names_parity.py
@@ -1,0 +1,26 @@
+"""Parity test: HOOK_EVENT_NAMES must match across both modules.
+
+setup_environment.py and scripts/models/environment_config.py each define the
+set of hook event names Claude Code recognizes. The standalone script policy
+forbids a cross-import, so the two definitions are deliberate duplicates. This
+test enforces strict equality between them.
+
+If this test fails, the event-name set was changed in one module but not the
+other. Fix: update BOTH modules so the constants match exactly.
+"""
+
+from __future__ import annotations
+
+from scripts.models import environment_config as model_mod
+from scripts.setup_environment import HOOK_EVENT_NAMES as SETUP_HOOK_EVENT_NAMES
+
+
+def test_hook_event_names_parity() -> None:
+    """HOOK_EVENT_NAMES is identical in both modules."""
+    assert SETUP_HOOK_EVENT_NAMES == model_mod.HOOK_EVENT_NAMES
+
+
+def test_hook_event_names_is_frozenset() -> None:
+    """Both definitions are frozensets (immutable, hashable membership sets)."""
+    assert isinstance(SETUP_HOOK_EVENT_NAMES, frozenset)
+    assert isinstance(model_mod.HOOK_EVENT_NAMES, frozenset)

--- a/tests/test_setup_environment.py
+++ b/tests/test_setup_environment.py
@@ -4844,6 +4844,328 @@ class TestBuildHooksJson:
         result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
         assert len(result['PostToolUse']) == 2
 
+    def test_unknown_type_skipped_without_empty_group(self, capsys):
+        """Unknown hook type is skipped and leaves no empty matcher group."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write', 'type': 'webhook',
+                             'url': 'http://localhost:8080/hook'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        assert result == {}
+        assert 'Unknown hook type: webhook' in capsys.readouterr().out
+
+
+class TestBuildHooksJsonSchemaFields:
+    """Tests for hook fields mirroring Claude Code's hook configuration schema."""
+
+    def test_prompt_continue_on_block_emitted(self):
+        """Prompt hook continue-on-block is emitted as continueOnBlock."""
+        hooks = {'events': [{'event': 'PreToolUse', 'matcher': 'Search|Grep', 'type': 'prompt',
+                             'prompt': 'Route search calls', 'continue-on-block': True}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PreToolUse'][0]['hooks'][0]
+        assert hook['continueOnBlock'] is True
+
+    def test_prompt_continue_on_block_false_emitted(self):
+        """An explicit continue-on-block: false is still emitted."""
+        hooks = {'events': [{'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'prompt',
+                             'prompt': 'Check safety', 'continue-on-block': False}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PreToolUse'][0]['hooks'][0]
+        assert hook['continueOnBlock'] is False
+
+    def test_prompt_continue_on_block_absent(self):
+        """Omitted continue-on-block never reaches the generated JSON."""
+        hooks = {'events': [{'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'prompt',
+                             'prompt': 'Check safety'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PreToolUse'][0]['hooks'][0]
+        assert 'continueOnBlock' not in hook
+
+    def test_command_async_rewake_emitted(self):
+        """Command hook async-rewake is emitted as asyncRewake."""
+        hooks = {'events': [{'event': 'Stop', 'matcher': '', 'type': 'command',
+                             'command': 'verify.py', 'async-rewake': True}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['Stop'][0]['hooks'][0]
+        assert hook['asyncRewake'] is True
+
+    def test_command_async_rewake_absent(self):
+        """Omitted async-rewake never reaches the generated JSON."""
+        hooks = {'events': [{'event': 'Stop', 'matcher': '', 'type': 'command',
+                             'command': 'verify.py'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['Stop'][0]['hooks'][0]
+        assert 'asyncRewake' not in hook
+
+    def test_command_async_and_async_rewake_together(self):
+        """async and asyncRewake can both be emitted on one command hook."""
+        hooks = {'events': [{'event': 'Stop', 'matcher': '', 'type': 'command',
+                             'command': 'verify.py', 'async': True, 'async-rewake': True}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['Stop'][0]['hooks'][0]
+        assert hook['async'] is True
+        assert hook['asyncRewake'] is True
+
+    def test_mcp_tool_hook_emitted(self):
+        """MCP tool hook emits server, tool, and input."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write', 'type': 'mcp_tool',
+                             'server': 'linter', 'tool': 'lint_file',
+                             'input': {'file_path': '${tool_input.file_path}'}}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PostToolUse'][0]['hooks'][0]
+        assert hook['type'] == 'mcp_tool'
+        assert hook['server'] == 'linter'
+        assert hook['tool'] == 'lint_file'
+        assert hook['input'] == {'file_path': '${tool_input.file_path}'}
+
+    def test_mcp_tool_hook_without_input(self):
+        """MCP tool hook without input omits the key."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write', 'type': 'mcp_tool',
+                             'server': 'linter', 'tool': 'lint_file'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PostToolUse'][0]['hooks'][0]
+        assert 'input' not in hook
+
+    def test_mcp_tool_hook_common_fields(self):
+        """MCP tool hook carries the common fields."""
+        hooks = {'events': [{'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'mcp_tool',
+                             'server': 'guard', 'tool': 'check_call', 'if': 'Bash(git *)',
+                             'status-message': 'Checking...', 'once': True, 'timeout': 20}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PreToolUse'][0]['hooks'][0]
+        assert hook['if'] == 'Bash(git *)'
+        assert hook['statusMessage'] == 'Checking...'
+        assert hook['once'] is True
+        assert hook['timeout'] == 20
+
+    def test_mcp_tool_missing_server_skipped(self, capsys):
+        """MCP tool hook without server is skipped with a warning."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': '', 'type': 'mcp_tool',
+                             'tool': 'lint_file'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        assert result == {}
+        assert 'missing server' in capsys.readouterr().out
+
+    def test_mcp_tool_missing_tool_skipped(self, capsys):
+        """MCP tool hook without tool is skipped with a warning."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': '', 'type': 'mcp_tool',
+                             'server': 'linter'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        assert result == {}
+        assert 'missing tool' in capsys.readouterr().out
+
+
+class TestBuildHooksJsonExecForm:
+    """Tests for command hooks with args (exec form)."""
+
+    def test_python_file_reference_folds_launcher(self):
+        """Python file reference becomes uv executable with folded launcher args."""
+        hooks = {'files': ['hooks/linter.py'],
+                 'events': [{'event': 'PostToolUse', 'matcher': 'Edit', 'type': 'command',
+                             'command': 'linter.py', 'args': ['--fix']}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PostToolUse'][0]['hooks'][0]
+        assert hook['command'] == 'uv'
+        assert hook['args'] == ['run', '--no-project', '--python', '3.12', '/hooks/linter.py', '--fix']
+
+    def test_javascript_file_reference_folds_node(self):
+        """JavaScript file reference becomes node executable with the script path."""
+        hooks = {'files': ['hooks/check.js'],
+                 'events': [{'event': 'PostToolUse', 'matcher': 'Read', 'type': 'command',
+                             'command': 'check.js', 'args': ['--verbose']}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PostToolUse'][0]['hooks'][0]
+        assert hook['command'] == 'node'
+        assert hook['args'] == ['/hooks/check.js', '--verbose']
+
+    def test_other_file_reference_direct_executable(self):
+        """A non-Python, non-JavaScript file becomes the executable itself."""
+        hooks = {'files': ['hooks/tool.sh'],
+                 'events': [{'event': 'PostToolUse', 'matcher': '', 'type': 'command',
+                             'command': 'tool.sh', 'args': ['--check']}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PostToolUse'][0]['hooks'][0]
+        assert hook['command'] == '/hooks/tool.sh'
+        assert hook['args'] == ['--check']
+
+    def test_empty_args_still_exec_form(self):
+        """An empty args list still switches to exec form."""
+        hooks = {'files': ['hooks/linter.py'],
+                 'events': [{'event': 'PostToolUse', 'matcher': '', 'type': 'command',
+                             'command': 'linter.py', 'args': []}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PostToolUse'][0]['hooks'][0]
+        assert hook['command'] == 'uv'
+        assert hook['args'] == ['run', '--no-project', '--python', '3.12', '/hooks/linter.py']
+
+    def test_config_precedes_user_args(self):
+        """The config file path lands between the script path and user args."""
+        hooks = {'files': ['hooks/linter.py', 'configs/linter-config.yaml'],
+                 'events': [{'event': 'PostToolUse', 'matcher': 'Edit', 'type': 'command',
+                             'command': 'linter.py', 'config': 'linter-config.yaml',
+                             'args': ['--strict']}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PostToolUse'][0]['hooks'][0]
+        assert hook['args'] == [
+            'run', '--no-project', '--python', '3.12',
+            '/hooks/linter.py', '/hooks/linter-config.yaml', '--strict',
+        ]
+
+    def test_exec_form_paths_unquoted(self):
+        """Exec-form path elements carry no quoting even with spaced directories."""
+        hooks = {'files': ['hooks/linter.py'],
+                 'events': [{'event': 'PostToolUse', 'matcher': '', 'type': 'command',
+                             'command': 'linter.py', 'args': []}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/home/John Smith/.claude/hooks'))
+        hook = result['PostToolUse'][0]['hooks'][0]
+        assert hook['args'][-1] == '/home/John Smith/.claude/hooks/linter.py'
+        assert '"' not in hook['args'][-1]
+
+    def test_direct_command_with_spaces_passes_through(self):
+        """An unlisted command with spaces stays verbatim in exec form."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': '', 'type': 'command',
+                             'command': 'my tool', 'args': ['--check']}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PostToolUse'][0]['hooks'][0]
+        assert hook['command'] == 'my tool'
+        assert hook['args'] == ['--check']
+
+    def test_unlisted_bare_command_stays_verbatim(self):
+        """An unlisted space-free command is the executable itself, never a hooks_dir path."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write', 'type': 'command',
+                             'command': 'echo', 'args': ['hi']}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PostToolUse'][0]['hooks'][0]
+        assert hook['command'] == 'echo'
+        assert hook['args'] == ['hi']
+
+    def test_unlisted_absolute_path_command_stays_verbatim(self):
+        """An unlisted absolute-path command keeps its directory in exec form."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': '', 'type': 'command',
+                             'command': '/usr/local/bin/mytool', 'args': ['--check']}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PostToolUse'][0]['hooks'][0]
+        assert hook['command'] == '/usr/local/bin/mytool'
+        assert hook['args'] == ['--check']
+
+    def test_shell_ignored_and_warned_with_args(self, capsys):
+        """shell is dropped with a warning when args switches to exec form."""
+        hooks = {'files': ['hooks/linter.py'],
+                 'events': [{'event': 'PostToolUse', 'matcher': '', 'type': 'command',
+                             'command': 'linter.py', 'args': ['--fix'], 'shell': 'bash'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PostToolUse'][0]['hooks'][0]
+        assert 'shell' not in hook
+        assert "'shell' is ignored" in capsys.readouterr().out
+
+    def test_async_fields_emitted_in_exec_form(self):
+        """async and asyncRewake are emitted alongside args."""
+        hooks = {'files': ['hooks/verify.py'],
+                 'events': [{'event': 'Stop', 'matcher': '', 'type': 'command',
+                             'command': 'verify.py', 'args': [], 'async': True,
+                             'async-rewake': True}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['Stop'][0]['hooks'][0]
+        assert hook['async'] is True
+        assert hook['asyncRewake'] is True
+
+    def test_args_elements_coerced_to_strings(self):
+        """Non-string args elements are coerced to strings."""
+        hooks = {'files': ['hooks/linter.py'],
+                 'events': [{'event': 'PostToolUse', 'matcher': '', 'type': 'command',
+                             'command': 'linter.py', 'args': ['--level', 3]}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PostToolUse'][0]['hooks'][0]
+        assert hook['args'][-2:] == ['--level', '3']
+
+    def test_no_args_keeps_shell_form(self):
+        """Without args the command stays a quoted shell string."""
+        hooks = {'files': ['hooks/linter.py'],
+                 'events': [{'event': 'PostToolUse', 'matcher': '', 'type': 'command',
+                             'command': 'linter.py'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PostToolUse'][0]['hooks'][0]
+        assert hook['command'] == 'uv run --no-project --python 3.12 "/hooks/linter.py"'
+        assert 'args' not in hook
+
+
+class TestBuildHooksJsonValueValidation:
+    """Tests for value-level validation in _build_hooks_json()."""
+
+    def test_zero_timeout_skipped(self, capsys):
+        """A zero timeout skips the hook with a warning."""
+        hooks = {'events': [{'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'prompt',
+                             'prompt': 'test', 'timeout': 0}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        assert result == {}
+        assert 'timeout must be a positive number' in capsys.readouterr().out
+
+    def test_negative_timeout_skipped(self, capsys):
+        """A negative timeout skips the hook with a warning."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': '', 'type': 'command',
+                             'command': 'linter.py', 'timeout': -5}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        assert result == {}
+        assert 'timeout must be a positive number' in capsys.readouterr().out
+
+    def test_boolean_timeout_skipped(self, capsys):
+        """A boolean timeout skips the hook with a warning."""
+        hooks = {'events': [{'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'prompt',
+                             'prompt': 'test', 'timeout': True}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        assert result == {}
+        assert 'timeout must be a positive number' in capsys.readouterr().out
+
+    def test_positive_timeout_kept(self):
+        """A positive timeout passes through."""
+        hooks = {'events': [{'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'prompt',
+                             'prompt': 'test', 'timeout': 30}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        assert result['PreToolUse'][0]['hooks'][0]['timeout'] == 30
+
+    def test_http_url_without_scheme_skipped(self, capsys):
+        """An http hook url without an http(s) scheme skips the hook."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': '', 'type': 'http',
+                             'url': 'localhost:8080/hook'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        assert result == {}
+        assert 'url must be an http:// or https:// URL' in capsys.readouterr().out
+
+    def test_http_url_https_kept(self):
+        """An https url passes through."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': '', 'type': 'http',
+                             'url': 'https://hooks.example.com/post'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        assert result['PostToolUse'][0]['hooks'][0]['url'] == 'https://hooks.example.com/post'
+
+    def test_unknown_event_name_warns_but_emits(self, capsys):
+        """An unrecognized event name warns yet still reaches the output."""
+        hooks = {'events': [{'event': 'TotallyMadeUpEvent', 'matcher': '', 'type': 'prompt',
+                             'prompt': 'test'}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        assert 'TotallyMadeUpEvent' in result
+        assert 'Unknown hook event name' in capsys.readouterr().out
+
+    def test_known_event_name_no_warning(self, capsys):
+        """A recognized event name produces no event-name warning."""
+        hooks = {'events': [{'event': 'PostToolUse', 'matcher': '', 'type': 'prompt',
+                             'prompt': 'test'}]}
+        setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        assert 'Unknown hook event name' not in capsys.readouterr().out
+
+    def test_unknown_keys_warned_and_ignored(self, capsys):
+        """Keys not supported for the hook type warn and never reach the JSON."""
+        hooks = {'events': [{'event': 'PreToolUse', 'matcher': 'Bash', 'type': 'prompt',
+                             'prompt': 'test', 'headers': {'X-Key': 'val'},
+                             'continueOnBlock': True}]}
+        result = setup_environment._build_hooks_json(hooks, Path('/hooks'))
+        hook = result['PreToolUse'][0]['hooks'][0]
+        assert 'headers' not in hook
+        assert 'continueOnBlock' not in hook
+        out = capsys.readouterr().out
+        assert 'ignoring key(s) not supported' in out
+        assert 'continueOnBlock' in out
+        assert 'headers' in out
+
     def test_direct_command_passthrough(self):
         """Direct commands with spaces are passed through as-is."""
         hooks = {'events': [{'event': 'PostToolUse', 'matcher': 'Write', 'type': 'command',


### PR DESCRIPTION
## What

Brings the environment-configuration hook schema up to the full hook configuration contract Claude Code 2.1.238 accepts:

- **`continue-on-block`** (prompt hooks only, emitted as `continueOnBlock`): a denying evaluation feeds its reason back to the agent and the turn continues instead of ending, so steering hooks can redirect tool choice within the same turn. Claude Code supports the setting although its public hooks reference does not document it.
- **`args`** (command hooks, exec form): Claude Code spawns the executable directly with an unquoted argument list and no shell. For a `hooks.files` script the launcher is folded into that shape (`uv` / `node` plus the resolved script path, config path, and user args); any unlisted command stays verbatim as the executable.
- **`async-rewake`** (command hooks, emitted as `asyncRewake`): runs in the background and wakes the model on exit code 2; implies `async`.
- **`mcp_tool`** hook type: calls a tool on an already-configured MCP server via required `server`/`tool` and optional `input` (with `${path}` interpolation).
- **Event-name allowlist**: the 31 event names Claude Code 2.1.238 recognizes, duplicated in both modules with a parity test. Unknown names warn but still install, so configurations written for newer Claude Code releases keep working while typos surface at setup time.
- **Value validation**: `timeout` must be positive and http hook `url` must be an http(s) URL, matching what Claude Code enforces at load time; failures surface at setup time instead.
- **No more silent drops**: the `HookEvent` model rejects undeclared keys (`extra='forbid'`) and the generator warns about keys the hook type does not support. A hook of an unknown type no longer leaves an empty matcher group in the generated JSON.

`rewakeMessage`/`rewakeSummary` are deliberately not exposed: Claude Code marks them `@internal`.

## Why

Every profile deployed through the toolbox could only generate turn-ending prompt-hook denies, and any hook field the schema did not know was dropped without a trace, so real Claude Code capabilities were unreachable and typos shipped as broken configurations.

## How it was verified

Full test suite (3083 passed, 56 skipped) and all pre-commit hooks pass. New unit tests cover every added field (present and absent), the exec-form fold for Python/JavaScript/other scripts, the `mcp_tool` emission, value-validation skips, and the unknown-event/unknown-key warnings; the E2E golden configuration exercises the new keys end to end, including component selection claims.

## Docs

`docs/environment-configuration-guide.md` (field tables, five-type matrix, recognized event names, exec form, MCP tool hooks), `CLAUDE.md`, and the README feature list are updated in the same change.