### PR TITLE
Update the PyPI publish action so current wheel metadata publishes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,7 +88,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.14.2
         with:
           packages-dir: dist/
           skip-existing: true


### PR DESCRIPTION
## What

Bumps `pypa/gh-action-pypi-publish` from v1.13.0 to v1.14.2 in `publish.yml`.

## Why

The v7.3.0 release failed at the publish step: `uv build` now produces wheels with `Metadata-Version: 2.5`, and the twine 6.1.0 bundled inside action v1.13.0 rejects them (`InvalidDistribution: '2.5' is not a valid metadata version`). v1.14.2 bundles twine 7.0.0, which accepts current distribution metadata.

The action is a Docker action pinned to an immutable version tag per the repository's Actions policy. After this lands, dispatching `publish.yml` on `main` publishes 7.3.0 (the version-determination step falls back to `pyproject.toml`, which reads 7.3.0 on `main`).